### PR TITLE
Add support for seekable file objects

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -168,8 +168,9 @@ class TransferManager(object):
     def upload(self, fileobj, bucket, key, extra_args=None, subscribers=None):
         """Uploads a file to S3
 
-        :type fileobj: str
-        :param fileobj: The name of a file to upload.
+        :type fileobj: str or seekable file-like object
+        :param fileobj: The name of a file to upload or a seekable file-like
+            object to upload.
 
         :type bucket: str
         :param bucket: The name of the bucket to upload to

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -12,11 +12,138 @@
 # language governing permissions and limitations under the License.
 import math
 
+from botocore.compat import six
+
 from s3transfer.tasks import Task
 from s3transfer.tasks import SubmissionTask
 from s3transfer.tasks import CreateMultipartUploadTask
 from s3transfer.tasks import CompleteMultipartUploadTask
 from s3transfer.utils import get_callbacks
+
+
+def get_upload_input_manager_cls(transfer_future):
+    """Retieves a class for managing input for an upload based on file type
+
+    :type transfer_future: s3transfer.futures.TransferFuture
+    :param transfer_future: The transfer future for the request
+
+    :rtype: class of UploadInputManager
+    :returns: The appropriate class to use for managing a specific type of
+        input for uploads.
+    """
+    fileobj = transfer_future.meta.call_args.fileobj
+    if isinstance(fileobj, six.string_types):
+        return UploadFilenameInputManager
+    else:
+        raise RuntimeError(
+            '%s must be a filename.' % fileobj)
+
+
+class UploadInputManager(object):
+    """Base manager class for handling various types of files for uploads
+
+    This class is typically used for the UploadSubmissionTask class to help
+    determine the following:
+
+        * How to determine the size of the file
+        * How to determine if a multipart upload is required
+        * How to retrieve the body for a PutObject
+        * How to retrieve the bodies for a set of UploadParts
+
+    The answers/implementations differ for the various types of file inputs
+    that may be accepted. All implementations must subclass and override
+    public methods from this class.
+    """
+    def provide_transfer_size(self, transfer_future):
+        """Provides the transfer size of an upload
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The future associated with upload request
+        """
+        raise NotImplementedError('must implement provide_transfer_size()')
+
+    def requires_multipart_upload(self, transfer_future, config):
+        """Determines where a multipart upload is required
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The future associated with upload request
+
+        :type config: s3transfer.manager.TransferConfig
+        :param config: The config associated to the transfer manager
+
+        :rtype: boolean
+        :returns: True, if the upload should be multipart based on
+            configuartion and size. False, otherwise.
+        """
+        raise NotImplementedError('must implement requires_multipart_upload()')
+
+    def get_put_object_body(self, transfer_future):
+        """Returns the body to use for PutObject
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The future associated with upload request
+
+        :type config: s3transfer.manager.TransferConfig
+        :param config: The config associated to the transfer manager
+
+        :rtype: s3transfer.utils.ReadFileChunk
+        :returns: A ReadFileChunk including all progress callbacks
+            associated with the transfer future.
+        """
+        raise NotImplementedError('must implement get_put_object_body()')
+
+    def yield_upload_part_bodies(self, transfer_future, config):
+        """Yields the part number and body to use for each UploadPart
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The future associated with upload request
+
+        :type config: s3transfer.manager.TransferConfig
+        :param config: The config associated to the transfer manager
+
+        :rtype: int, s3transfer.utils.ReadFileChunk
+        :returns: Yields the part number and the ReadFileChunk including all
+            progress callbacks associated with the transfer future for that
+            specific yielded part.
+        """
+        raise NotImplementedError('must implement yield_upload_part_bodies()')
+
+
+class UploadFilenameInputManager(UploadInputManager):
+    """Upload utility for filenames"""
+    def __init__(self, osutil):
+        self._osutil = osutil
+
+    def provide_transfer_size(self, transfer_future):
+        transfer_future.meta.provide_transfer_size(
+            self._osutil.get_file_size(
+                transfer_future.meta.call_args.fileobj))
+
+    def requires_multipart_upload(self, transfer_future, config):
+        return transfer_future.meta.size >= config.multipart_threshold
+
+    def get_put_object_body(self, transfer_future):
+        fileobj = transfer_future.meta.call_args.fileobj
+        callbacks = get_callbacks(transfer_future, 'progress')
+        return self._osutil.open_file_chunk_reader(
+            filename=fileobj, start_byte=0, size=transfer_future.meta.size,
+            callbacks=callbacks)
+
+    def yield_upload_part_bodies(self, transfer_future, config):
+        part_size = config.multipart_chunksize
+        num_parts = self._get_num_parts(transfer_future, part_size)
+        for part_number in range(1, num_parts + 1):
+            fileobj = transfer_future.meta.call_args.fileobj
+            callbacks = get_callbacks(transfer_future, 'progress')
+            fileobj = self._osutil.open_file_chunk_reader(
+                filename=fileobj, start_byte=part_size * (part_number - 1),
+                size=part_size, callbacks=callbacks
+            )
+            yield part_number, fileobj
+
+    def _get_num_parts(self, transfer_future, part_size):
+        return int(
+            math.ceil(transfer_future.meta.size / float(part_size)))
 
 
 class UploadSubmissionTask(SubmissionTask):
@@ -49,26 +176,27 @@ class UploadSubmissionTask(SubmissionTask):
         :param transfer_future: The transfer future associated with the
             transfer request that tasks are being submitted for
         """
-        if transfer_future.meta.size is None:
-            transfer_future.meta.provide_transfer_size(
-                osutil.get_file_size(
-                    transfer_future.meta.call_args.fileobj))
+        upload_input_manager = get_upload_input_manager_cls(
+            transfer_future)(osutil)
 
-        # If it is greater than threshold do a multipart upload, otherwise
-        # do a regular put object.
-        if transfer_future.meta.size < config.multipart_threshold:
+        # Determine the size if it was not provided
+        if transfer_future.meta.size is None:
+            upload_input_manager.provide_transfer_size(transfer_future)
+
+        # Do a multipart upload if needed, otherwise do a regular put object.
+        if not upload_input_manager.requires_multipart_upload(
+                transfer_future, config):
             self._submit_upload_request(
-                client, config, osutil, request_executor, transfer_future)
+                client, config, osutil, request_executor, transfer_future,
+                upload_input_manager)
         else:
             self._submit_multipart_request(
-                client, config, osutil, request_executor, transfer_future)
+                client, config, osutil, request_executor, transfer_future,
+                upload_input_manager)
 
     def _submit_upload_request(self, client, config, osutil, request_executor,
-                               transfer_future):
+                               transfer_future, upload_input_manager):
         call_args = transfer_future.meta.call_args
-
-        # Get the needed progress callbacks for the task
-        progress_callbacks = get_callbacks(transfer_future, 'progress')
 
         # Submit the request of a single upload.
         self._submit_task(
@@ -77,20 +205,19 @@ class UploadSubmissionTask(SubmissionTask):
                 transfer_coordinator=self._transfer_coordinator,
                 main_kwargs={
                     'client': client,
-                    'fileobj': call_args.fileobj,
+                    'fileobj': upload_input_manager.get_put_object_body(
+                        transfer_future),
                     'bucket': call_args.bucket,
                     'key': call_args.key,
-                    'extra_args': call_args.extra_args,
-                    'osutil': osutil,
-                    'size': transfer_future.meta.size,
-                    'progress_callbacks': progress_callbacks
+                    'extra_args': call_args.extra_args
                 },
                 is_final=True
             )
         )
 
     def _submit_multipart_request(self, client, config, osutil,
-                                  request_executor, transfer_future):
+                                  request_executor, transfer_future,
+                                  upload_input_manager):
         call_args = transfer_future.meta.call_args
 
         # Submit the request to create a multipart upload.
@@ -107,18 +234,14 @@ class UploadSubmissionTask(SubmissionTask):
             )
         )
 
-        # Determine how many parts are needed based on filesize and
-        # desired chunksize.
-        part_size = config.multipart_chunksize
-        num_parts = int(
-            math.ceil(transfer_future.meta.size / float(part_size)))
-
         # Submit requests to upload the parts of the file.
         part_futures = []
-        progress_callbacks = get_callbacks(transfer_future, 'progress')
         extra_part_args = self._extra_upload_part_args(call_args.extra_args)
 
-        for part_number in range(1, num_parts + 1):
+        part_iterator = upload_input_manager.yield_upload_part_bodies(
+            transfer_future, config)
+
+        for part_number, fileobj in part_iterator:
             part_futures.append(
                 self._submit_task(
                     request_executor,
@@ -126,14 +249,11 @@ class UploadSubmissionTask(SubmissionTask):
                         transfer_coordinator=self._transfer_coordinator,
                         main_kwargs={
                             'client': client,
-                            'fileobj': call_args.fileobj,
+                            'fileobj': fileobj,
                             'bucket': call_args.bucket,
                             'key': call_args.key,
                             'part_number': part_number,
-                            'extra_args': extra_part_args,
-                            'osutil': osutil,
-                            'part_size': part_size,
-                            'progress_callbacks': progress_callbacks
+                            'extra_args': extra_part_args
                         },
                         pending_main_kwargs={
                             'upload_id': create_multipart_future
@@ -172,8 +292,7 @@ class UploadSubmissionTask(SubmissionTask):
 
 class PutObjectTask(Task):
     """Task to do a nonmultipart upload"""
-    def _main(self, client, fileobj, bucket, key, extra_args, osutil, size,
-              progress_callbacks):
+    def _main(self, client, fileobj, bucket, key, extra_args):
         """
         :param client: The client to use when calling PutObject
         :param fileobj: The file to upload.
@@ -181,19 +300,15 @@ class PutObjectTask(Task):
         :param key: The name of the key to upload to
         :param extra_args: A dictionary of any extra arguments that may be
             used in the upload.
-        :param osutil: OSUtil for upload
-        :param size: The size of the part
-        :param progress_callbacks: The callbacks to invoke on progress.
         """
-        with osutil.open_file_chunk_reader(
-                fileobj, 0, size, progress_callbacks) as body:
+        with fileobj as body:
             client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
 
 
 class UploadPartTask(Task):
     """Task to upload a part in a multipart upload"""
     def _main(self, client, fileobj, bucket, key, upload_id, part_number,
-              extra_args, osutil, part_size, progress_callbacks):
+              extra_args):
         """
         :param client: The client to use when calling PutObject
         :param fileobj: The file to upload.
@@ -204,9 +319,6 @@ class UploadPartTask(Task):
             upload
         :param extra_args: A dictionary of any extra arguments that may be
             used in the upload.
-        :param osutil: OSUtil for upload
-        :param part_size: The size of the part
-        :param progress_callbacks: The callbacks to invoke on progress.
 
         :rtype: dict
         :returns: A dictionary representing a part::
@@ -216,9 +328,7 @@ class UploadPartTask(Task):
             This value can be appended to a list to be used to complete
             the multipart upload.
         """
-        with osutil.open_file_chunk_reader(
-                fileobj, part_size * (part_number - 1),
-                part_size, progress_callbacks) as body:
+        with fileobj as body:
             response = client.upload_part(
                 Bucket=bucket, Key=key,
                 UploadId=upload_id, PartNumber=part_number,

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -221,7 +221,8 @@ class DeferredOpenFile(object):
         return self._fileobj.tell()
 
     def close(self):
-        self._fileobj.close()
+        if self._fileobj:
+            self._fileobj.close()
 
     def __enter__(self):
         self._open_if_needed()

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -163,6 +163,12 @@ class OSUtils(object):
                                            size, callbacks,
                                            enable_callbacks=False)
 
+    def open_file_chunk_reader_from_fileobj(self, fileobj, chunk_size,
+                                            full_file_size, callbacks):
+        return ReadFileChunk(
+            fileobj, chunk_size, full_file_size,
+            callbacks=callbacks, enable_callbacks=False)
+
     def open(self, filename, mode):
         return open(filename, mode)
 
@@ -299,8 +305,9 @@ class ReadFileChunk(object):
         :return: A new instance of ``ReadFileChunk``
 
         """
-        file_size = os.path.getsize(filename)
-        f = DeferredOpenFile(filename=filename, start_byte=start_byte)
+        f = open(filename, 'rb')
+        f.seek(start_byte)
+        file_size = os.fstat(f.fileno()).st_size
         return cls(f, chunk_size, file_size, callbacks, enable_callbacks)
 
     def _calculate_file_size(self, fileobj, requested_size, start_byte,

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -236,7 +236,7 @@ class ReadFileChunk(object):
                  callbacks=None, enable_callbacks=True):
         """
 
-        Given a file object shown below:
+        Given a file object shown below::
 
             |___________________________________________________|
             0          |                 |                 full_file_size

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -204,8 +204,7 @@ class DeferredOpenFile(object):
     def _open_if_needed(self):
         if self._fileobj is None:
             self._fileobj = self.OPEN_METHOD(self._filename, 'rb')
-            if self._start_byte != 0:
-                self._fileobj.seek(self._start_byte)
+            self._fileobj.seek(self._start_byte)
 
     def read(self, amount=None):
         self._open_if_needed()
@@ -266,7 +265,6 @@ class ReadFileChunk(object):
         self._size = self._calculate_file_size(
             self._fileobj, requested_size=chunk_size,
             start_byte=self._start_byte, actual_file_size=full_file_size)
-        self._fileobj.seek(self._start_byte)
         self._amount_read = 0
         self._callbacks = callbacks
         if callbacks is None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -197,6 +197,12 @@ class BaseTaskTest(StubbedClientTest):
             kwargs['transfer_coordinator'] = self.transfer_coordinator
         return task_cls(**kwargs)
 
+    def get_transfer_future(self, call_args=None):
+        return TransferFuture(
+            meta=TransferMeta(call_args),
+            coordinator=self.transfer_coordinator
+        )
+
 
 class BaseSubmissionTaskTest(BaseTaskTest):
     def setUp(self):
@@ -208,12 +214,6 @@ class BaseSubmissionTaskTest(BaseTaskTest):
     def tearDown(self):
         super(BaseSubmissionTaskTest, self).tearDown()
         self.executor.shutdown()
-
-    def get_transfer_future(self, call_args=None):
-        return TransferFuture(
-            meta=TransferMeta(call_args),
-            coordinator=self.transfer_coordinator
-        )
 
 
 class BaseGeneralInterfaceTest(StubbedClientTest):

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -105,7 +105,7 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
 
         stubbed_responses = self.create_stubbed_responses()
 
-        # If the length of copy responses is greater than one then it is
+        # If the length of upload responses is greater than one then it is
         # a multipart upload.
         upload_responses = stubbed_responses[0:1]
         if len(stubbed_responses) > 1:
@@ -116,7 +116,7 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
             stubbed_responses[0][
                 'expected_params'] = expected_create_mpu_params
 
-        # Add any expected copy parameters.
+        # Add any expected upload parameters.
         if expected_upload_params:
             for i, upload_response in enumerate(upload_responses):
                 if isinstance(expected_upload_params, list):
@@ -231,7 +231,7 @@ class TestMultipartUpload(BaseUploadTest):
         }
 
         expected_upload_params = []
-        # Add expected parameters to the copy part
+        # Add expected parameters to the upload part
         num_parts = 3
         for i in range(num_parts):
             expected_upload_params.append(

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -14,10 +14,10 @@ import os
 import tempfile
 import shutil
 
-import mock
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from botocore.awsrequest import AWSRequest
+from botocore.stub import ANY
 
 from tests import BaseGeneralInterfaceTest
 from tests import RecordingSubscriber
@@ -141,7 +141,7 @@ class TestNonMultipartUpload(BaseUploadTest):
     def test_upload(self):
         self.extra_args['RequestPayer'] = 'requester'
         expected_params = {
-            'Body': mock.ANY, 'Bucket': self.bucket,
+            'Body': ANY, 'Bucket': self.bucket,
             'Key': self.key, 'RequestPayer': 'requester'
         }
         self.add_successful_upload_responses(
@@ -154,7 +154,7 @@ class TestNonMultipartUpload(BaseUploadTest):
 
     def test_upload_for_fileobj(self):
         expected_params = {
-            'Body': mock.ANY, 'Bucket': self.bucket,
+            'Body': ANY, 'Bucket': self.bucket,
             'Key': self.key
         }
         self.add_successful_upload_responses(
@@ -176,7 +176,7 @@ class TestNonMultipartUpload(BaseUploadTest):
 
         # Add the expected params
         expected_params = {
-            'Body': mock.ANY, 'Bucket': self.bucket,
+            'Body': ANY, 'Bucket': self.bucket,
             'Key': self.key
         }
         self.add_successful_upload_responses(
@@ -239,7 +239,7 @@ class TestMultipartUpload(BaseUploadTest):
                     'Bucket': self.bucket,
                     'Key': self.key,
                     'UploadId': self.multipart_id,
-                    'Body': mock.ANY,
+                    'Body': ANY,
                     'PartNumber': i + 1,
                 }
             )
@@ -324,7 +324,7 @@ class TestMultipartUpload(BaseUploadTest):
                 'ETag': 'etag-1'
             },
             expected_params={
-                'Bucket': self.bucket, 'Body': mock.ANY,
+                'Bucket': self.bucket, 'Body': ANY,
                 'Key': self.key, 'UploadId': self.multipart_id,
                 'PartNumber': 1
             }

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -43,6 +43,26 @@ class TestUpload(BaseTransferManagerIntegTest):
         future.result()
         self.assertTrue(self.object_exists('20mb.txt'))
 
+    def test_upload_open_file_below_threshold(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+        filename = self.files.create_file_with_size(
+            '1mb.txt', filesize=1024 * 1024)
+        with open(filename, 'rb') as f:
+            future = transfer_manager.upload(f, self.bucket_name, '1mb.txt')
+            self.addCleanup(self.delete_object, '1mb.txt')
+            future.result()
+        self.assertTrue(self.object_exists('1mb.txt'))
+
+    def test_upload_open_file_above_threshold(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        with open(filename, 'rb') as f:
+            future = transfer_manager.upload(f, self.bucket_name, '20mb.txt')
+            self.addCleanup(self.delete_object, '20mb.txt')
+            future.result()
+        self.assertTrue(self.object_exists('20mb.txt'))
+
     def test_progress_subscribers_on_upload(self):
         subscriber = RecordingSubscriber()
         transfer_manager = self.create_transfer_manager(self.config)

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 import shutil
 
-import mock
+from botocore.stub import ANY
 
 from tests import BaseTaskTest
 from tests import BaseSubmissionTaskTest
@@ -247,7 +247,7 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
             method='put_object',
             service_response={},
             expected_params={
-                'Body': mock.ANY, 'Bucket': self.bucket,
+                'Body': ANY, 'Bucket': self.bucket,
                 'Key': self.key
             }
         )
@@ -282,7 +282,7 @@ class TestPutObjectTask(BaseUploadTest):
                 method='put_object',
                 service_response={},
                 expected_params={
-                    'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
+                    'Body': ANY, 'Bucket': self.bucket, 'Key': self.key,
                     'Metadata': {'foo': 'bar'}
                 }
             )
@@ -314,7 +314,7 @@ class TestUploadPartTask(BaseUploadTest):
                 method='upload_part',
                 service_response={'ETag': etag},
                 expected_params={
-                    'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
+                    'Body': ANY, 'Bucket': self.bucket, 'Key': self.key,
                     'UploadId': upload_id, 'PartNumber': part_number,
                     'RequestPayer': 'requester'
                 }

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -19,6 +19,10 @@ import mock
 from tests import BaseTaskTest
 from tests import BaseSubmissionTaskTest
 from tests import FileSizeProvider
+from tests import RecordingSubscriber
+from s3transfer.manager import TransferConfig
+from s3transfer.upload import get_upload_input_manager_cls
+from s3transfer.upload import UploadFilenameInputManager
 from s3transfer.upload import UploadSubmissionTask
 from s3transfer.upload import PutObjectTask
 from s3transfer.upload import UploadPartTask
@@ -32,9 +36,9 @@ class OSUtilsExceptionOnFileSize(OSUtils):
             "The file %s should not have been stated" % filename)
 
 
-class BaseUploadTaskTest(BaseTaskTest):
+class BaseUploadTest(BaseTaskTest):
     def setUp(self):
-        super(BaseUploadTaskTest, self).setUp()
+        super(BaseUploadTest, self).setUp()
         self.bucket = 'mybucket'
         self.key = 'foo'
         self.osutil = OSUtils()
@@ -42,6 +46,7 @@ class BaseUploadTaskTest(BaseTaskTest):
         self.tempdir = tempfile.mkdtemp()
         self.filename = os.path.join(self.tempdir, 'myfile')
         self.content = b'my content'
+        self.subscribers = []
 
         with open(self.filename, 'wb') as f:
             f.write(self.content)
@@ -53,12 +58,111 @@ class BaseUploadTaskTest(BaseTaskTest):
             'before-parameter-build.s3.*', self.collect_body)
 
     def tearDown(self):
-        super(BaseUploadTaskTest, self).tearDown()
+        super(BaseUploadTest, self).tearDown()
         shutil.rmtree(self.tempdir)
 
     def collect_body(self, params, **kwargs):
         if 'Body' in params:
             self.sent_bodies.append(params['Body'].read())
+
+
+class TestGetUploadManagerClsTest(BaseUploadTest):
+    def test_for_filename(self):
+        call_args = CallArgs(fileobj=self.filename)
+        future = self.get_transfer_future(call_args)
+        # Ensure the correct class was returned for filenames
+        self.assertIs(
+            get_upload_input_manager_cls(future), UploadFilenameInputManager)
+
+
+class BaseUploadInputManagerTest(BaseUploadTest):
+    def setUp(self):
+        super(BaseUploadInputManagerTest, self).setUp()
+        self.osutil = OSUtils()
+        self.config = TransferConfig()
+        self.recording_subscriber = RecordingSubscriber()
+        self.subscribers.append(self.recording_subscriber)
+
+    def _get_expected_body_for_part(self, part_number):
+        # A helper method for retrieving the expected body for a specific
+        # part number of the data
+        total_size = len(self.content)
+        chunk_size = self.config.multipart_chunksize
+        start_index = (part_number - 1) * chunk_size
+        end_index = part_number * chunk_size
+        if end_index >= total_size:
+            return self.content[start_index:]
+        return self.content[start_index:end_index]
+
+
+class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
+    def setUp(self):
+        super(TestUploadFilenameInputManager, self).setUp()
+        self.upload_input_manager = UploadFilenameInputManager(self.osutil)
+        self.call_args = CallArgs(
+            fileobj=self.filename, subscribers=self.subscribers)
+        self.future = self.get_transfer_future(self.call_args)
+
+    def test_provide_transfer_size(self):
+        self.upload_input_manager.provide_transfer_size(self.future)
+        # The provided file size should be equal to size of the contents of
+        # the file.
+        self.assertEqual(self.future.meta.size, len(self.content))
+
+    def test_requires_multipart_upload(self):
+        self.future.meta.provide_transfer_size(len(self.content))
+        # With the default multipart threshold, the length of the content
+        # should be smaller than the threshold thus not requiring a multipart
+        # transfer.
+        self.assertFalse(
+            self.upload_input_manager.requires_multipart_upload(
+                self.future, self.config))
+        # Decreasing the threshold to that of the length of the content of
+        # the file should trigger the need for a multipart upload.
+        self.config.multipart_threshold = len(self.content)
+        self.assertTrue(
+            self.upload_input_manager.requires_multipart_upload(
+                self.future, self.config))
+
+    def test_get_put_object_body(self):
+        self.future.meta.provide_transfer_size(len(self.content))
+        read_file_chunk = self.upload_input_manager.get_put_object_body(
+            self.future)
+        read_file_chunk.enable_callback()
+        # The file-like object provided back should be the same as the content
+        # of the file.
+        self.assertEqual(read_file_chunk.read(), self.content)
+        # The file-like object should also have been wrapped with the
+        # on_queued callbacks to track the amount of bytes being transferred.
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
+
+    def test_yield_upload_part_bodies(self):
+        # Adjust the chunk size to something more grainular for testing.
+        self.config.multipart_chunksize = 4
+        self.future.meta.provide_transfer_size(len(self.content))
+
+        # Get an iterator that will yield all of the bodies and their
+        # respective part number.
+        part_iterator = self.upload_input_manager.yield_upload_part_bodies(
+            self.future, self.config)
+        expected_part_number = 1
+        for part_number, read_file_chunk in part_iterator:
+            # Ensure that the part number is as expected
+            self.assertEqual(part_number, expected_part_number)
+            read_file_chunk.enable_callback()
+            # Ensure that the body is correct for that part.
+            self.assertEqual(
+                read_file_chunk.read(),
+                self._get_expected_body_for_part(part_number))
+            expected_part_number += 1
+
+        # All of the file-like object should also have been wrapped with the
+        # on_queued callbacks to track the amount of bytes being transferred.
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(),
+            len(self.content))
 
 
 class TestUploadSubmissionTask(BaseSubmissionTaskTest):
@@ -134,66 +238,62 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.assertEqual(self.sent_bodies, [self.content])
 
 
-class TestPutObjectTask(BaseUploadTaskTest):
+class TestPutObjectTask(BaseUploadTest):
     def test_main(self):
         extra_args = {'Metadata': {'foo': 'bar'}}
-        task = self.get_task(
-            PutObjectTask,
-            main_kwargs={
-                'client': self.client,
-                'fileobj': self.filename,
-                'bucket': self.bucket,
-                'key': self.key,
-                'extra_args': extra_args,
-                'osutil': self.osutil,
-                'size': len(self.content),
-                'progress_callbacks': []
-            }
-        )
-        self.stubber.add_response(
-            method='put_object',
-            service_response={},
-            expected_params={
-                'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
-                'Metadata': {'foo': 'bar'}
-            }
-        )
-        task()
-        self.stubber.assert_no_pending_responses()
-        self.assertEqual(self.sent_bodies, [self.content])
+        with open(self.filename, 'rb') as fileobj:
+            task = self.get_task(
+                PutObjectTask,
+                main_kwargs={
+                    'client': self.client,
+                    'fileobj': fileobj,
+                    'bucket': self.bucket,
+                    'key': self.key,
+                    'extra_args': extra_args
+                }
+            )
+            self.stubber.add_response(
+                method='put_object',
+                service_response={},
+                expected_params={
+                    'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
+                    'Metadata': {'foo': 'bar'}
+                }
+            )
+            task()
+            self.stubber.assert_no_pending_responses()
+            self.assertEqual(self.sent_bodies, [self.content])
 
 
-class TestUploadPartTask(BaseUploadTaskTest):
+class TestUploadPartTask(BaseUploadTest):
     def test_main(self):
         extra_args = {'RequestPayer': 'requester'}
         upload_id = 'my-id'
         part_number = 1
         etag = 'foo'
-        task = self.get_task(
-            UploadPartTask,
-            main_kwargs={
-                'client': self.client,
-                'fileobj': self.filename,
-                'bucket': self.bucket,
-                'key': self.key,
-                'upload_id': upload_id,
-                'part_number': part_number,
-                'extra_args': extra_args,
-                'osutil': self.osutil,
-                'part_size': len(self.content),
-                'progress_callbacks': []
-            }
-        )
-        self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': etag},
-            expected_params={
-                'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
-                'UploadId': upload_id, 'PartNumber': part_number,
-                'RequestPayer': 'requester'
-            }
-        )
-        rval = task()
-        self.stubber.assert_no_pending_responses()
-        self.assertEqual(rval, {'ETag': etag, 'PartNumber': part_number})
-        self.assertEqual(self.sent_bodies, [self.content])
+        with open(self.filename, 'rb') as fileobj:
+            task = self.get_task(
+                UploadPartTask,
+                main_kwargs={
+                    'client': self.client,
+                    'fileobj': fileobj,
+                    'bucket': self.bucket,
+                    'key': self.key,
+                    'upload_id': upload_id,
+                    'part_number': part_number,
+                    'extra_args': extra_args
+                }
+            )
+            self.stubber.add_response(
+                method='upload_part',
+                service_response={'ETag': etag},
+                expected_params={
+                    'Body': mock.ANY, 'Bucket': self.bucket, 'Key': self.key,
+                    'UploadId': upload_id, 'PartNumber': part_number,
+                    'RequestPayer': 'requester'
+                }
+            )
+            rval = task()
+            self.stubber.assert_no_pending_responses()
+            self.assertEqual(rval, {'ETag': etag, 'PartNumber': part_number})
+            self.assertEqual(self.sent_bodies, [self.content])

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -21,7 +21,6 @@ from tests import BaseSubmissionTaskTest
 from tests import FileSizeProvider
 from tests import RecordingSubscriber
 from s3transfer.manager import TransferConfig
-from s3transfer.upload import get_upload_input_manager_cls
 from s3transfer.upload import UploadFilenameInputManager
 from s3transfer.upload import UploadSeekableInputManager
 from s3transfer.upload import UploadSubmissionTask
@@ -65,23 +64,6 @@ class BaseUploadTest(BaseTaskTest):
     def collect_body(self, params, **kwargs):
         if 'Body' in params:
             self.sent_bodies.append(params['Body'].read())
-
-
-class TestGetUploadManagerClsTest(BaseUploadTest):
-    def test_for_filename(self):
-        call_args = CallArgs(fileobj=self.filename)
-        future = self.get_transfer_future(call_args)
-        # Ensure the correct class was returned for filenames
-        self.assertIs(
-            get_upload_input_manager_cls(future), UploadFilenameInputManager)
-
-    def test_for_seekable(self):
-        with open(self.filename, 'rb') as f:
-            call_args = CallArgs(fileobj=f)
-            future = self.get_transfer_future(call_args)
-            self.assertIs(
-                get_upload_input_manager_cls(future),
-                UploadSeekableInputManager)
 
 
 class BaseUploadInputManagerTest(BaseUploadTest):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -158,6 +158,18 @@ class TestOSUtils(BaseUtilsTest):
         # Callbacks should be disabled depspite being passed in.
         self.assertEqual(self.amounts_seen, [])
 
+    def test_open_file_chunk_reader_from_fileobj(self):
+        with open(self.filename, 'rb') as f:
+            reader = OSUtils().open_file_chunk_reader_from_fileobj(
+                f, len(self.content), len(self.content), [self.callback])
+
+            # The returned reader should be a ReadFileChunk.
+            self.assertIsInstance(reader, ReadFileChunk)
+            # The content of the reader should be correct.
+            self.assertEqual(reader.read(), self.content)
+            # Callbacks should be disabled depspite being passed in.
+            self.assertEqual(self.amounts_seen, [])
+
     def test_open_file(self):
         fileobj = OSUtils().open(os.path.join(self.tempdir, 'foo'), 'w')
         self.assertTrue(hasattr(fileobj, 'write'))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -26,6 +26,7 @@ from s3transfer.utils import calculate_range_parameter
 from s3transfer.utils import CallArgs
 from s3transfer.utils import FunctionContainer
 from s3transfer.utils import OSUtils
+from s3transfer.utils import DeferredOpenFile
 from s3transfer.utils import ReadFileChunk
 from s3transfer.utils import StreamReaderProgress
 
@@ -179,6 +180,55 @@ class TestOSUtils(BaseUtilsTest):
         OSUtils().rename_file(self.filename, new_filename)
         self.assertFalse(os.path.exists(self.filename))
         self.assertTrue(os.path.exists(new_filename))
+
+
+class TestDefferedOpenFile(BaseUtilsTest):
+    def setUp(self):
+        super(TestDefferedOpenFile, self).setUp()
+        self.filename = os.path.join(self.tempdir, 'foo')
+        self.contents = b'my contents'
+        with open(self.filename, 'wb') as f:
+            f.write(self.contents)
+        self.deffered_open_file = DeferredOpenFile(self.filename)
+        self.open_called_count = 0
+        self.deffered_open_file.OPEN_METHOD = self.counting_open_method
+
+    def counting_open_method(self, filename, mode):
+        self.open_called_count += 1
+        return open(filename, mode)
+
+    def test_instantiation_does_not_open_file(self):
+        deffered_open_file = DeferredOpenFile(self.filename)
+        self.open_called_count = 0
+        deffered_open_file.OPEN_METHOD = self.counting_open_method
+        self.assertEqual(self.open_called_count, 0)
+
+    def test_read(self):
+        content = self.deffered_open_file.read(2)
+        self.assertEqual(content, self.contents[0:2])
+        content = self.deffered_open_file.read(2)
+        self.assertEqual(content, self.contents[2:4])
+        self.assertEqual(self.open_called_count, 1)
+
+    def test_seek(self):
+        self.deffered_open_file.seek(2)
+        content = self.deffered_open_file.read(2)
+        self.assertEqual(content, self.contents[2:4])
+        self.assertEqual(self.open_called_count, 1)
+
+    def test_tell(self):
+        self.deffered_open_file.tell()
+        # tell() should not have opened the file if it has not been seeked
+        # or read because we know the start bytes upfront.
+        self.assertEqual(self.open_called_count, 0)
+
+        self.deffered_open_file.seek(2)
+        self.assertEqual(self.deffered_open_file.tell(), 2)
+        self.assertEqual(self.open_called_count, 1)
+
+    def test_context_handler(self):
+        with self.deffered_open_file:
+            self.assertEqual(self.open_called_count, 1)
 
 
 class TestReadFileChunk(BaseUtilsTest):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -201,45 +201,45 @@ class TestDefferedOpenFile(BaseUtilsTest):
         self.contents = b'my contents'
         with open(self.filename, 'wb') as f:
             f.write(self.contents)
-        self.deffered_open_file = DeferredOpenFile(self.filename)
+        self.deferred_open_file = DeferredOpenFile(self.filename)
         self.open_called_count = 0
-        self.deffered_open_file.OPEN_METHOD = self.counting_open_method
+        self.deferred_open_file.OPEN_METHOD = self.counting_open_method
 
     def counting_open_method(self, filename, mode):
         self.open_called_count += 1
         return open(filename, mode)
 
     def test_instantiation_does_not_open_file(self):
-        deffered_open_file = DeferredOpenFile(self.filename)
+        deferred_open_file = DeferredOpenFile(self.filename)
         self.open_called_count = 0
-        deffered_open_file.OPEN_METHOD = self.counting_open_method
+        deferred_open_file.OPEN_METHOD = self.counting_open_method
         self.assertEqual(self.open_called_count, 0)
 
     def test_read(self):
-        content = self.deffered_open_file.read(2)
+        content = self.deferred_open_file.read(2)
         self.assertEqual(content, self.contents[0:2])
-        content = self.deffered_open_file.read(2)
+        content = self.deferred_open_file.read(2)
         self.assertEqual(content, self.contents[2:4])
         self.assertEqual(self.open_called_count, 1)
 
     def test_seek(self):
-        self.deffered_open_file.seek(2)
-        content = self.deffered_open_file.read(2)
+        self.deferred_open_file.seek(2)
+        content = self.deferred_open_file.read(2)
         self.assertEqual(content, self.contents[2:4])
         self.assertEqual(self.open_called_count, 1)
 
     def test_tell(self):
-        self.deffered_open_file.tell()
+        self.deferred_open_file.tell()
         # tell() should not have opened the file if it has not been seeked
         # or read because we know the start bytes upfront.
         self.assertEqual(self.open_called_count, 0)
 
-        self.deffered_open_file.seek(2)
-        self.assertEqual(self.deffered_open_file.tell(), 2)
+        self.deferred_open_file.seek(2)
+        self.assertEqual(self.deferred_open_file.tell(), 2)
         self.assertEqual(self.open_called_count, 1)
 
     def test_context_handler(self):
-        with self.deffered_open_file:
+        with self.deferred_open_file:
             self.assertEqual(self.open_called_count, 1)
 
 


### PR DESCRIPTION
First, this pull request is based off of this PR: https://github.com/boto/s3transfer/pull/13. So you probably would want to review that one first.

As to the changes made, in this PR they are as follows:
* Cleaned up functional tests for uploads. Mainly making them easier to read.
* Abstracted logic for different source inputs for uploads into different classes to make it much easier to add new strategies for consuming different sources of data.
* Add support for seekable files.

Note that right now there is no protection from having too many chunks in memory. I am looking to add this in a follow up pull request to make it less to review at a time.

cc @jamesls @JordonPhillips 