### PR TITLE
Allow users to inject OSUtils

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -156,17 +156,21 @@ class TransferManager(object):
         'MetadataDirective'
     ]
 
-    def __init__(self, client, config=None):
+    def __init__(self, client, config=None, osutil=None):
         """A transfer manager interface for Amazon S3
 
         :param client: Client to be used by the manager
         :param config: TransferConfig to associate specific configurations
+        :param osutil: OSUtils object to use for os-related behavior when
+            using with transfer manager.
         """
         self._client = client
         self._config = config
         if config is None:
             self._config = TransferConfig()
-        self._osutil = OSUtils()
+        self._osutil = osutil
+        if osutil is None:
+            self._osutil = OSUtils()
         self._coordinator_controller = TransferCoordinatorController()
 
         # The executor responsible for making S3 API transfer requests

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -230,13 +230,18 @@ class UploadFilenameInputManager(UploadInputManager):
     def _wrap_with_interrupt_reader(self, fileobj):
         return InterruptReader(fileobj, self._transfer_coordinator)
 
+    def _get_deferred_open_file(self, fileobj, start_byte):
+        fileobj = DeferredOpenFile(fileobj, start_byte)
+        fileobj.OPEN_METHOD = self._osutil.open
+        return fileobj
+
     def _get_put_object_fileobj(self, fileobj):
-        return DeferredOpenFile(fileobj, 0)
+        return self._get_deferred_open_file(fileobj, 0)
 
     def _get_upload_part_fileobj_with_full_size(self, fileobj, **kwargs):
         start_byte = kwargs['start_byte']
         full_size = kwargs['full_file_size']
-        return DeferredOpenFile(fileobj, start_byte), full_size
+        return self._get_deferred_open_file(fileobj, start_byte), full_size
 
     def _get_num_parts(self, transfer_future, part_size):
         return int(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -139,6 +139,23 @@ class FileCreator(object):
         return os.path.join(self.rootdir, filename)
 
 
+class RecordingOSUtils(OSUtils):
+    """An OSUtil abstraction that records openings and renamings"""
+    def __init__(self):
+        super(RecordingOSUtils, self).__init__()
+        self.open_records = []
+        self.rename_records = []
+
+    def open(self, filename, mode):
+        self.open_records.append((filename, mode))
+        return super(RecordingOSUtils, self).open(filename, mode)
+
+    def rename_file(self, current_filename, new_filename):
+        self.rename_records.append((current_filename, new_filename))
+        super(RecordingOSUtils, self).rename_file(
+            current_filename, new_filename)
+
+
 class RecordingSubscriber(BaseSubscriber):
     def __init__(self):
         self.on_queued_calls = []


### PR DESCRIPTION
This is mainly needed for the boto3 port as it allows you to pass your own ``OSUtils`` object. In injecting it, I also noticed that the uploads were not actually using the ``OSUtils.open`` so I fixed that as well.

cc @jamesls @JordonPhillips 