### PR TITLE
Add ability to limit number of in-memory upload chunks

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -297,12 +297,12 @@ class BoundedExecutor(object):
         """
         self._max_num_threads = max_num_threads
         self._executor = self.EXECUTOR_CLS(max_workers=self._max_num_threads)
-        self._tags_to_track = ['all']
+        self._tags_to_track = [ALL_TAG]
         self._max_sizes = {
-            'all': max_size
+            ALL_TAG: max_size
         }
         self._currently_running_futures = {
-            'all': set()
+            ALL_TAG: set()
         }
         if tag_max_sizes:
             for tag, max_size in tag_max_sizes.items():
@@ -339,10 +339,10 @@ class BoundedExecutor(object):
     def _get_tags_to_operate_on(self, tag):
         # No matter the tag provided, each future is included under the 'all'
         # tag to represent its membership in the set of all running futures.
-        tag_to_operate_on = ['all']
+        tag_to_operate_on = [ALL_TAG]
         # Only add the tag to the set of the tags to operate on if the tag
         # is not equal to all and the tag is being tracked for max sizes.
-        if tag != 'all' and tag in self._tags_to_track:
+        if tag is not ALL_TAG and tag in self._tags_to_track:
             tag_to_operate_on.append(tag)
         return tag_to_operate_on
 
@@ -372,3 +372,12 @@ class BoundedExecutor(object):
             # track of how many futures are currently being ran.
             if self._max_sizes[tag] != 0:
                 self._currently_running_futures[tag].add(future)
+
+
+class FutureTag(object):
+    def __init__(self, name):
+        self.name = name
+
+
+ALL_TAG = FutureTag('all')
+IN_MEMORY_UPLOAD_TAG = FutureTag('in_memory_upload')

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from concurrent import futures
+from collections import namedtuple
 import copy
 import logging
 import threading
@@ -342,7 +343,7 @@ class BoundedExecutor(object):
         tag_to_operate_on = [ALL_TAG]
         # Only add the tag to the set of the tags to operate on if the tag
         # is not equal to all and the tag is being tracked for max sizes.
-        if tag is not ALL_TAG and tag in self._tags_to_track:
+        if tag != ALL_TAG and tag in self._tags_to_track:
             tag_to_operate_on.append(tag)
         return tag_to_operate_on
 
@@ -374,10 +375,7 @@ class BoundedExecutor(object):
                 self._currently_running_futures[tag].add(future)
 
 
-class FutureTag(object):
-    def __init__(self, name):
-        self.name = name
-
+FutureTag = namedtuple('FutureTag', ['name'])
 
 ALL_TAG = FutureTag('all')
 IN_MEMORY_UPLOAD_TAG = FutureTag('in_memory_upload')

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -272,7 +272,7 @@ class TransferCoordinator(object):
 class BoundedExecutor(object):
     EXECUTOR_CLS = futures.ThreadPoolExecutor
 
-    def __init__(self, max_size, max_num_threads):
+    def __init__(self, max_size, max_num_threads, tag_max_sizes=None):
         """An executor implentation that has a maximum queued up tasks
 
         The executor will block if the number of tasks that have been
@@ -285,11 +285,30 @@ class BoundedExecutor(object):
 
         :params max_num_threads: The maximum number of threads the executor
             uses.
+
+        :type tag_max_sizes: dict
+        :params tag_max_sizes: A dictionary where the key is the name of the
+            tag and the value is the number of inflight futures can be running
+            with that tag value. For example, a value of  ``{'my_tag': 3}``
+            will ensure that where will be at most three inflight futures
+            tagged with the value ``'my_tag'``. Note that no matter if a future
+            is tagged, the future will be accounted against the executor's
+            ``max_size`` param.
         """
-        self._max_size = max_size
         self._max_num_threads = max_num_threads
         self._executor = self.EXECUTOR_CLS(max_workers=self._max_num_threads)
-        self._currently_running_futures = set()
+        self._tags_to_track = ['all']
+        self._max_sizes = {
+            'all': max_size
+        }
+        self._currently_running_futures = {
+            'all': set()
+        }
+        if tag_max_sizes:
+            for tag, max_size in tag_max_sizes.items():
+                self._tags_to_track.append(tag)
+                self._max_sizes[tag] = max_size
+                self._currently_running_futures[tag] = set()
         self._lock = threading.Lock()
 
     def submit(self, fn, *args, **kwargs):
@@ -297,32 +316,59 @@ class BoundedExecutor(object):
 
         :param fn: The function to call
         :param args: The positional arguments to use to call the function
-        :param kwargs: The keyword arguments to use to call the function
+        :param kwargs: The keyword arguments to use to call the function. You
+            can provide a tag for the submittion by providing the keyword arg
+            ``'future_tag'``.
 
         :returns: The future assocaited to the submitted task
         """
+        tag = kwargs.pop('future_tag', None)
+
         with self._lock:
-            # First determine if there are already too many futures running
-            if self._at_maximum_running_futures():
-                # If there are too many futures running, wait till some
-                # complete and save the remaining running futures as the
-                # next set to wait for.
-                self._currently_running_futures = futures.wait(
-                    self._currently_running_futures,
-                    return_when=futures.FIRST_COMPLETED
-                ).not_done
+            # Wait if there is a maximum reached
+            self._wait_for_futures_to_complete_if_needed(tag)
             # Submit the task to the executor
             future = self._executor.submit(fn, *args, **kwargs)
-            # If the queue is bounded then add the new submitted task
-            # to the list of futures to wait for. If it is not bounded,
-            # then we do not need to store the future as we are not keeping
-            # track of how many futures are currently being ran.
-            if self._max_size is not None:
-                self._currently_running_futures.add(future)
+            # Add the recently added future to the currently running futures
+            self._add_future_to_currently_running(future, tag)
         return future
 
     def shutdown(self, wait=True):
         self._executor.shutdown(wait)
 
-    def _at_maximum_running_futures(self):
-        return len(self._currently_running_futures) == self._max_size
+    def _get_tags_to_operate_on(self, tag):
+        # No matter the tag provided, each future is included under the 'all'
+        # tag to represent its membership in the set of all running futures.
+        tag_to_operate_on = ['all']
+        # Only add the tag to the set of the tags to operate on if the tag
+        # is not equal to all and the tag is being tracked for max sizes.
+        if tag != 'all' and tag in self._tags_to_track:
+            tag_to_operate_on.append(tag)
+        return tag_to_operate_on
+
+    def _at_maximum_running_futures(self, tag):
+        return len(self._currently_running_futures[tag]) == \
+            self._max_sizes[tag]
+
+    def _wait_for_futures_to_complete_if_needed(self, tag):
+        tags_to_wait_on = self._get_tags_to_operate_on(tag)
+        for tag in tags_to_wait_on:
+            # First determine if there are already too many futures running
+            if self._at_maximum_running_futures(tag):
+                # If there are too many futures running, wait till some
+                # complete and save the remaining running futures as the
+                # next set to wait for.
+                self._currently_running_futures[tag] = futures.wait(
+                        self._currently_running_futures[tag],
+                        return_when=futures.FIRST_COMPLETED
+                ).not_done
+
+    def _add_future_to_currently_running(self, future, tag):
+        tags_to_add_future_to = self._get_tags_to_operate_on(tag)
+        for tag in tags_to_add_future_to:
+            # If the queue is bounded then add the new submitted task
+            # to the list of futures to wait for. If it is not bounded,
+            # then we do not need to store the future as we are not keeping
+            # track of how many futures are currently being ran.
+            if self._max_sizes[tag] != 0:
+                self._currently_running_futures[tag].add(future)

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -16,6 +16,7 @@ from s3transfer.utils import disable_upload_callbacks
 from s3transfer.utils import enable_upload_callbacks
 from s3transfer.utils import CallArgs
 from s3transfer.utils import OSUtils
+from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.futures import BoundedExecutor
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import TransferMeta
@@ -161,7 +162,7 @@ class TransferManager(object):
             max_size=self._config.max_request_queue_size,
             max_num_threads=self._config.max_request_concurrency,
             tag_max_sizes={
-                'in_memory_upload': self._config.max_in_memory_upload_chunks
+                IN_MEMORY_UPLOAD_TAG: self._config.max_in_memory_upload_chunks
             }
         )
 

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -83,14 +83,20 @@ class TransferConfig(object):
             number of exceptions retried by botocore.
 
         :param max_in_memory_upload_chunks: The number of chunks that can
-            be stored in memory at a time for all ongoing uploads. This
-            pertains to chunks of data that need to be stored in memory
+            be stored in memory at a time for all ongoing upload requests.
+            This pertains to chunks of data that need to be stored in memory
             during an upload if the data is sourced from a file-like object.
-            The total expected memory footprint due to in-memory upload
+            The total maximum memory footprint due to a in-memory upload
             chunks is roughly equal to:
 
                 max_in_memory_upload_chunks * multipart_chunksize
+                + max_submission_concurrency * multipart_chunksize
 
+            ``max_submission_concurrency`` has an affect on this value because
+            for each thread pulling data off of a file-like object, they may
+            be waiting with a single read chunk to be submitted for upload
+            because the ``max_in_memory_upload_chunks`` value has been reached
+            by the threads making the upload request.
         """
         self.multipart_threshold = multipart_threshold
         self.multipart_chunksize = multipart_chunksize

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -196,12 +196,12 @@ class Task(object):
             kwargs[key] = result
         return kwargs
 
-    def _submit_task(self, executor, task):
+    def _submit_task(self, executor, task, future_tag=None):
         logger.debug(
             "Submitting task %s to executor %s from task %s." % (
                 task, executor, self)
         )
-        future = executor.submit(task)
+        future = executor.submit(task, future_tag=future_tag)
         # Add this created future to the list of associated future just
         # in case it is needed during cleanups.
         self._transfer_coordinator.add_associated_future(future)

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -14,6 +14,7 @@ import math
 
 from botocore.compat import six
 
+from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.tasks import Task
 from s3transfer.tasks import SubmissionTask
 from s3transfer.tasks import CreateMultipartUploadTask
@@ -407,7 +408,7 @@ class UploadSubmissionTask(SubmissionTask):
     def _get_upload_future_tag(self, upload_input_manager, operation_name):
         future_tag = None
         if upload_input_manager.stores_body_in_memory(operation_name):
-            future_tag = 'in_memory_upload'
+            future_tag = IN_MEMORY_UPLOAD_TAG
         return future_tag
 
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -19,6 +19,7 @@ from tests import RecordingSubscriber
 from tests import BaseTaskTest
 from tests import BaseSubmissionTaskTest
 from s3transfer.futures import TransferCoordinator
+from s3transfer.futures import BoundedExecutor
 from s3transfer.tasks import Task
 from s3transfer.tasks import SubmissionTask
 from s3transfer.tasks import CreateMultipartUploadTask
@@ -80,7 +81,7 @@ class ExceptionSubmissionTask(SubmissionTask):
 class TestSubmissionTask(BaseSubmissionTaskTest):
     def setUp(self):
         super(TestSubmissionTask, self).setUp()
-        self.executor = futures.ThreadPoolExecutor(5)
+        self.executor = BoundedExecutor(0, 5)
         self.call_args = CallArgs(subscribers=[])
         self.transfer_future = self.get_transfer_future(self.call_args)
         self.main_kwargs = {'transfer_future': self.transfer_future}

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -21,6 +21,7 @@ from tests import BaseSubmissionTaskTest
 from tests import FileSizeProvider
 from tests import RecordingSubscriber
 from tests import RecordingExecutor
+from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.manager import TransferConfig
 from s3transfer.upload import UploadFilenameInputManager
 from s3transfer.upload import UploadSeekableInputManager
@@ -183,7 +184,7 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
     def tearDown(self):
         self.fileobj.close()
         super(TestUploadSeekableInputManager, self).tearDown()
-    
+
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertTrue(
             self.upload_input_manager.stores_body_in_memory('upload_part'))
@@ -368,7 +369,7 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         # Make sure tags to limit all of the upload part tasks were
         # were associated when submitted to the executor as these tasks will
         # have chunks of data stored with them in memory.
-        self.assert_tag_value_for_upload_parts('in_memory_upload')
+        self.assert_tag_value_for_upload_parts(IN_MEMORY_UPLOAD_TAG)
 
 
 class TestPutObjectTask(BaseUploadTest):

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -20,6 +20,7 @@ from tests import BaseTaskTest
 from tests import BaseSubmissionTaskTest
 from tests import FileSizeProvider
 from tests import RecordingSubscriber
+from tests import RecordingExecutor
 from s3transfer.manager import TransferConfig
 from s3transfer.upload import UploadFilenameInputManager
 from s3transfer.upload import UploadSeekableInputManager
@@ -100,6 +101,14 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
                 self.future.meta.call_args.fileobj)
         )
 
+    def test_stores_bodies_in_memory_put_object(self):
+        self.assertFalse(
+            self.upload_input_manager.stores_body_in_memory('put_object'))
+
+    def test_stores_bodies_in_memory_upload_part(self):
+        self.assertFalse(
+            self.upload_input_manager.stores_body_in_memory('upload_part'))
+
     def test_provide_transfer_size(self):
         self.upload_input_manager.provide_transfer_size(self.future)
         # The provided file size should be equal to size of the contents of
@@ -174,6 +183,10 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
     def tearDown(self):
         self.fileobj.close()
         super(TestUploadSeekableInputManager, self).tearDown()
+    
+    def test_stores_bodies_in_memory_upload_part(self):
+        self.assertTrue(
+            self.upload_input_manager.stores_body_in_memory('upload_part'))
 
 
 class TestUploadSubmissionTask(BaseSubmissionTaskTest):
@@ -226,6 +239,46 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         default_call_args.update(kwargs)
         return CallArgs(**default_call_args)
 
+    def add_multipart_upload_stubbed_responses(self):
+        self.stubber.add_response(
+            method='create_multipart_upload',
+            service_response={'UploadId': 'my-id'}
+        )
+        self.stubber.add_response(
+            method='upload_part',
+            service_response={'ETag': 'etag-1'}
+        )
+        self.stubber.add_response(
+            method='upload_part',
+            service_response={'ETag': 'etag-2'}
+        )
+        self.stubber.add_response(
+            method='upload_part',
+            service_response={'ETag': 'etag-3'}
+        )
+        self.stubber.add_response(
+            method='complete_multipart_upload',
+            service_response={}
+        )
+
+    def wrap_executor_in_recorder(self):
+        self.executor = RecordingExecutor(self.executor)
+        self.submission_main_kwargs['request_executor'] = self.executor
+
+    def use_fileobj_in_call_args(self, fileobj):
+        self.call_args = self.get_call_args(fileobj=fileobj)
+        self.transfer_future = self.get_transfer_future(self.call_args)
+        self.submission_main_kwargs['transfer_future'] = self.transfer_future
+
+    def assert_tag_value_for_put_object(self, tag_value):
+        self.assertEqual(
+            self.executor.submissions[0]['kwargs']['future_tag'], tag_value)
+
+    def assert_tag_value_for_upload_parts(self, tag_value):
+        for submission in self.executor.submissions[1:-1]:
+            self.assertEqual(
+                submission['kwargs']['future_tag'], tag_value)
+
     def test_provide_file_size_on_put(self):
         self.call_args.subscribers.append(FileSizeProvider(len(self.content)))
         self.stubber.add_response(
@@ -247,6 +300,75 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.transfer_future.result()
         self.stubber.assert_no_pending_responses()
         self.assertEqual(self.sent_bodies, [self.content])
+
+    def test_submits_no_tag_for_put_object_filename(self):
+        self.wrap_executor_in_recorder()
+        self.stubber.add_response('put_object', {})
+
+        self.submission_task = self.get_task(
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+        self.submission_task()
+        self.transfer_future.result()
+        self.stubber.assert_no_pending_responses()
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_value_for_put_object(None)
+
+    def test_submits_no_tag_for_multipart_filename(self):
+        self.wrap_executor_in_recorder()
+
+        # Set up for a multipart upload.
+        self.add_multipart_upload_stubbed_responses()
+        self.config.multipart_threshold = 1
+        self.config.multipart_chunksize = 4
+
+        self.submission_task = self.get_task(
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+        self.submission_task()
+        self.transfer_future.result()
+        self.stubber.assert_no_pending_responses()
+
+        # Make sure no tag to limit any of the upload part tasks were
+        # were associated when submitted to the executor
+        self.assert_tag_value_for_upload_parts(None)
+
+    def test_submits_no_tag_for_put_object_fileobj(self):
+        self.wrap_executor_in_recorder()
+        self.stubber.add_response('put_object', {})
+
+        with open(self.filename, 'rb') as f:
+            self.use_fileobj_in_call_args(f)
+            self.submission_task = self.get_task(
+                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            self.submission_task()
+            self.transfer_future.result()
+            self.stubber.assert_no_pending_responses()
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_value_for_put_object(None)
+
+    def test_submits_tag_for_multipart_fileobj(self):
+        self.wrap_executor_in_recorder()
+
+        # Set up for a multipart upload.
+        self.add_multipart_upload_stubbed_responses()
+        self.config.multipart_threshold = 1
+        self.config.multipart_chunksize = 4
+
+        with open(self.filename, 'rb') as f:
+            self.use_fileobj_in_call_args(f)
+            self.submission_task = self.get_task(
+                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            self.submission_task()
+            self.transfer_future.result()
+            self.stubber.assert_no_pending_responses()
+
+        # Make sure tags to limit all of the upload part tasks were
+        # were associated when submitted to the executor as these tasks will
+        # have chunks of data stored with them in memory.
+        self.assert_tag_value_for_upload_parts('in_memory_upload')
 
 
 class TestPutObjectTask(BaseUploadTest):


### PR DESCRIPTION
This is currently helpful for multipart seekable files where we have to store
the data into memory. This will allow users to limit the number of these
partitioned chunks of data can be in memory at a time. This will also be needed
for nonseekable uploads and possibly nonseekable downloads.

cc @jamesls @JordonPhillips 
