### PR TITLE
Add support for non-seekable streaming uploads

### DIFF
--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -76,3 +76,16 @@ def seekable(fileobj):
             return False
     # Else, the fileobj is not seekable
     return False
+
+
+def readable(fileobj):
+    """Determines whether or not a file-like object is readable.
+
+    :param fileobj: The file-like object to determine if readable
+
+    :returns: True, if readable. False otherwise.
+    """
+    if hasattr(fileobj, 'readable'):
+        return fileobj.readable()
+
+    return hasattr(fileobj, 'read')

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -22,6 +22,7 @@ from botocore.stub import ANY
 from tests import BaseGeneralInterfaceTest
 from tests import RecordingSubscriber
 from tests import RecordingOSUtils
+from tests import NonSeekableReader
 from s3transfer.compat import six
 from s3transfer.manager import TransferManager
 from s3transfer.manager import TransferConfig
@@ -150,6 +151,15 @@ class TestNonMultipartUpload(BaseUploadTest):
         bytes_io = six.BytesIO(self.content)
         future = self.manager.upload(
             bytes_io, self.bucket, self.key, self.extra_args)
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_put_object_body_was_correct()
+
+    def test_upload_for_non_seekable_filelike_obj(self):
+        self.add_put_object_response_with_default_expected_params()
+        body = NonSeekableReader(self.content)
+        future = self.manager.upload(
+            body, self.bucket, self.key, self.extra_args)
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
@@ -307,6 +317,17 @@ class TestMultipartUpload(BaseUploadTest):
         bytes_io = six.BytesIO(self.content)
         future = self.manager.upload(
             bytes_io, self.bucket, self.key, self.extra_args)
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_upload_part_bodies_were_correct()
+
+    def test_upload_for_non_seekable_filelike_obj(self):
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params()
+        stream = NonSeekableReader(self.content)
+        future = self.manager.upload(
+            stream, self.bucket, self.key, self.extra_args)
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_upload_part_bodies_were_correct()

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -14,7 +14,8 @@ import time
 
 from concurrent.futures import CancelledError
 
-from tests import RecordingSubscriber
+from botocore.compat import six
+from tests import RecordingSubscriber, NonSeekableReader
 from tests.integration import BaseTransferManagerIntegTest
 from s3transfer.manager import TransferConfig
 
@@ -26,11 +27,13 @@ class TestUpload(BaseTransferManagerIntegTest):
         self.config = TransferConfig(
             multipart_threshold=self.multipart_threshold)
 
+    def get_input_fileobj(self, size, name=''):
+        return self.files.create_file_with_size(name, size)
+
     def test_upload_below_threshold(self):
         transfer_manager = self.create_transfer_manager(self.config)
-        filename = self.files.create_file_with_size(
-            '1mb.txt', filesize=1024 * 1024)
-        future = transfer_manager.upload(filename, self.bucket_name, '1mb.txt')
+        file = self.get_input_fileobj(size=1024 * 1024, name='1mb.txt')
+        future = transfer_manager.upload(file, self.bucket_name, '1mb.txt')
         self.addCleanup(self.delete_object, '1mb.txt')
 
         future.result()
@@ -38,10 +41,9 @@ class TestUpload(BaseTransferManagerIntegTest):
 
     def test_upload_above_threshold(self):
         transfer_manager = self.create_transfer_manager(self.config)
-        filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=20 * 1024 * 1024)
+        file = self.get_input_fileobj(size=20 * 1024 * 1024, name='20mb.txt')
         future = transfer_manager.upload(
-            filename, self.bucket_name, '20mb.txt')
+            file, self.bucket_name, '20mb.txt')
         self.addCleanup(self.delete_object, '20mb.txt')
 
         future.result()
@@ -50,8 +52,8 @@ class TestUpload(BaseTransferManagerIntegTest):
     def test_large_upload_exits_quicky_on_exception(self):
         transfer_manager = self.create_transfer_manager(self.config)
 
-        filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+        filename = self.get_input_fileobj(
+            name='foo.txt', size=20 * 1024 * 1024)
 
         sleep_time = 0.25
         try:
@@ -83,33 +85,12 @@ class TestUpload(BaseTransferManagerIntegTest):
             # make sure the object does not exist.
             self.assertFalse(self.object_exists('20mb.txt'))
 
-    def test_upload_open_file_below_threshold(self):
-        transfer_manager = self.create_transfer_manager(self.config)
-        filename = self.files.create_file_with_size(
-            '1mb.txt', filesize=1024 * 1024)
-        with open(filename, 'rb') as f:
-            future = transfer_manager.upload(f, self.bucket_name, '1mb.txt')
-            self.addCleanup(self.delete_object, '1mb.txt')
-            future.result()
-        self.assertTrue(self.object_exists('1mb.txt'))
-
-    def test_upload_open_file_above_threshold(self):
-        transfer_manager = self.create_transfer_manager(self.config)
-        filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=20 * 1024 * 1024)
-        with open(filename, 'rb') as f:
-            future = transfer_manager.upload(f, self.bucket_name, '20mb.txt')
-            self.addCleanup(self.delete_object, '20mb.txt')
-            future.result()
-        self.assertTrue(self.object_exists('20mb.txt'))
-
     def test_progress_subscribers_on_upload(self):
         subscriber = RecordingSubscriber()
         transfer_manager = self.create_transfer_manager(self.config)
-        filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=20 * 1024 * 1024)
+        file = self.get_input_fileobj(size=20 * 1024 * 1024, name='20mb.txt')
         future = transfer_manager.upload(
-            filename, self.bucket_name, '20mb.txt',
+            file, self.bucket_name, '20mb.txt',
             subscribers=[subscriber])
         self.addCleanup(self.delete_object, '20mb.txt')
 
@@ -119,3 +100,13 @@ class TestUpload(BaseTransferManagerIntegTest):
         # arg to the callback function) should be the size
         # of the file we uploaded.
         self.assertEqual(subscriber.calculate_bytes_seen(), 20 * 1024 * 1024)
+
+
+class TestUploadSeekableStream(TestUpload):
+    def get_input_fileobj(self, size, name=''):
+        return six.BytesIO(b'0' * size)
+
+
+class TestUploadNonSeekableStream(TestUpload):
+    def get_input_fileobj(self, size, name=''):
+        return NonSeekableReader(b'0' * size)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -14,8 +14,10 @@ import os
 import tempfile
 import shutil
 
+from botocore.compat import six
+
 from tests import unittest
-from s3transfer.compat import seekable
+from s3transfer.compat import seekable, readable
 
 
 class ErrorRaisingSeekWrapper(object):
@@ -60,3 +62,15 @@ class TestSeekable(unittest.TestCase):
         # Should return False if OSError is thrown.
         with open(self.filename, 'w') as f:
             self.assertFalse(seekable(ErrorRaisingSeekWrapper(f, OSError())))
+
+
+class TestReadable(unittest.TestCase):
+    def test_readable_fileobj(self):
+        with tempfile.TemporaryFile() as f:
+            self.assertTrue(readable(f))
+
+    def test_readable_file_like_obj(self):
+        self.assertTrue(readable(six.BytesIO()))
+
+    def test_non_file_like_obj(self):
+        self.assertFalse(readable(object()))


### PR DESCRIPTION
The tricky part of this change is that existing code relies on the
ability to get the length of the object being uploaded, which is
not possible for non-seekable objects. To work around that issue,
this will read data into memory up to the configured multipart
threshold to determine if it requires a multipart upload. That data
will then be used to generate the initial parts.

cc @kyleknap @jamesls 