### PR TITLE
Add support for non-seekable downloads

### DIFF
--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -191,15 +191,7 @@ class DownloadNonSeekableOutputManager(DownloadOutputManager):
 
     @classmethod
     def is_compatible(cls, download_target):
-        # We're lying a bit here.  We actually *are* compatible
-        # with seekable fileobjs, we'll still queue the IO writes
-        # in order.  Technically works, but this is not ideal behavior when you
-        # could just use DownloadSeekableOutputManager.
-        # Perhaps this method makes more sense as "should_use()"
-        return (
-            not seekable(download_target) and
-            hasattr(download_target, 'write')
-        )
+        return hasattr(download_target, 'write')
 
     def get_fileobj_for_io_writes(self, transfer_future):
         return transfer_future.meta.call_args.fileobj

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -180,9 +180,9 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
         self.download_output_manager = DownloadNonSeekableOutputManager(
             self.osutil, self.transfer_coordinator, io_executor=None)
 
-    def test_not_compatible_with_seekable_stream(self):
+    def test_is_compatible_with_seekable_stream(self):
         with open(self.filename, 'wb') as f:
-            self.assertFalse(self.download_output_manager.is_compatible(f))
+            self.assertTrue(self.download_output_manager.is_compatible(f))
 
     def test_not_compatible_with_filename(self):
         self.assertFalse(self.download_output_manager.is_compatible(
@@ -196,8 +196,8 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
         f = NonSeekable()
         self.assertTrue(self.download_output_manager.is_compatible(f))
 
-    def test_no_compatible_with_bytesio(self):
-        self.assertFalse(
+    def test_is_compatible_with_bytesio(self):
+        self.assertTrue(
             self.download_output_manager.is_compatible(six.BytesIO()))
 
     def test_submit_writes_from_internal_queue(self):

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -432,7 +432,7 @@ class TestIOStreamingWriteTask(BaseIOTaskTest):
                 IOStreamingWriteTask,
                 main_kwargs={
                     'fileobj': f,
-                    'data': 'foobar'
+                    'data': b'foobar'
                 }
             )
             task()
@@ -440,7 +440,7 @@ class TestIOStreamingWriteTask(BaseIOTaskTest):
                 IOStreamingWriteTask,
                 main_kwargs={
                     'fileobj': f,
-                    'data': 'baz'
+                    'data': b'baz'
                 }
             )
             task2()

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -92,7 +92,7 @@ class TestDownloadFilenameOutputManager(BaseDownloadOutputManagerTest):
     def setUp(self):
         super(TestDownloadFilenameOutputManager, self).setUp()
         self.download_output_manager = DownloadFilenameOutputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator, io_executor=None)
 
     def test_is_compatible(self):
         self.assertTrue(
@@ -132,7 +132,7 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
     def setUp(self):
         super(TestDownloadSeekableOutputManager, self).setUp()
         self.download_output_manager = DownloadSeekableOutputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator, io_executor=None)
 
         # Create a fileobj to write to
         self.fileobj = open(self.filename, 'wb')
@@ -183,14 +183,14 @@ class TestGetObjectTask(BaseTaskTest):
         self.fileobj = WriteCollector()
         self.osutil = OSUtils()
         self.download_output_manager = DownloadSeekableOutputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator, self.io_executor)
 
     def get_download_task(self, **kwargs):
         default_kwargs = {
             'client': self.client, 'bucket': self.bucket, 'key': self.key,
             'fileobj': self.fileobj, 'extra_args': self.extra_args,
             'callbacks': self.callbacks,
-            'max_attempts': self.max_attempts, 'io_executor': self.io_executor,
+            'max_attempts': self.max_attempts,
             'download_output_manager': self.download_output_manager,
         }
         default_kwargs.update(kwargs)

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -181,13 +181,17 @@ class TestGetObjectTask(BaseTaskTest):
         self.content = b'my content'
         self.stream = six.BytesIO(self.content)
         self.fileobj = WriteCollector()
+        self.osutil = OSUtils()
+        self.download_output_manager = DownloadSeekableOutputManager(
+            self.osutil, self.transfer_coordinator)
 
     def get_download_task(self, **kwargs):
         default_kwargs = {
             'client': self.client, 'bucket': self.bucket, 'key': self.key,
             'fileobj': self.fileobj, 'extra_args': self.extra_args,
             'callbacks': self.callbacks,
-            'max_attempts': self.max_attempts, 'io_executor': self.io_executor
+            'max_attempts': self.max_attempts, 'io_executor': self.io_executor,
+            'download_output_manager': self.download_output_manager,
         }
         default_kwargs.update(kwargs)
         return self.get_task(GetObjectTask, main_kwargs=default_kwargs)

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -405,7 +405,7 @@ class BaseIOTaskTest(BaseTaskTest):
         self.files.remove_all()
 
 
-class TestIORenameFileTask(BaseIOTaskTest):
+class TestIOStreamingWriteTask(BaseIOTaskTest):
     def test_main(self):
         with open(self.temp_filename, 'wb') as f:
             task = self.get_task(


### PR DESCRIPTION
This adds support for non seekable downloads.  It's not 100% ready to go, but I'd like to get some design feedback before I get too far along.  It's also still missing an integration test.

I'd recommend reviewing the commits in order, I tried to break them down logically.

The big change is that I moved the IO task submission into the download manager.  Doing so let me put all the non seekable logic in a new download output manager rather than cluttering the GetObjectTask.  This also means that the download output managers take an io executor.

I also had to add an abstraction to buffer/defer IO writes until we could queue them in sequential order.

The other missing piece is that there's nothing here that's capping the max memory allowed for buffering IO writes.  That will likely be in another pull request.



To test non-seekable, I just used:

```
class NonSeekable(object):
    def __init__(self, f):
        self.f = f

    def read(self, amt=None):
        return self.f.read(amt)

    def write(self, content):
        self.f.write(content)

    def close(self):
        self.f.close()
```

Perf is about the same as a seekable fileobj:

```
From seekable fileobj:
Queued download time            : 0.0012
Download complete time          : 22.9263

STREAMING

Queued download time            : 0.0012
Download complete time          : 22.6799

```

cc @kyleknap @JordonPhillips 