### PR TITLE
Wrap upload bodies with InterruptReader

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -125,8 +125,7 @@ class TransferCoordinator(object):
 
     @property
     def exception(self):
-        with self._lock:
-            return self._exception
+        return self._exception
 
     @property
     def associated_futures(self):

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -124,6 +124,11 @@ class TransferCoordinator(object):
         self._failure_cleanups_lock = threading.Lock()
 
     @property
+    def exception(self):
+        with self._lock:
+            return self._exception
+
+    @property
     def associated_futures(self):
         """The list of futures associated to the inprogress TransferFuture
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import botocore.session
+from botocore.exceptions import ClientError
 
 from tests import unittest
 from tests import FileCreator
@@ -57,9 +58,11 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
             Key=key)
 
     def object_exists(self, key):
-        self.client.head_object(Bucket=self.bucket_name,
-                                Key=key)
-        return True
+        try:
+            self.client.head_object(Bucket=self.bucket_name, Key=key)
+            return True
+        except ClientError:
+            return False
 
     def create_transfer_manager(self, config=None):
         return TransferManager(self.client, config=config)

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -123,6 +123,7 @@ class TestTransferCoordinator(unittest.TestCase):
         # Setting an exception should result in a failed state and the return
         # value should be the rasied exception
         self.assertEqual(self.transfer_coordinator.status, 'failed')
+        self.assertEqual(self.transfer_coordinator.exception, exception_result)
         with self.assertRaises(exception_result):
             self.transfer_coordinator.result()
 


### PR DESCRIPTION
This is the second part needed to quickly cancel all transfers.

This enables the interruption of a socket while it reads so that the entire body does not have to be uploaded before a transfer can be cancelled. So you can do something like this:
```py
import boto3
from s3transfer.manager import TransferManager

client = boto3.client('s3')

with TransferManager(client) as m:
    future1 = m.upload('100MB', 'mybucket', '100MB-upload')
    future1.result()
```
And should be able to get it cancel using Cntrl-C within a couple of seconds.

I also considered wrapping the fileobj ``PutObjectTask`` and ``UploadPartTask`` but that would require me to implement a lot of the interfaces provided by ``ReadFileChunk``, which is the current top wrapper layer, and that did not make sense because I would have to enable and disable callbacks.

I am not sure if it is strange that I pass the TransferCoordinator now to the UploadInputManagers, but I figured it is acceptable because it now matches the initializer for the DownloadOutputManager.

cc @jamesls @JordonPhillips 