### PR TITLE
Wrap task submission for transfer into tasks

### DIFF
--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -28,7 +28,7 @@ from s3transfer.utils import calculate_range_parameter
 from s3transfer.utils import FunctionContainer
 from s3transfer.utils import StreamReaderProgress
 from s3transfer.tasks import Task
-from s3transfer.tasks import TaskSubmitter
+from s3transfer.tasks import SubmissionTask
 
 
 logger = logging.getLogger(__name__)
@@ -38,17 +38,37 @@ S3_RETRYABLE_ERRORS = (
 )
 
 
-class DownloadTaskSubmitter(TaskSubmitter):
-    def __init__(self, client, config, osutil, executor, io_executor):
-        super(DownloadTaskSubmitter, self).__init__(
-            client, config, osutil, executor)
-        self._io_executor = io_executor
+class DownloadSubmissionTask(SubmissionTask):
+    """Task for submitting tasks to execute a download"""
 
-    def _submit(self, transfer_future, transfer_coordinator):
+    def _submit(self, client, config, osutil, request_executor, io_executor,
+                transfer_future):
+        """
+        :param client: The client associated with the transfer manager
+
+        :type config: s3transfer.manager.TransferConfig
+        :param config: The transfer config associated with the transfer
+            manager
+
+        :type osutil: s3transfer.utils.OSUtil
+        :param osutil: The os utility associated to the transfer manager
+
+        :type request_executor: s3transfer.futures.BoundedExecutor
+        :param request_executor: The request executor associated with the
+            transfer manager
+
+        :type io_executor: s3transfer.futures.BoundedExecutor
+        :param io_executor: The io executor associated with the
+            transfer manager
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The transfer future associated with the
+            transfer request that tasks are being submitted for
+        """
         if transfer_future.meta.size is None:
             # If a size was not provided figure out the size for the
             # user.
-            response = self._client.head_object(
+            response = client.head_object(
                 Bucket=transfer_future.meta.call_args.bucket,
                 Key=transfer_future.meta.call_args.key,
                 **transfer_future.meta.call_args.extra_args
@@ -63,76 +83,76 @@ class DownloadTaskSubmitter(TaskSubmitter):
         )
         # If it is greater than threshold do a ranged download, otherwise
         # do a regular GetObject download.
-        if transfer_future.meta.size < self._config.multipart_threshold:
+        if transfer_future.meta.size < config.multipart_threshold:
             self._submit_download_request(
-                temp_filename, transfer_future, transfer_coordinator)
+                client, config, osutil, request_executor, io_executor,
+                temp_filename, transfer_future)
         else:
             self._submit_ranged_download_request(
-                temp_filename, transfer_future, transfer_coordinator)
+                client, config, osutil, request_executor, io_executor,
+                temp_filename, transfer_future)
 
-    def _submit_download_request(
-            self, temp_filename, transfer_future, transfer_coordinator):
+    def _submit_download_request(self, client, config, osutil,
+                                 request_executor, io_executor, temp_filename,
+                                 transfer_future):
         call_args = transfer_future.meta.call_args
 
         # Get a handle to the temp file
-        temp_fileobj = self._get_io_file_handle(
-            temp_filename, transfer_coordinator)
+        temp_fileobj = self._get_io_file_handle(temp_filename, osutil)
 
         # Get the needed callbacks for the task
         progress_callbacks = get_callbacks(transfer_future, 'progress')
-        done_callbacks = get_callbacks(transfer_future, 'done')
 
         # Before starting any tasks for downloads set up a cleanup function
         # that will make sure that the temporary file always gets
         # cleaned up.
-        transfer_coordinator.add_failure_cleanup(
-            self._osutil.remove_file, temp_filename)
+        self._transfer_coordinator.add_failure_cleanup(
+            osutil.remove_file, temp_filename)
 
         # Submit the task to download the object.
-        download_future = self._executor.submit(
+        download_future = self._submit_task(
+            request_executor,
             GetObjectTask(
-                transfer_coordinator=transfer_coordinator,
+                transfer_coordinator=self._transfer_coordinator,
                 main_kwargs={
-                    'client': self._client,
+                    'client': client,
                     'bucket': call_args.bucket,
                     'key': call_args.key,
                     'fileobj': temp_fileobj,
                     'extra_args': call_args.extra_args,
                     'callbacks': progress_callbacks,
-                    'max_attempts': self._config.num_download_attempts,
-                    'io_executor': self._io_executor
+                    'max_attempts': config.num_download_attempts,
+                    'io_executor': io_executor
                 }
             )
         )
 
         # Send the necessary tasks to complete the download.
         self._complete_download(
-            temp_fileobj, call_args.fileobj, transfer_coordinator,
-            [download_future], done_callbacks
-        )
+            osutil, request_executor, io_executor, temp_fileobj,
+            call_args.fileobj, [download_future])
 
-    def _submit_ranged_download_request(
-            self, temp_filename, transfer_future, transfer_coordinator):
+    def _submit_ranged_download_request(self, client, config, osutil,
+                                        request_executor, io_executor,
+                                        temp_filename, transfer_future):
         call_args = transfer_future.meta.call_args
 
-        # Get the needed callbacks for the task
+        # Get the needed progress callbacks for the task
         progress_callbacks = get_callbacks(transfer_future, 'progress')
-        done_callbacks = get_callbacks(transfer_future, 'done')
 
         # Get a handle to the temp file
-        temp_fileobj = self._get_io_file_handle(
-            temp_filename, transfer_coordinator)
+        temp_fileobj = self._get_io_file_handle(temp_filename, osutil)
 
         # Determine the number of parts
-        part_size = self._config.multipart_chunksize
+        part_size = config.multipart_chunksize
         num_parts = int(
             math.ceil(transfer_future.meta.size / float(part_size)))
 
         # Before starting any tasks for downloads set up a cleanup function
         # that will make sure that the temporary file always gets
         # cleaned up.
-        transfer_coordinator.add_failure_cleanup(
-            self._osutil.remove_file, temp_filename)
+        self._transfer_coordinator.add_failure_cleanup(
+            osutil.remove_file, temp_filename)
 
         ranged_downloads = []
         for i in range(num_parts):
@@ -146,18 +166,19 @@ class DownloadTaskSubmitter(TaskSubmitter):
             extra_args.update(call_args.extra_args)
             # Submit the ranged downloads
             ranged_downloads.append(
-                self._executor.submit(
+                self._submit_task(
+                    request_executor,
                     GetObjectTask(
-                        transfer_coordinator=transfer_coordinator,
+                        transfer_coordinator=self._transfer_coordinator,
                         main_kwargs={
-                            'client': self._client,
+                            'client': client,
                             'bucket': call_args.bucket,
                             'key': call_args.key,
                             'fileobj': temp_fileobj,
                             'extra_args': extra_args,
                             'callbacks': progress_callbacks,
-                            'max_attempts': self._config.num_download_attempts,
-                            'io_executor': self._io_executor,
+                            'max_attempts': config.num_download_attempts,
+                            'io_executor': io_executor,
                             'start_index': i * part_size
                         }
                     )
@@ -165,40 +186,38 @@ class DownloadTaskSubmitter(TaskSubmitter):
             )
         # Send the necessary tasks to complete the download.
         self._complete_download(
-            temp_fileobj, call_args.fileobj, transfer_coordinator,
-            ranged_downloads, done_callbacks
-        )
+            osutil, request_executor, io_executor, temp_fileobj,
+            call_args.fileobj, ranged_downloads)
 
-    def _get_io_file_handle(self, filename, transfer_coordinator):
-        f = self._osutil.open(filename, 'wb')
-        transfer_coordinator.add_failure_cleanup(f.close)
+    def _get_io_file_handle(self, filename, osutil):
+        f = osutil.open(filename, 'wb')
+        self._transfer_coordinator.add_failure_cleanup(f.close)
         return f
 
-    def _complete_download(self, fileobj, final_filename,
-                           transfer_coordinator, download_futures,
-                           done_callbacks):
+    def _complete_download(self, osutil, request_executor, io_executor,
+                           fileobj, final_filename, download_futures):
         # A task to rename the file from the temporary file to its final
         # location. This should be the last task needed to complete the
         # download.
         rename_task = IORenameFileTask(
-            transfer_coordinator=transfer_coordinator,
+            transfer_coordinator=self._transfer_coordinator,
             main_kwargs={
                 'fileobj': fileobj,
                 'final_filename': final_filename,
-                'osutil': self._osutil
+                'osutil': osutil
             },
-            done_callbacks=done_callbacks,
             is_final=True
         )
         submit_rename_task = FunctionContainer(
-            self._io_executor.submit, rename_task)
+            self._submit_task, io_executor, rename_task)
 
         # Submit a task to wait for all of the downloads to complete
         # and submit their downloaded content to the io executor before
         # submitting the renaming task to the io executor.
-        self._executor.submit(
+        self._submit_task(
+            request_executor,
             JoinFuturesTask(
-                transfer_coordinator=transfer_coordinator,
+                transfer_coordinator=self._transfer_coordinator,
                 pending_main_kwargs={
                     'futures_to_wait_on': download_futures
                 },
@@ -252,7 +271,8 @@ class GetObjectTask(Task):
                     # or error somewhere else, stop trying to submit more
                     # data to be written and break out of the download.
                     if not self._transfer_coordinator.done():
-                        io_executor.submit(
+                        self._submit_task(
+                            io_executor,
                             IOWriteTask(
                                 self._transfer_coordinator,
                                 main_kwargs={

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,6 +27,8 @@ from concurrent import futures
 
 from s3transfer.manager import TransferConfig
 from s3transfer.futures import TransferCoordinator
+from s3transfer.futures import TransferMeta
+from s3transfer.futures import TransferFuture
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
 
@@ -195,16 +197,22 @@ class BaseTaskTest(StubbedClientTest):
         return task_cls(**kwargs)
 
 
-class BaseTaskSubmitterTest(StubbedClientTest):
+class BaseSubmissionTaskTest(BaseTaskTest):
     def setUp(self):
-        super(BaseTaskSubmitterTest, self).setUp()
+        super(BaseSubmissionTaskTest, self).setUp()
         self.config = TransferConfig()
         self.osutil = OSUtils()
         self.executor = futures.ThreadPoolExecutor(1)
 
     def tearDown(self):
-        super(BaseTaskSubmitterTest, self).tearDown()
+        super(BaseSubmissionTaskTest, self).tearDown()
         self.executor.shutdown()
+
+    def get_transfer_future(self, call_args=None):
+        return TransferFuture(
+            meta=TransferMeta(call_args),
+            coordinator=self.transfer_coordinator
+        )
 
 
 class BaseGeneralInterfaceTest(StubbedClientTest):

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -22,7 +22,7 @@ from s3transfer.manager import TransferConfig
 class BaseCopyTest(BaseGeneralInterfaceTest):
     def setUp(self):
         super(BaseCopyTest, self).setUp()
-        self.config = TransferConfig(max_concurrency=1)
+        self.config = TransferConfig(max_request_concurrency=1)
         self._manager = TransferManager(self.client, self.config)
 
         # Initialize some default arguments
@@ -150,8 +150,9 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
 
     def test_invalid_copy_source(self):
         self.copy_source = ['bucket', 'key']
+        future = self.manager.copy(**self.create_call_kwargs())
         with self.assertRaises(TypeError):
-            self.manager.copy(**self.create_call_kwargs())
+            future.result()
 
     def test_provide_copy_source_client(self):
         source_client = self.session.create_client(
@@ -252,7 +253,8 @@ class TestMultipartCopy(BaseCopyTest):
     def setUp(self):
         super(TestMultipartCopy, self).setUp()
         self.config = TransferConfig(
-            max_concurrency=1, multipart_threshold=1, multipart_chunksize=4)
+            max_request_concurrency=1, multipart_threshold=1,
+            multipart_chunksize=4)
         self._manager = TransferManager(self.client, self.config)
 
     def create_stubbed_responses(self):

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -33,7 +33,7 @@ from s3transfer.download import GetObjectTask
 class BaseDownloadTest(BaseGeneralInterfaceTest):
     def setUp(self):
         super(BaseDownloadTest, self).setUp()
-        self.config = TransferConfig(max_concurrency=1)
+        self.config = TransferConfig(max_request_concurrency=1)
         self._manager = TransferManager(self.client, self.config)
 
         # Create a temporary directory to write to
@@ -167,8 +167,9 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         call_kwargs = self.create_call_kwargs()
         call_kwargs['fileobj'] = os.path.join(
             self.tempdir, 'missing-directory', 'myfile')
+        future = self.manager.download(**call_kwargs)
         with self.assertRaises(IOError):
-            self.manager.download(**call_kwargs)
+            future.result()
 
     def test_retries_and_succeeds(self):
         self.add_head_object_response()
@@ -296,7 +297,8 @@ class TestRangedDownload(BaseDownloadTest):
     def setUp(self):
         super(TestRangedDownload, self).setUp()
         self.config = TransferConfig(
-            max_concurrency=1, multipart_threshold=1, multipart_chunksize=4)
+            max_request_concurrency=1, multipart_threshold=1,
+            multipart_chunksize=4)
         self._manager = TransferManager(self.client, self.config)
 
     def create_stubbed_responses(self):

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -28,7 +28,7 @@ from s3transfer.manager import TransferConfig
 class BaseUploadTest(BaseGeneralInterfaceTest):
     def setUp(self):
         super(BaseUploadTest, self).setUp()
-        self.config = TransferConfig(max_concurrency=1)
+        self.config = TransferConfig(max_request_concurrency=1)
         self._manager = TransferManager(self.client, self.config)
 
         # Create a temporary directory with files to read from
@@ -151,7 +151,8 @@ class TestMultipartUpload(BaseUploadTest):
     def setUp(self):
         super(TestMultipartUpload, self).setUp()
         self.config = TransferConfig(
-            max_concurrency=1, multipart_threshold=1, multipart_chunksize=4)
+            max_request_concurrency=1, multipart_threshold=1,
+            multipart_chunksize=4)
         self._manager = TransferManager(self.client, self.config)
 
     def create_stubbed_responses(self):

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -18,14 +18,30 @@ from concurrent.futures import CancelledError
 
 
 from tests import unittest
+from s3transfer.futures import get_transfer_future_with_components
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferCoordinator
 from s3transfer.futures import BoundedExecutor
+from s3transfer.utils import FunctionContainer
 
 
 def return_call_args(*args, **kwargs):
     return args, kwargs
+
+
+class TestGetTransferFutureWithComponents(unittest.TestCase):
+    def test_get_transfer_future_with_components(self):
+        call_args = object()
+        transfer_future, components = get_transfer_future_with_components(
+            call_args)
+        # Assert all of the returned objects are of the expected type.
+        self.assertIsInstance(transfer_future, TransferFuture)
+        self.assertIsInstance(components['meta'], TransferMeta)
+        self.assertIsInstance(components['coordinator'], TransferCoordinator)
+
+        # Ensure the call args provided is attached to the transfer future.
+        self.assertEqual(call_args, transfer_future.meta.call_args)
 
 
 class TestTransferFuture(unittest.TestCase):
@@ -191,6 +207,76 @@ class TestTransferCoordinator(unittest.TestCase):
             result_list.append(cleanup())
         self.assertEqual(
             result_list, [(args, kwargs), (second_args, second_kwargs)])
+
+    def test_associated_futures(self):
+        first_future = object()
+        # Associate one future to the transfer
+        self.transfer_coordinator.add_associated_future(first_future)
+        associated_futures = self.transfer_coordinator.associated_futures
+        # The first future should be in the returned list of futures.
+        self.assertEqual(associated_futures, [first_future])
+
+        second_future = object()
+        # Associate another future to the transfer.
+        self.transfer_coordinator.add_associated_future(second_future)
+        # The association should not have mutated the returned list from
+        # before.
+        self.assertEqual(associated_futures, [first_future])
+
+        # Both futures should be in the returned list.
+        self.assertEqual(
+            self.transfer_coordinator.associated_futures,
+            [first_future, second_future])
+
+    def test_associated_futures_on_done(self):
+        future = object()
+        self.transfer_coordinator.add_associated_future(future)
+        self.assertEqual(
+            self.transfer_coordinator.associated_futures, [future])
+
+        self.transfer_coordinator.announce_done()
+        # When the transfer completes that means all of the futures have
+        # completed as well, leaving no need to keep the completed futures
+        # around as the transfer is done.
+        self.assertEqual(self.transfer_coordinator.associated_futures, [])
+
+    def test_done_callbacks_on_done(self):
+        done_callback_invocations = []
+        callback = FunctionContainer(
+            done_callback_invocations.append, 'done callback called')
+
+        # Add the done callback to the transfer.
+        self.transfer_coordinator.add_done_callback(callback)
+
+        # Announce that the transfer is done. This should invoke the done
+        # callback.
+        self.transfer_coordinator.announce_done()
+        self.assertEqual(done_callback_invocations, ['done callback called'])
+
+        # If done is announced again, we should not invoke the callback again
+        # because done has already been announced and thus the callback has
+        # been ran as well.
+        self.transfer_coordinator.announce_done()
+        self.assertEqual(done_callback_invocations, ['done callback called'])
+
+    def test_failure_cleanups_on_done(self):
+        cleanup_invocations = []
+        callback = FunctionContainer(
+            cleanup_invocations.append, 'cleanup called')
+
+        # Add the failure cleanup to the transfer.
+        self.transfer_coordinator.add_failure_cleanup(callback)
+
+        # Announce that the transfer is done. This should invoke the failure
+        # cleanup.
+        self.transfer_coordinator.announce_done()
+        self.assertEqual(cleanup_invocations, ['cleanup called'])
+
+        # If done is announced again, we should not invoke the cleanup again
+        # because done has already been announced and thus the cleanup has
+        # been ran as well.
+        self.transfer_coordinator.announce_done()
+        self.assertEqual(cleanup_invocations, ['cleanup called'])
 
 
 class TestBoundedExecutor(unittest.TestCase):


### PR DESCRIPTION
This is a pretty large refactoring of the architecture, but I think that it is worth it and necessary in the long run as we add features. In short, the change wraps the ``TaskSubmitter`` logic that submits all of the tasks to execute a transfer into a ``SubmissionTask`` itself and these submission tasks are then executed by an executor specific for running submission tasks. This is really helpful for the following reasons:

* The submission of tasks are no longer handled in the main thread, which makes it quicker to enqueue transfer request and get a transfer future back. For example, in downloads and copies you are no longer doing a ``HeadObject ``in the main thread. This is also going to be needed for streaming uploads (i.e. we do not want to stream the entire file in the main thread).
* Exception handling is more robust such that if there was an error during submission before the final task was submitted, bad things could have happened such as hanging or cleanup tasks not being ran. This is no longer the case.
* ``on_queued`` callbacks happen in the submission thread pool. This allows you to make slower calls in these callbacks without slowing down your speed in adding more transfer requests. This will be critical if you want to try to do complete copies for multipart which could require multiple API requests.

As to the changes that were made in the refactoring, they include:

* Remove the ``TaskSubmitter`` class in place of a ``SubmissionTask`` class. They relatively have the same functionality but the ``SubmissionTask`` subclasses from the ``Task`` class so it can be ran by an executor.
* Added a new executor to complete ``SubmissionTask`` that does not interfere with the main executor.
* Moved the running of failure cleanups and done callbacks into the ``TransferCoordinator``. This was changed because logically it made sense that coordinator runs the callbacks associated to it when it announces done especially since it is no longer the responsibility of a single know task to announce that the transfer is done (This can happen in the submission task if it fails or the designated final task).

Let me know if you have any questions. I tried my best to add comments and documentation at the trickier parts of the code.

cc @jamesls @JordonPhillips 