### PR TITLE
Add support for downloading to seekable files

### DIFF
--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -50,3 +50,27 @@ else:
         return inspect.getargspec(func)[2]
 
     SOCKET_ERROR = socket.error
+
+
+def seekable(fileobj):
+    """Backwards compat function to determine if a fileobj is seekable
+
+    :param fileobj: The file-like object to determine if seekable
+
+    :returns: True, if seekable. False, otherwise.
+    """
+    try:
+        # If the fileobj has a seekable attr, try calling the seekable()
+        # method on it.
+        if hasattr(fileobj, 'seekable'):
+            return fileobj.seekable()
+        # If there is no seekable attr, check if the object can be seeked
+        # or telled. If it can, try to seek to the current position.
+        elif hasattr(fileobj, 'seek') and hasattr(fileobj, 'tell'):
+            fileobj.seek(0, 1)
+            return True
+        # Else, the fileobj is not seekable
+        return False
+    except (OSError, IOError):
+        # If an io related error was thrown as well then it is not seekable.
+        return False

--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -59,18 +59,18 @@ def seekable(fileobj):
 
     :returns: True, if seekable. False, otherwise.
     """
-    try:
-        # If the fileobj has a seekable attr, try calling the seekable()
-        # method on it.
-        if hasattr(fileobj, 'seekable'):
-            return fileobj.seekable()
-        # If there is no seekable attr, check if the object can be seeked
-        # or telled. If it can, try to seek to the current position.
-        elif hasattr(fileobj, 'seek') and hasattr(fileobj, 'tell'):
+    # If the fileobj has a seekable attr, try calling the seekable()
+    # method on it.
+    if hasattr(fileobj, 'seekable'):
+        return fileobj.seekable()
+    # If there is no seekable attr, check if the object can be seeked
+    # or telled. If it can, try to seek to the current position.
+    elif hasattr(fileobj, 'seek') and hasattr(fileobj, 'tell'):
+        try:
             fileobj.seek(0, 1)
             return True
-        # Else, the fileobj is not seekable
-        return False
-    except (OSError, IOError):
-        # If an io related error was thrown as well then it is not seekable.
-        return False
+        except (OSError, IOError):
+            # If an io related error was thrown then it is not seekable.
+            return False
+    # Else, the fileobj is not seekable
+    return False

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -21,6 +21,7 @@ from botocore.vendored.requests.packages.urllib3.exceptions import \
     ReadTimeoutError
 
 from s3transfer.compat import SOCKET_ERROR
+from s3transfer.compat import seekable
 from s3transfer.exceptions import RetriesExceededError
 from s3transfer.utils import random_file_extension
 from s3transfer.utils import get_callbacks
@@ -134,10 +135,7 @@ class DownloadFilenameOutputManager(DownloadOutputManager):
 class DownloadSeekableOutputManager(DownloadOutputManager):
     @classmethod
     def is_compatible(self, download_target):
-        return (
-            hasattr(download_target, 'seek') and
-            hasattr(download_target, 'tell')
-        )
+        return seekable(download_target)
 
     def get_fileobj_for_io_writes(self, transfer_future):
         # Return the fileobj provided to the future.

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -15,6 +15,7 @@ import os
 import socket
 import math
 
+from botocore.compat import six
 from botocore.exceptions import IncompleteReadError
 from botocore.vendored.requests.packages.urllib3.exceptions import \
     ReadTimeoutError
@@ -38,8 +39,122 @@ S3_RETRYABLE_ERRORS = (
 )
 
 
+class DownloadOutputManager(object):
+    """Base manager class for handling various types of files for downloads
+
+    This class is typically used for the DownloadSubmissionTask class to help
+    determine the following:
+
+        * Provides the fileobj to write to downloads to
+        * Get a task to complete once everything downloaded has been written
+
+    The answers/implementations differ for the various types of file outputs
+    that may be accepted. All implementations must subclass and override
+    public methods from this class.
+    """
+    def __init__(self, osutil, transfer_coordinator):
+        self._osutil = osutil
+        self._transfer_coordinator = transfer_coordinator
+
+    @classmethod
+    def is_compatible(self, download_target):
+        """Determines if the target for the download is compatible with manager
+
+        :param download_target: The target for which the upload will write
+            data to.
+
+        :returns: True if the manager can handle the type of target specified
+            otherwise returns False.
+        """
+        raise NotImplementedError('must implement is_compatible()')
+
+    def get_fileobj_for_io_writes(self, transfer_future):
+        """Get file-like object to use for io writes in the io executor
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The future associated with upload request
+
+        returns: A file-like object to write to
+        """
+        raise NotImplementedError('must implement get_fileobj_for_io_writes()')
+
+    def get_final_io_task(self):
+        """Get the final io task to complete the download
+
+        :rtype: s3transfer.tasks.Task
+        :returns: A final task to completed in the io executor
+        """
+        raise NotImplementedError(
+            'must implement get_final_io_task()')
+
+
+class DownloadFilenameOutputManager(DownloadOutputManager):
+    def __init__(self, osutil, transfer_coordinator):
+        super(DownloadFilenameOutputManager, self).__init__(
+            osutil, transfer_coordinator)
+        self._final_filename = None
+        self._temp_filename = None
+        self._temp_fileobj = None
+
+    @classmethod
+    def is_compatible(self, download_target):
+        return isinstance(download_target, six.string_types)
+
+    def get_fileobj_for_io_writes(self, transfer_future):
+        fileobj = transfer_future.meta.call_args.fileobj
+        self._final_filename = fileobj
+        self._temp_filename = fileobj + os.extsep + random_file_extension()
+        self._temp_fileobj = self._get_temp_fileobj()
+        return self._temp_fileobj
+
+    def get_final_io_task(self):
+        # A task to rename the file from the temporary file to its final
+        # location is needed. This should be the last task needed to complete
+        # the download.
+        return IORenameFileTask(
+            transfer_coordinator=self._transfer_coordinator,
+            main_kwargs={
+                'fileobj': self._temp_fileobj,
+                'final_filename': self._final_filename,
+                'osutil': self._osutil
+            },
+            is_final=True
+        )
+
+    def _get_temp_fileobj(self):
+        f = self._osutil.open(self._temp_filename, 'wb')
+        # Make sure the file gets closed and we remove the temporary file
+        # if anything goes wrong during the process.
+        self._transfer_coordinator.add_failure_cleanup(f.close)
+        self._transfer_coordinator.add_failure_cleanup(
+            self._osutil.remove_file, self._temp_filename)
+        return f
+
+
 class DownloadSubmissionTask(SubmissionTask):
     """Task for submitting tasks to execute a download"""
+
+    def _get_download_output_manager_cls(self, transfer_future):
+        """Retieves a class for managing output for a download
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The transfer future for the request
+
+        :rtype: class of DownloadOutputManager
+        :returns: The appropriate class to use for managing a specific type of
+            input for downloads.
+        """
+        download_manager_resolver_chain = [
+            DownloadFilenameOutputManager,
+        ]
+
+        fileobj = transfer_future.meta.call_args.fileobj
+        for download_manager_cls in download_manager_resolver_chain:
+            if download_manager_cls.is_compatible(fileobj):
+                return download_manager_cls
+        raise RuntimeError(
+            'Output %s of type: %s is not supported.' % (
+                fileobj, type(fileobj)))
 
     def _submit(self, client, config, osutil, request_executor, io_executor,
                 transfer_future):
@@ -76,38 +191,32 @@ class DownloadSubmissionTask(SubmissionTask):
             transfer_future.meta.provide_transfer_size(
                 response['ContentLength'])
 
-        # Figure out a temporary filename for the file.
-        temp_filename = (
-            transfer_future.meta.call_args.fileobj + os.extsep +
-            random_file_extension()
-        )
+        download_output_manager = self._get_download_output_manager_cls(
+            transfer_future)(osutil, self._transfer_coordinator)
+
         # If it is greater than threshold do a ranged download, otherwise
         # do a regular GetObject download.
         if transfer_future.meta.size < config.multipart_threshold:
             self._submit_download_request(
                 client, config, osutil, request_executor, io_executor,
-                temp_filename, transfer_future)
+                download_output_manager, transfer_future)
         else:
             self._submit_ranged_download_request(
                 client, config, osutil, request_executor, io_executor,
-                temp_filename, transfer_future)
+                download_output_manager, transfer_future)
 
     def _submit_download_request(self, client, config, osutil,
-                                 request_executor, io_executor, temp_filename,
-                                 transfer_future):
+                                 request_executor, io_executor,
+                                 download_output_manager, transfer_future):
         call_args = transfer_future.meta.call_args
 
-        # Get a handle to the temp file
-        temp_fileobj = self._get_io_file_handle(temp_filename, osutil)
+        # Get a handle to the file that will be used for writing downloaded
+        # contents
+        fileobj = download_output_manager.get_fileobj_for_io_writes(
+            transfer_future)
 
         # Get the needed callbacks for the task
         progress_callbacks = get_callbacks(transfer_future, 'progress')
-
-        # Before starting any tasks for downloads set up a cleanup function
-        # that will make sure that the temporary file always gets
-        # cleaned up.
-        self._transfer_coordinator.add_failure_cleanup(
-            osutil.remove_file, temp_filename)
 
         # Submit the task to download the object.
         download_future = self._submit_task(
@@ -118,7 +227,7 @@ class DownloadSubmissionTask(SubmissionTask):
                     'client': client,
                     'bucket': call_args.bucket,
                     'key': call_args.key,
-                    'fileobj': temp_fileobj,
+                    'fileobj': fileobj,
                     'extra_args': call_args.extra_args,
                     'callbacks': progress_callbacks,
                     'max_attempts': config.num_download_attempts,
@@ -129,30 +238,27 @@ class DownloadSubmissionTask(SubmissionTask):
 
         # Send the necessary tasks to complete the download.
         self._complete_download(
-            osutil, request_executor, io_executor, temp_fileobj,
-            call_args.fileobj, [download_future])
+            request_executor, io_executor, download_output_manager,
+            [download_future])
 
     def _submit_ranged_download_request(self, client, config, osutil,
                                         request_executor, io_executor,
-                                        temp_filename, transfer_future):
+                                        download_output_manager,
+                                        transfer_future):
         call_args = transfer_future.meta.call_args
 
         # Get the needed progress callbacks for the task
         progress_callbacks = get_callbacks(transfer_future, 'progress')
 
-        # Get a handle to the temp file
-        temp_fileobj = self._get_io_file_handle(temp_filename, osutil)
+        # Get a handle to the file that will be used for writing downloaded
+        # contents
+        fileobj = download_output_manager.get_fileobj_for_io_writes(
+            transfer_future)
 
         # Determine the number of parts
         part_size = config.multipart_chunksize
         num_parts = int(
             math.ceil(transfer_future.meta.size / float(part_size)))
-
-        # Before starting any tasks for downloads set up a cleanup function
-        # that will make sure that the temporary file always gets
-        # cleaned up.
-        self._transfer_coordinator.add_failure_cleanup(
-            osutil.remove_file, temp_filename)
 
         ranged_downloads = []
         for i in range(num_parts):
@@ -174,7 +280,7 @@ class DownloadSubmissionTask(SubmissionTask):
                             'client': client,
                             'bucket': call_args.bucket,
                             'key': call_args.key,
-                            'fileobj': temp_fileobj,
+                            'fileobj': fileobj,
                             'extra_args': extra_args,
                             'callbacks': progress_callbacks,
                             'max_attempts': config.num_download_attempts,
@@ -186,34 +292,22 @@ class DownloadSubmissionTask(SubmissionTask):
             )
         # Send the necessary tasks to complete the download.
         self._complete_download(
-            osutil, request_executor, io_executor, temp_fileobj,
-            call_args.fileobj, ranged_downloads)
+            request_executor, io_executor, download_output_manager,
+            ranged_downloads)
 
-    def _get_io_file_handle(self, filename, osutil):
-        f = osutil.open(filename, 'wb')
-        self._transfer_coordinator.add_failure_cleanup(f.close)
-        return f
+    def _complete_download(self, request_executor, io_executor,
+                           download_output_manager, download_futures):
 
-    def _complete_download(self, osutil, request_executor, io_executor,
-                           fileobj, final_filename, download_futures):
-        # A task to rename the file from the temporary file to its final
-        # location. This should be the last task needed to complete the
-        # download.
-        rename_task = IORenameFileTask(
-            transfer_coordinator=self._transfer_coordinator,
-            main_kwargs={
-                'fileobj': fileobj,
-                'final_filename': final_filename,
-                'osutil': osutil
-            },
-            is_final=True
-        )
-        submit_rename_task = FunctionContainer(
-            self._submit_task, io_executor, rename_task)
+        # Get the final io task that will be placed into the io queue once
+        # all of the other GetObjectTasks have completed.
+        final_task = download_output_manager.get_final_io_task()
+        submit_final_task = FunctionContainer(
+            self._submit_task, io_executor, final_task)
 
         # Submit a task to wait for all of the downloads to complete
         # and submit their downloaded content to the io executor before
-        # submitting the renaming task to the io executor.
+        # submitting the final task to the io executor that ensures that all
+        # of the io tasks have been completed.
         self._submit_task(
             request_executor,
             JoinFuturesTask(
@@ -221,7 +315,7 @@ class DownloadSubmissionTask(SubmissionTask):
                 pending_main_kwargs={
                     'futures_to_wait_on': download_futures
                 },
-                done_callbacks=[submit_rename_task]
+                done_callbacks=[submit_final_task]
             )
         )
 

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -14,6 +14,7 @@ import math
 
 from botocore.compat import six
 
+from s3transfer.compat import seekable
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.tasks import Task
 from s3transfer.tasks import SubmissionTask
@@ -187,9 +188,7 @@ class UploadSeekableInputManager(UploadFilenameInputManager):
     """Upload utility for am open file object"""
     @classmethod
     def is_compatible(cls, upload_source):
-        return (
-            hasattr(upload_source, 'seek') and hasattr(upload_source, 'tell')
-        )
+        return seekable(upload_source)
 
     def stores_body_in_memory(self, operation_name):
         if operation_name == 'put_object':

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -145,6 +145,19 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         possible_matches = glob.glob('%s*' % self.filename + os.extsep)
         self.assertEqual(possible_matches, [])
 
+    def test_download_for_fileobj(self):
+        self.add_head_object_response()
+        self.add_successful_get_object_responses()
+
+        with open(self.filename, 'wb') as f:
+            future = self.manager.download(
+                self.bucket, self.key, f, self.extra_args)
+            future.result()
+
+        # Ensure that the contents are correct
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(self.content, f.read())
+
     def test_download_cleanup_on_failure(self):
         self.add_head_object_response()
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -158,6 +158,22 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         with open(self.filename, 'rb') as f:
             self.assertEqual(self.content, f.read())
 
+    def test_download_for_seekable_filelike_obj(self):
+        self.add_head_object_response()
+        self.add_successful_get_object_responses()
+
+        # Create a file-like object to test. In this case, it is a BytesIO
+        # object.
+        bytes_io = six.BytesIO()
+
+        future = self.manager.download(
+            self.bucket, self.key, bytes_io, self.extra_args)
+        future.result()
+
+        # Ensure that the contents are correct
+        bytes_io.seek(0)
+        self.assertEqual(self.content, bytes_io.read())
+
     def test_download_cleanup_on_failure(self):
         self.add_head_object_response()
 

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -21,6 +21,7 @@ from botocore.stub import ANY
 
 from tests import BaseGeneralInterfaceTest
 from tests import RecordingSubscriber
+from s3transfer.compat import six
 from s3transfer.manager import TransferManager
 from s3transfer.manager import TransferConfig
 
@@ -140,6 +141,15 @@ class TestNonMultipartUpload(BaseUploadTest):
             future = self.manager.upload(
                 f, self.bucket, self.key, self.extra_args)
             future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_put_object_body_was_correct()
+
+    def test_upload_for_seekable_filelike_obj(self):
+        self.add_put_object_response_with_default_expected_params()
+        bytes_io = six.BytesIO(self.content)
+        future = self.manager.upload(
+            bytes_io, self.bucket, self.key, self.extra_args)
+        future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
 
@@ -272,6 +282,17 @@ class TestMultipartUpload(BaseUploadTest):
             future = self.manager.upload(
                 f, self.bucket, self.key, self.extra_args)
             future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_upload_part_bodies_were_correct()
+
+    def test_upload_for_seekable_filelike_obj(self):
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params()
+        bytes_io = six.BytesIO(self.content)
+        future = self.manager.upload(
+            bytes_io, self.bucket, self.key, self.extra_args)
+        future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_upload_part_bodies_were_correct()
 

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -67,3 +67,31 @@ class TestDownload(BaseTransferManagerIntegTest):
             subscribers=[subscriber])
         future.result()
         self.assertEqual(subscriber.calculate_bytes_seen(), 20 * 1024 * 1024)
+
+    def test_below_threshold_for_fileobj(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        self.upload_file(filename, '1mb.txt')
+
+        download_path = os.path.join(self.files.rootdir, '1mb.txt')
+        with open(download_path, 'wb') as f:
+            future = transfer_manager.download(
+                self.bucket_name, '1mb.txt', f)
+            future.result()
+        assert_files_equal(filename, download_path)
+
+    def test_above_threshold_for_fileobj(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=20 * 1024 * 1024)
+        self.upload_file(filename, '20mb.txt')
+
+        download_path = os.path.join(self.files.rootdir, '20mb.txt')
+        with open(download_path, 'wb') as f:
+            future = transfer_manager.download(
+                self.bucket_name, '20mb.txt', f)
+            future.result()
+        assert_files_equal(filename, download_path)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,0 +1,62 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import tempfile
+import shutil
+
+from tests import unittest
+from s3transfer.compat import seekable
+
+
+class ErrorRaisingSeekWrapper(object):
+    """An object wrapper that throws an error when seeked on
+
+    :param fileobj: The fileobj that it wraps
+    :param execption: The exception to raise when seeked on.
+    """
+    def __init__(self, fileobj, exception):
+        self._fileobj = fileobj
+        self._exception = exception
+
+    def seek(self, offset, whence=0):
+        raise self._exception
+
+    def tell(self):
+        return self._fileobj.tell()
+
+
+class TestSeekable(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'foo')
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_seekable_fileobj(self):
+        with open(self.filename, 'w') as f:
+            self.assertTrue(seekable(f))
+
+    def test_non_file_like_obj(self):
+        # Fails becase there is no seekable(), seek(), nor tell()
+        self.assertFalse(seekable(object()))
+
+    def test_non_seekable_ioerror(self):
+        # Should return False if IOError is thrown.
+        with open(self.filename, 'w') as f:
+            self.assertFalse(seekable(ErrorRaisingSeekWrapper(f, IOError())))
+
+    def test_non_seekable_oserror(self):
+        # Should return False if OSError is thrown.
+        with open(self.filename, 'w') as f:
+            self.assertFalse(seekable(ErrorRaisingSeekWrapper(f, OSError())))

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 import copy
 import os
+import shutil
+import tempfile
 
 from tests import BaseTaskTest
 from tests import StreamWithError
@@ -19,11 +21,13 @@ from tests import FileCreator
 from s3transfer.compat import six
 from s3transfer.compat import SOCKET_ERROR
 from s3transfer.exceptions import RetriesExceededError
+from s3transfer.download import DownloadFilenameOutputManager
 from s3transfer.download import GetObjectTask
 from s3transfer.download import IOWriteTask
 from s3transfer.download import IORenameFileTask
 from s3transfer.futures import BoundedExecutor
 from s3transfer.utils import OSUtils
+from s3transfer.utils import CallArgs
 
 
 class DownloadException(Exception):
@@ -63,6 +67,58 @@ class CancelledStreamWrapper(object):
             self._transfer_coordinator.cancel()
         self._stream.read(*args, **kwargs)
         self._count += 1
+
+
+class TestDownloadFilenameOutputManager(BaseTaskTest):
+    def setUp(self):
+        super(TestDownloadFilenameOutputManager, self).setUp()
+        self.osutil = OSUtils()
+        self.download_output_manager = DownloadFilenameOutputManager(
+            self.osutil, self.transfer_coordinator)
+
+        # Create a file to write to
+        self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'myfile')
+
+        self.call_args = CallArgs(fileobj=self.filename)
+        self.future = self.get_transfer_future(self.call_args)
+
+    def tearDown(self):
+        super(TestDownloadFilenameOutputManager, self).tearDown()
+        shutil.rmtree(self.tempdir)
+
+    def test_is_compatible(self):
+        self.assertTrue(
+            self.download_output_manager.is_compatible(self.filename))
+
+    def test_get_fileobj_for_io_writes(self):
+        with self.download_output_manager.get_fileobj_for_io_writes(
+                self.future) as f:
+            # Ensure it is a file like object returned
+            self.assertTrue(hasattr(f, 'read'))
+            self.assertTrue(hasattr(f, 'seek'))
+            # Make sure the name of the file returned is not the same as the
+            # final filename as we should be writing to a temporary file.
+            self.assertNotEqual(f.name, self.filename)
+
+    def test_get_final_io_task(self):
+        ref_contents = b'my_contents'
+        with self.download_output_manager.get_fileobj_for_io_writes(
+                self.future) as f:
+            temp_filename = f.name
+            # Write some data to test that the data gets moved over to the
+            # final location.
+            f.write(ref_contents)
+            final_task = self.download_output_manager.get_final_io_task()
+            # Make sure it is the appropriate task.
+            self.assertIsInstance(final_task, IORenameFileTask)
+            final_task()
+            # Make sure the temp_file gets removed
+            self.assertFalse(os.path.exists(temp_filename))
+        # Make sure what ever was written to the temp file got moved to
+        # the final filename
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(f.read(), ref_contents)
 
 
 class TestGetObjectTask(BaseTaskTest):

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -148,6 +148,13 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
         self.assertTrue(
             self.download_output_manager.is_compatible(self.fileobj))
 
+    def test_is_compatible_bytes_io(self):
+        self.assertTrue(
+            self.download_output_manager.is_compatible(six.BytesIO()))
+
+    def test_not_compatible_for_non_filelike_obj(self):
+        self.assertFalse(self.download_output_manager.is_compatible(object()))
+
     def test_get_fileobj_for_io_writes(self):
         self.assertIs(
             self.download_output_manager.get_fileobj_for_io_writes(

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -21,6 +21,7 @@ from tests import BaseSubmissionTaskTest
 from tests import FileSizeProvider
 from tests import RecordingSubscriber
 from tests import RecordingExecutor
+from s3transfer.compat import six
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.manager import TransferConfig
 from s3transfer.upload import UploadFilenameInputManager
@@ -184,6 +185,13 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
     def tearDown(self):
         self.fileobj.close()
         super(TestUploadSeekableInputManager, self).tearDown()
+
+    def test_is_compatible_bytes_io(self):
+        self.assertTrue(
+            self.upload_input_manager.is_compatible(six.BytesIO()))
+
+    def test_not_compatible_for_non_filelike_obj(self):
+        self.assertFalse(self.upload_input_manager.is_compatible(object()))
 
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertTrue(


### PR DESCRIPTION
This pull request does the following:
* Add a DownloadOutputManager that gives us flexibility in a similar fashion as the UploadInputManager
* Add support for seekable files.

Here is some comparisons:
**Seekable file download**
**Code:**
```py
import time

import boto3
from s3transfer.manager import TransferManager

c = boto3.client('s3')
key = '100MB'

start_time = time.time()
manager = TransferManager(c)
with open(key, 'wb') as f:
    future = manager.download('mybucketfoo', key, f)
    queue_time = time.time()
    print("Time to queue download: %s" % (queue_time - start_time))
    future.result()
    end_time = time.time()
    print("Time to complete download: %s" % (end_time - start_time))
```
**Results:**
```
Time to queue download: 0.00941491127014
Time to complete download: 3.51214289665
```

**Filename**
**Code**
```py
import time

import boto3
from s3transfer.manager import TransferManager

c = boto3.client('s3')
key = '100MB'

start_time = time.time()
manager = TransferManager(c)
future = manager.download('mybucketfoo', key, key)
queue_time = time.time()
print("Time to queue download: %s" % (queue_time - start_time))
future.result()
end_time = time.time()
print("Time to complete download: %s" % (end_time - start_time))
```
**Results**
```
Time to queue download: 0.00508308410645
Time to complete download: 3.74164819717
```

**CLI Comparison**
```
$ time aws s3 cp s3://mybucketfoo/100MB 100MB
download: s3://mybucketfoo/100MB to ./100MB        

real	0m3.738s
user	0m0.844s
sys	0m0.491s
```
cc @jamesls @JordonPhillips 