### PR TITLE
Add support for streaming uploads

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -126,8 +126,36 @@ class TransferManager(object):
     def upload(self, fileobj, bucket, key, extra_args=None, subscribers=None):
         """Uploads a file to S3
 
-        :type fileobj: str
-        :param fileobj: The name of a file to upload.
+        :type fileobj: str or filelike object
+        :param fileobj: The file to upload. Valid value types are as follows:
+
+            * name of file (str): This format is recommended because it
+              results in much better memory management and handles the
+              file management for you.
+
+            * seekable file-like object: The file like object **must**
+              produce binary data. Note that there are memory implications
+              with this format. In the worst possible scenario, you can
+              expect based on the TransferConfig::
+
+                  multipart_chunksize * min(max_queue_size, max_concurrency)
+
+              So configure the manager accordingly.
+
+            * unseekable file-like object: The file like object **must**
+              produce binary data. Note that there are memory implications
+              with this format. In the worst possible scenario, you can
+              expect based on the TransferConfig::
+
+                  multipart_threshold + (
+                     multipart_chunksize * (min(
+                        max_queue_size, max_concurrency))
+
+              If a transfer size is provided, the worst case scenario becomes::
+
+                  multipart_chunksize * min(max_queue_size, max_concurrency)
+
+            So configure the manager accordingly.
 
         :type bucket: str
         :param bucket: The name of the bucket to upload to

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -150,8 +150,60 @@ class OSUtils(object):
         rename_file(current_filename, new_filename)
 
 
+class DeferredOpenFile(object):
+    OPEN_METHOD = open
+
+    def __init__(self, filename, start_byte=0):
+        """A class that defers the opening of a file till needed
+
+        This is useful for deffering opening of a file till it is needed
+        in a separate thread, as there is a limit of how many open files
+        there can be in a single thread for most operating systems. The
+        file gets opened in the following methods: ``read()``, ``seek()``,
+        and ``__enter__()``
+
+        :type filename: str
+        :param filename: The name of the file to open
+
+        :type start_byte: int
+        :param start_byte: The byte to seek to when the file is opened.
+        """
+        self._filename = filename
+        self._fileobj = None
+        self._start_byte = start_byte
+
+    def _open_if_needed(self):
+        if self._fileobj is None:
+            self._fileobj = self.OPEN_METHOD(self._filename, 'rb')
+            if self._start_byte != 0:
+                self._fileobj.seek(self._start_byte)
+
+    def read(self, amount=None):
+        self._open_if_needed()
+        return self._fileobj.read(amount)
+
+    def seek(self, where):
+        self._open_if_needed()
+        self._fileobj.seek(where)
+
+    def tell(self):
+        if self._fileobj is None:
+            return self._start_byte
+        return self._fileobj.tell()
+
+    def close(self):
+        self._fileobj.close()
+
+    def __enter__(self):
+        self._open_if_needed()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+
 class ReadFileChunk(object):
-    def __init__(self, fileobj, start_byte, chunk_size, full_file_size,
+    def __init__(self, fileobj, chunk_size, full_file_size,
                  callbacks=None, enable_callbacks=True):
         """
 
@@ -160,13 +212,10 @@ class ReadFileChunk(object):
             |___________________________________________________|
             0          |                 |                 full_file_size
                        |----chunk_size---|
-                 start_byte
+                    f.tell()
 
         :type fileobj: file
         :param fileobj: File like object
-
-        :type start_byte: int
-        :param start_byte: The first byte from which to start reading.
 
         :type chunk_size: int
         :param chunk_size: The max chunk size to read.  Trying to read
@@ -183,10 +232,10 @@ class ReadFileChunk(object):
 
         """
         self._fileobj = fileobj
-        self._start_byte = start_byte
+        self._start_byte = self._fileobj.tell()
         self._size = self._calculate_file_size(
             self._fileobj, requested_size=chunk_size,
-            start_byte=start_byte, actual_file_size=full_file_size)
+            start_byte=self._start_byte, actual_file_size=full_file_size)
         self._fileobj.seek(self._start_byte)
         self._amount_read = 0
         self._callbacks = callbacks
@@ -222,10 +271,9 @@ class ReadFileChunk(object):
         :return: A new instance of ``ReadFileChunk``
 
         """
-        f = open(filename, 'rb')
-        file_size = os.fstat(f.fileno()).st_size
-        return cls(f, start_byte, chunk_size, file_size, callbacks,
-                   enable_callbacks)
+        file_size = os.path.getsize(filename)
+        f = DeferredOpenFile(filename=filename, start_byte=start_byte)
+        return cls(f, chunk_size, file_size, callbacks, enable_callbacks)
 
     def _calculate_file_size(self, fileobj, requested_size, start_byte,
                              actual_file_size):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -78,7 +78,24 @@ class StreamWithError(object):
         return self._stream.read(n)
 
 
-class FileSizeProvider(object):
+class UnseekableStream(object):
+    def __init__(self, stream): 
+        self._stream = stream
+
+    def read(self, amount=None):
+        return self._stream.read(amount)
+
+    def close(self):
+        self._stream.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        return self.close()
+
+
+class FileSizeProvider(BaseSubscriber):
     def __init__(self, file_size):
         self.file_size = file_size
 

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from tests import UnseekableStream
 from tests import RecordingSubscriber
 from tests.integration import BaseTransferManagerIntegTest
 from s3transfer.manager import TransferConfig
@@ -39,6 +40,54 @@ class TestUpload(BaseTransferManagerIntegTest):
         future = transfer_manager.upload(
             filename, self.bucket_name, '20mb.txt')
         self.addCleanup(self.delete_object, '20mb.txt')
+
+        future.result()
+        self.assertTrue(self.object_exists('20mb.txt'))
+
+    def test_upload_open_file_below_threshold(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+        filename = self.files.create_file_with_size(
+            '1mb.txt', filesize=1024 * 1024)
+        with open(filename, 'rb') as f:
+            future = transfer_manager.upload(f, self.bucket_name, '1mb.txt')
+            self.addCleanup(self.delete_object, '1mb.txt')
+
+        future.result()
+        self.assertTrue(self.object_exists('1mb.txt'))
+
+    def test_upload_open_file_above_threshold(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        with open(filename, 'rb') as f:
+            future = transfer_manager.upload(f, self.bucket_name, '20mb.txt')
+            self.addCleanup(self.delete_object, '20mb.txt')
+
+        future.result()
+        self.assertTrue(self.object_exists('20mb.txt'))
+
+    def test_upload_unseekable_stream_below_threshold(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+        filename = self.files.create_file_with_size(
+            '1mb.txt', filesize=1024 * 1024)
+        with open(filename, 'rb') as f:
+            with UnseekableStream(f) as stream:            
+                future = transfer_manager.upload(
+                    stream, self.bucket_name, '1mb.txt')
+                self.addCleanup(self.delete_object, '1mb.txt')
+
+        future.result()
+        self.assertTrue(self.object_exists('1mb.txt'))
+
+    def test_upload_unseekable_stream_above_threshold(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        with open(filename, 'rb') as f:
+            with UnseekableStream(f) as stream:            
+                future = transfer_manager.upload(
+                    stream, self.bucket_name, '20mb.txt')
+                self.addCleanup(self.delete_object, '20mb.txt')
 
         future.result()
         self.assertTrue(self.object_exists('20mb.txt'))

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -19,6 +19,15 @@ import mock
 from tests import BaseTaskTest
 from tests import BaseTaskSubmitterTest
 from tests import FileSizeProvider
+from tests import RecordingSubscriber
+from tests import UnseekableStream
+from s3transfer.futures import TransferFuture
+from s3transfer.futures import TransferMeta
+from s3transfer.manager import TransferConfig
+from s3transfer.upload import get_upload_utils_cls
+from s3transfer.upload import UploadFilenameUtils
+from s3transfer.upload import UploadSeekableStreamUtils
+from s3transfer.upload import UploadUnseekableStreamUtils
 from s3transfer.upload import UploadTaskSubmitter
 from s3transfer.upload import PutObjectTask
 from s3transfer.upload import CreateMultipartUploadTask
@@ -34,9 +43,9 @@ class OSUtilsExceptionOnFileSize(OSUtils):
             "The file %s should not have been stated" % filename)
 
 
-class BaseUploadTaskTest(BaseTaskTest):
+class BaseUploadTest(BaseTaskTest):
     def setUp(self):
-        super(BaseUploadTaskTest, self).setUp()
+        super(BaseUploadTest, self).setUp()
         self.bucket = 'mybucket'
         self.key = 'foo'
         self.osutil = OSUtils()
@@ -48,19 +57,261 @@ class BaseUploadTaskTest(BaseTaskTest):
         with open(self.filename, 'wb') as f:
             f.write(self.content)
 
-        # A list to keep track of all of the bodies sent over the wire
-        # and their order.
-        self.sent_bodies = []
-        self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
+        self.subscribers = []
 
     def tearDown(self):
-        super(BaseUploadTaskTest, self).tearDown()
+        super(BaseUploadTest, self).tearDown()
         shutil.rmtree(self.tempdir)
 
-    def collect_body(self, params, **kwargs):
-        if 'Body' in params:
-            self.sent_bodies.append(params['Body'].read())
+    def get_future(self, fileobj):
+        meta = TransferMeta(
+            CallArgs(fileobj=fileobj, subscribers=self.subscribers))
+        return TransferFuture(meta, self.transfer_coordinator)
+
+
+class TestGetUploadUtilsClsTest(BaseUploadTest):
+    def test_for_filename(self):
+        future = self.get_future(self.filename)
+        self.assertIs(get_upload_utils_cls(future), UploadFilenameUtils)
+
+    def test_for_seekable_file(self):
+        with open(self.filename, 'rb') as f:
+            future = self.get_future(f)
+            self.assertIs(
+                get_upload_utils_cls(future), UploadSeekableStreamUtils)
+
+    def test_for_unseekable_file(self):
+        with open(self.filename, 'rb') as f:
+            with UnseekableStream(f) as stream:
+                future = self.get_future(stream)
+                self.assertIs(
+                    get_upload_utils_cls(future), UploadUnseekableStreamUtils)
+
+
+class BaseUploadUtilsTest(BaseUploadTest):
+    def setUp(self):
+        super(BaseUploadUtilsTest, self).setUp()
+        self.osutil = OSUtils()
+        self.config = TransferConfig()
+        self.recording_subscriber = RecordingSubscriber()
+        self.subscribers.append(self.recording_subscriber)
+
+    def _get_expected_body_for_part(self, part_number, chunk_size, offset=0):
+        total_size = len(self.content)
+        start_index = (part_number - 1) * chunk_size - offset
+        end_index = part_number * chunk_size - offset
+        if end_index >= total_size:
+            return self.content[start_index:]
+        return self.content[start_index:end_index]
+
+
+class TestUploadFilenameUtils(BaseUploadUtilsTest):
+    def setUp(self):
+        super(TestUploadFilenameUtils, self).setUp()
+        self.upload_utils = UploadFilenameUtils(self.osutil)
+        self.future = self.get_future(self.filename)
+        self.future.meta.provide_transfer_size(len(self.content))
+
+    def test_provide_transfer_size(self):
+        self.upload_utils.provide_transfer_size(self.future)
+        self.assertEqual(self.future.meta.size, len(self.content))
+
+    def test_requires_multipart_upload(self):
+        self.assertFalse(
+            self.upload_utils.requires_multipart_upload(
+                self.future, self.config))
+        self.config.multipart_threshold = len(self.content)
+        self.assertTrue(
+            self.upload_utils.requires_multipart_upload(
+                self.future, self.config))
+
+    def test_get_put_object_body(self):
+        read_file_chunk = self.upload_utils.get_put_object_body(self.future)
+        read_file_chunk.enable_callback()
+        self.assertEqual(read_file_chunk.read(), self.content)
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
+
+    def test_yield_upload_part_bodies(self):
+        chunk_size = 4
+        self.config.multipart_chunksize = chunk_size
+        part_iterator = self.upload_utils.yield_upload_part_bodies(
+            self.future, self.config)
+        expected_part_number = 1
+        for part_number, read_file_chunk in part_iterator:
+            # Ensure that the part number is as expected
+            self.assertEqual(part_number, expected_part_number)
+            read_file_chunk.enable_callback()
+            # Ensure that the body is correct for that part.
+            self.assertEqual(
+                read_file_chunk.read(),
+                self._get_expected_body_for_part(part_number, chunk_size))
+            expected_part_number += 1
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
+
+
+class TestUploadSeekableStreamUtils(TestUploadFilenameUtils):
+    def setUp(self):
+        super(TestUploadSeekableStreamUtils, self).setUp()
+        self.upload_utils = UploadSeekableStreamUtils(self.osutil)
+        self.fileobj = open(self.filename, 'rb')
+        self.addCleanup(self.fileobj.close)
+        self.future = self.get_future(self.fileobj)
+        self.future.meta.provide_transfer_size(len(self.content))
+
+
+class TestUploadUnseekableStreamUtils(BaseUploadUtilsTest):
+    def setUp(self):
+        super(TestUploadUnseekableStreamUtils, self).setUp()
+        self.upload_utils = UploadUnseekableStreamUtils(self.osutil)
+        self.fileobj = open(self.filename, 'rb')
+        self.stream = UnseekableStream(self.fileobj)
+        self.addCleanup(self.stream.close)
+        self.future = self.get_future(self.stream)
+
+    def test_provide_transfer_size(self):
+        # We should not be able to determine the transfer size of an
+        # unseekable stream because we would have to buffer that all into
+        # memory.
+        self.upload_utils.provide_transfer_size(self.future)
+        self.assertEqual(self.future.meta.size, None)
+
+    def test_requires_multipart_upload_with_provided_size(self):
+        self.future.meta.provide_transfer_size(len(self.content))
+        self.assertFalse(
+            self.upload_utils.requires_multipart_upload(
+                self.future, self.config))
+        self.config.multipart_threshold = len(self.content)
+        self.assertTrue(
+            self.upload_utils.requires_multipart_upload(
+                self.future, self.config))
+
+    def test_requires_multipart_upload_with_no_provided_size(self):
+        self.assertFalse(
+            self.upload_utils.requires_multipart_upload(
+                self.future, self.config))
+
+        # The stream needs to be rewound as it determines multipart
+        # uploads by streaming up to the threshold.
+        self.fileobj.seek(0)
+        self.config.multipart_threshold = len(self.content)
+        self.assertTrue(
+            self.upload_utils.requires_multipart_upload(
+                self.future, self.config))
+
+    def test_get_put_object_body_with_provided_size(self):
+        self.future.meta.provide_transfer_size(len(self.content))
+        read_file_chunk = self.upload_utils.get_put_object_body(self.future)
+        read_file_chunk.enable_callback()
+        self.assertEqual(read_file_chunk.read(), self.content)
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
+
+    def test_get_put_object_body_with_no_provided_size(self):
+        # This needs to be called first to pull from the stream initially.
+        self.upload_utils.requires_multipart_upload(self.future, self.config)
+        read_file_chunk = self.upload_utils.get_put_object_body(self.future)
+        read_file_chunk.enable_callback()
+        self.assertEqual(read_file_chunk.read(), self.content)
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
+
+    def test_get_put_object_body_can_be_reread(self):
+        # This needs to be called first to pull from the stream initially.
+        self.upload_utils.requires_multipart_upload(self.future, self.config)
+        read_file_chunk = self.upload_utils.get_put_object_body(self.future)
+        read_file_chunk.enable_callback()
+        self.assertEqual(read_file_chunk.read(), self.content)
+        # We should still be able to seek and reread the stream if botocore
+        # ever needed to rewind the stream.
+        read_file_chunk.seek(0)
+        self.assertEqual(read_file_chunk.read(), self.content)
+
+    def test_yield_upload_part_bodies_with_provided_size(self):
+        self.future.meta.provide_transfer_size(len(self.content))
+        chunk_size = 4
+        self.config.multipart_chunksize = chunk_size
+        part_iterator = self.upload_utils.yield_upload_part_bodies(
+            self.future, self.config)
+        expected_part_number = 1
+        for part_number, read_file_chunk in part_iterator:
+            # Ensure that the part number is as expected
+            self.assertEqual(part_number, expected_part_number)
+            read_file_chunk.enable_callback()
+            # Ensure that the body is correct for that part.
+            self.assertEqual(
+                read_file_chunk.read(),
+                self._get_expected_body_for_part(part_number, chunk_size))
+            expected_part_number += 1
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
+
+    def test_yield_upload_part_bodies_with_no_provided_size(self):
+        threshold = 2
+        chunk_size = 4
+        self.config.multipart_chunksize = chunk_size
+        self.config.multipart_threshold = threshold
+
+        # This needs to be called first to pull from the stream initially.
+        self.upload_utils.requires_multipart_upload(self.future, self.config)
+        # Then get the iterator to retrieve the part bodies.
+        part_iterator = self.upload_utils.yield_upload_part_bodies(
+            self.future, self.config)
+
+        expected_part_number = 1
+        for part_number, read_file_chunk in part_iterator:
+            print(part_number)
+            # Ensure that the part number is as expected
+            self.assertEqual(part_number, expected_part_number)
+            read_file_chunk.enable_callback()
+
+            offset = threshold
+            expected_chunk_size = chunk_size
+            # The first part will have the size of the threshold as
+            # the stream is pulled to see if it is large enough to
+            # require a multipart upload
+            if part_number == 1:
+                offset = 0
+                expected_chunk_size = threshold
+
+            # Ensure that the body is correct for that part.
+            self.assertEqual(
+                read_file_chunk.read(),
+                self._get_expected_body_for_part(
+                    part_number, expected_chunk_size, offset))
+            expected_part_number += 1
+
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
+
+    def test_yield_upload_part_bodies_can_be_reread(self):
+        self.future.meta.provide_transfer_size(len(self.content))
+        chunk_size = 4
+        self.config.multipart_chunksize = chunk_size
+        part_iterator = self.upload_utils.yield_upload_part_bodies(
+            self.future, self.config)
+        expected_part_number = 1
+        for part_number, read_file_chunk in part_iterator:
+            # Ensure that the part number is as expected
+            self.assertEqual(part_number, expected_part_number)
+            read_file_chunk.enable_callback()
+            # Ensure that the body is correct for that part.
+            self.assertEqual(
+                read_file_chunk.read(),
+                self._get_expected_body_for_part(part_number, chunk_size))
+            # Ensure that each part can be reread via seeking.
+            read_file_chunk.seek(0)
+            self.assertEqual(
+                read_file_chunk.read(),
+                self._get_expected_body_for_part(part_number, chunk_size))
+            expected_part_number += 1
 
 
 class TestUploadTaskSubmitter(BaseTaskSubmitterTest):
@@ -82,19 +333,9 @@ class TestUploadTaskSubmitter(BaseTaskSubmitterTest):
         self.extra_args = {}
         self.subscribers = []
 
-        # A list to keep track of all of the bodies sent over the wire
-        # and their order.
-        self.sent_bodies = []
-        self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
-
     def tearDown(self):
         super(TestUploadTaskSubmitter, self).tearDown()
         shutil.rmtree(self.tempdir)
-
-    def collect_body(self, params, **kwargs):
-        if 'Body' in params:
-            self.sent_bodies.append(params['Body'].read())
 
     def get_call_args(self, **kwargs):
         default_call_args = {
@@ -127,39 +368,35 @@ class TestUploadTaskSubmitter(BaseTaskSubmitterTest):
         future = self.submitter(call_args)
         future.result()
         self.stubber.assert_no_pending_responses()
-        self.assertEqual(self.sent_bodies, [self.content])
 
 
-class TestPutObjectTask(BaseUploadTaskTest):
+class TestPutObjectTask(BaseUploadTest):
     def test_main(self):
         extra_args = {'Metadata': {'foo': 'bar'}}
-        task = self.get_task(
-            PutObjectTask,
-            main_kwargs={
-                'client': self.client,
-                'fileobj': self.filename,
-                'bucket': self.bucket,
-                'key': self.key,
-                'extra_args': extra_args,
-                'osutil': self.osutil,
-                'size': len(self.content),
-                'progress_callbacks': []
-            }
-        )
-        self.stubber.add_response(
-            method='put_object',
-            service_response={},
-            expected_params={
-                'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
-                'Metadata': {'foo': 'bar'}
-            }
-        )
-        task()
+        with open(self.filename, 'rb') as fileobj:
+            task = self.get_task(
+                PutObjectTask,
+                main_kwargs={
+                    'client': self.client,
+                    'fileobj': fileobj,
+                    'bucket': self.bucket,
+                    'key': self.key,
+                    'extra_args': extra_args,
+                }
+            )
+            self.stubber.add_response(
+                method='put_object',
+                service_response={},
+                expected_params={
+                    'Body': fileobj, 'Bucket': self.bucket, 'Key': self.key,
+                    'Metadata': {'foo': 'bar'}
+                }
+            )
+            task()
         self.stubber.assert_no_pending_responses()
-        self.assertEqual(self.sent_bodies, [self.content])
 
 
-class TestCreateMultipartUploadTask(BaseUploadTaskTest):
+class TestCreateMultipartUploadTask(BaseUploadTest):
     def test_main(self):
         upload_id = 'foo'
         extra_args = {'Metadata': {'foo': 'bar'}}
@@ -203,43 +440,40 @@ class TestCreateMultipartUploadTask(BaseUploadTaskTest):
         self.stubber.assert_no_pending_responses()
 
 
-class TestUploadPartTask(BaseUploadTaskTest):
+class TestUploadPartTask(BaseUploadTest):
     def test_main(self):
         extra_args = {'RequestPayer': 'requester'}
         upload_id = 'my-id'
         part_number = 1
         etag = 'foo'
-        task = self.get_task(
-            UploadPartTask,
-            main_kwargs={
-                'client': self.client,
-                'fileobj': self.filename,
-                'bucket': self.bucket,
-                'key': self.key,
-                'upload_id': upload_id,
-                'part_number': part_number,
-                'extra_args': extra_args,
-                'osutil': self.osutil,
-                'part_size': len(self.content),
-                'progress_callbacks': []
-            }
-        )
-        self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': etag},
-            expected_params={
-                'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
-                'UploadId': upload_id, 'PartNumber': part_number,
-                'RequestPayer': 'requester'
-            }
-        )
-        rval = task()
+        with open(self.filename, 'rb') as fileobj:
+            task = self.get_task(
+                UploadPartTask,
+                main_kwargs={
+                    'client': self.client,
+                    'fileobj': fileobj,
+                    'bucket': self.bucket,
+                    'key': self.key,
+                    'upload_id': upload_id,
+                    'part_number': part_number,
+                    'extra_args': extra_args
+                }
+            )
+            self.stubber.add_response(
+                method='upload_part',
+                service_response={'ETag': etag},
+                expected_params={
+                    'Body': fileobj, 'Bucket': self.bucket, 'Key': self.key,
+                    'UploadId': upload_id, 'PartNumber': part_number,
+                    'RequestPayer': 'requester'
+                }
+            )
+            rval = task()
         self.stubber.assert_no_pending_responses()
         self.assertEqual(rval, {'ETag': etag, 'PartNumber': part_number})
-        self.assertEqual(self.sent_bodies, [self.content])
 
 
-class TestCompleteMultipartUploadTask(BaseUploadTaskTest):
+class TestCompleteMultipartUploadTask(BaseUploadTest):
     def test_main(self):
         upload_id = 'my-id'
         parts = [{'ETag': 'etag', 'PartNumber': 1}]


### PR DESCRIPTION
Supports both seekable and unseekable streams. This builds off of https://github.com/boto/s3transfer/pull/4 pretty heavily.

Fixes https://github.com/boto/s3transfer/issues/3

cc @jamesls @JordonPhillips 