### PR TITLE
Fix issue in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -281,6 +281,10 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
     def test_returns_future_with_meta(self):
         self._setup_default_stubbed_responses()
         future = self.method(**self.create_call_kwargs())
+        # The result is called so we ensure that the entire process executes
+        # before we try to clean up resources in the tearDown.
+        future.result()
+
         # Assert the return value is a future with metadata associated to it.
         self.assertIsInstance(future, TransferFuture)
         self.assertIsInstance(future.meta, TransferMeta)
@@ -289,6 +293,10 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
         self._setup_default_stubbed_responses()
         call_kwargs = self.create_call_kwargs()
         future = self.method(**call_kwargs)
+        # The result is called so we ensure that the entire process executes
+        # before we try to clean up resources in the tearDown.
+        future.result()
+
         # Assert that there are call args associated to the metadata
         self.assertIsInstance(future.meta.call_args, CallArgs)
         # Assert that all of the arguments passed to the method exist and


### PR DESCRIPTION
The issue is that since we did not call result on the future, the process still
maybe going during the tearDown and as a result on systems like windows we
may be trying to remove the temporary file for downloads while the transfer
manager is still acting on it, which causes issues when two processes are
performing on the same file.

cc @jamesls @JordonPhillips 