### PR TITLE
Add TransferManagerController for Cntrl-C

### DIFF
--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -45,11 +45,13 @@ if six.PY3:
     # In py3 all the socket related errors are in a newly created
     # ConnectionError
     SOCKET_ERROR = ConnectionError
+    MAXINT = None
 else:
     def accepts_kwargs(func):
         return inspect.getargspec(func)[2]
 
     SOCKET_ERROR = socket.error
+    MAXINT = sys.maxint
 
 
 def seekable(fileobj):

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -14,9 +14,9 @@ from concurrent import futures
 from collections import namedtuple
 import copy
 import logging
-import sys
 import threading
 
+from s3transfer.compat import MAXINT
 from s3transfer.utils import FunctionContainer
 
 
@@ -189,7 +189,7 @@ class TransferCoordinator(object):
         # can be interrupted in python3 so we just wait with the largest
         # possible value integer value, which is on the scale of billions of
         # years...
-        self._done_event.wait(sys.maxint)
+        self._done_event.wait(MAXINT)
 
         # Once done waiting, raise an exception if present or return the
         # final result.

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -487,7 +487,12 @@ class TransferCoordinatorController(object):
             transfer_coordinator.cancel()
 
     def wait(self):
-        """Wait until there are no more inprogress transfers"""
+        """Wait until there are no more inprogress transfers
+
+        This will not stop when failures are encountered and not propogate any
+        of these errors from failed transfers, but it can be interrupted with
+        a KeyboardInterrupt.
+        """
         try:
             for transfer_coordinator in self.tracked_transfer_coordinators:
                 transfer_coordinator.result()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -161,6 +161,12 @@ class RecordingSubscriber(BaseSubscriber):
         return amount_seen
 
 
+class TransferCoordinatorWithInterrupt(TransferCoordinator):
+    """Used to inject keyboard interrupts"""
+    def result(self):
+        raise KeyboardInterrupt()
+
+
 class RecordingExecutor(object):
     """A wrapper on an executor to record calls made to submit()
 

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -64,7 +64,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         self.upload_file(filename, '20mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '20mb.txt')
-        sleep_time = 1
+        sleep_time = 0.5
         try:
             with transfer_manager:
                 start_time = time.time()

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -10,7 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import glob
 import os
+import time
+
+from concurrent.futures import CancelledError
 
 from tests import assert_files_equal
 from tests import RecordingSubscriber
@@ -51,6 +55,43 @@ class TestDownload(BaseTransferManagerIntegTest):
             self.bucket_name, '20mb.txt', download_path)
         future.result()
         assert_files_equal(filename, download_path)
+
+    def test_large_download_exits_quicky_on_exception(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=20 * 1024 * 1024)
+        self.upload_file(filename, '20mb.txt')
+
+        download_path = os.path.join(self.files.rootdir, '20mb.txt')
+        sleep_time = 1
+        try:
+            with transfer_manager:
+                start_time = time.time()
+                future = transfer_manager.download(
+                    self.bucket_name, '20mb.txt', download_path)
+                # Sleep for a little to get the transfer process going
+                time.sleep(sleep_time)
+                # Raise an exception which should cause the preceeding
+                # download to cancel and exit quickly
+                raise KeyboardInterrupt()
+        except KeyboardInterrupt:
+            pass
+        end_time = time.time()
+        # The maximum time allowed for the transfer manager to exit.
+        # This means that it should take less than a couple second after
+        # sleeping to exit.
+        max_allowed_exit_time = sleep_time + 1
+        self.assertTrue(end_time - start_time < max_allowed_exit_time)
+
+        # Make sure the future was cancelled because of the KeyboardInterrupt
+        with self.assertRaises(CancelledError):
+            future.result()
+
+        # Make sure the actual file and the temporary do not exist
+        # by globbing for the file and any of its extensions
+        possible_matches = glob.glob('%s*' % download_path)
+        self.assertEqual(possible_matches, [])
 
     def test_progress_subscribers_on_download(self):
         subscriber = RecordingSubscriber()

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -17,6 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import CancelledError
 
 from tests import unittest
+from tests import TransferCoordinatorWithInterrupt
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferCoordinator
@@ -26,12 +27,6 @@ from s3transfer.utils import FunctionContainer
 
 def return_call_args(*args, **kwargs):
     return args, kwargs
-
-
-class TransferCoordinatorWithInterrupt(TransferCoordinator):
-    """Used to inject keyboard interrupts"""
-    def result(self):
-        raise KeyboardInterrupt()
 
 
 class TestTransferFuture(unittest.TestCase):

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -16,7 +16,6 @@ from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import CancelledError
 
-
 from tests import unittest
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import TransferMeta
@@ -29,11 +28,26 @@ def return_call_args(*args, **kwargs):
     return args, kwargs
 
 
+class TransferCoordinatorWithInterrupt(TransferCoordinator):
+    """Used to inject keyboard interrupts"""
+    def result(self):
+        raise KeyboardInterrupt()
+
+
 class TestTransferFuture(unittest.TestCase):
     def setUp(self):
         self.meta = TransferMeta()
         self.coordinator = TransferCoordinator()
-        self.future = TransferFuture(self.meta, self.coordinator)
+        self.future = self._get_transfer_future()
+
+    def _get_transfer_future(self, **kwargs):
+        components = {
+            'meta': self.meta,
+            'coordinator': self.coordinator,
+        }
+        for component_name, component in kwargs.items():
+            components[component_name] = component
+        return TransferFuture(**components)
 
     def test_meta(self):
         self.assertIs(self.future.meta, self.meta)
@@ -48,6 +62,16 @@ class TestTransferFuture(unittest.TestCase):
         self.coordinator.set_result(result)
         self.coordinator.announce_done()
         self.assertEqual(self.future.result(), result)
+
+    def test_keyboard_interrupt_on_result_does_not_block(self):
+        # This should raise a KeyboardInterrupt when result is called on it.
+        self.coordinator = TransferCoordinatorWithInterrupt()
+        self.future = self._get_transfer_future()
+
+        # result() should not block and immediately raise the keyboard
+        # interrupt exception.
+        with self.assertRaises(KeyboardInterrupt):
+            self.future.result()
 
     def test_cancel(self):
         self.future.cancel()

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,0 +1,76 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import time
+
+from concurrent.futures import ThreadPoolExecutor
+
+from tests import unittest
+from s3transfer.futures import TransferCoordinator
+from s3transfer.manager import TransferCoordinatorCanceler
+
+
+class TestTransferCoordinatorCanceler(unittest.TestCase):
+    def setUp(self):
+        self.canceler = TransferCoordinatorCanceler()
+
+    def sleep_then_announce_done(self, transfer_coordinator, sleep_time):
+        time.sleep(sleep_time)
+        transfer_coordinator.set_result('done')
+        transfer_coordinator.announce_done()
+
+    def assert_coordinator_is_not_cancelled(self, transfer_coordinator):
+        self.assertNotEqual(transfer_coordinator.status, 'cancelled')
+
+    def assert_coordinator_is_cancelled(self, transfer_coordinator):
+        self.assertEqual(transfer_coordinator.status, 'cancelled')
+
+    def test_add_transfer_coordinator(self):
+        transfer_coordinator = TransferCoordinator()
+        # Add the transfer coordinator
+        self.canceler.add_transfer_coordinator(transfer_coordinator)
+        # Cancel with the canceler
+        self.canceler.cancel()
+        # Check that coordinator got canceled
+        self.assert_coordinator_is_cancelled(transfer_coordinator)
+
+    def test_remove_transfer_coordinator(self):
+        transfer_coordinator = TransferCoordinator()
+        # Add the coordinator
+        self.canceler.add_transfer_coordinator(transfer_coordinator)
+        # Now remove the coordinator
+        self.canceler.remove_transfer_coordinator(transfer_coordinator)
+        self.canceler.cancel()
+        # The coordinator should not have been canceled.
+        self.assert_coordinator_is_not_cancelled(transfer_coordinator)
+
+    def test_wait_for_done_transfer_coordinators(self):
+        # Create a coordinator and add it to the canceler
+        transfer_coordinator = TransferCoordinator()
+        self.canceler.add_transfer_coordinator(transfer_coordinator)
+
+        sleep_time = 0.02
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            # In a seperate thread sleep and then set the transfer coordinator
+            # to done after sleeping.
+            start_time = time.time()
+            executor.submit(
+                self.sleep_then_announce_done, transfer_coordinator,
+                sleep_time)
+            # Now call wait to wait for the transfer coordinator to be done.
+            self.canceler.wait(sleep_time)
+            end_time = time.time()
+            wait_time = end_time - start_time
+        # The time waited should not be less than the time it took to sleep in
+        # the seperate thread because the wait ending should be dependent on
+        # the sleeping thread announcing that the transfer coordinator is done.
+        self.assertTrue(sleep_time <= wait_time)


### PR DESCRIPTION
The abstraction serves the purpose of keeping track all in progress transfers such that:

   * We can Cntrl-C for TransferFuture.result().

   * Introduce a context handler on the TransferManager that wait for all
     TransferFutures to complete, can be quickly cancel all TransferFutures
     if encounters Cntrl-C, and can cancel all inprogress TransferFutures if
     an exception is raised in the middle of the with statement as if there
     is an exception the goal should be to exit as quickly and cleanly as
     possible while still raising the exception hit.


Note that Cntrl-C for uploads are still pretty slow. We will need to wrap the body that is sent with something that will interrupt the sending of the body.

@jamesls @JordonPhillips 