### PR TITLE
Check file mode in readable

### DIFF
--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -88,4 +88,7 @@ def readable(fileobj):
     if hasattr(fileobj, 'readable'):
         return fileobj.readable()
 
+    if hasattr(fileobj, 'mode'):
+        return 'r' in fileobj.mode or '+' in fileobj.mode
+
     return hasattr(fileobj, 'read')

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -74,3 +74,15 @@ class TestReadable(unittest.TestCase):
 
     def test_non_file_like_obj(self):
         self.assertFalse(readable(object()))
+
+    def test_file_modes(self):
+        readable_modes = ['r', 'rb', 'r+', 'rb+', 'w+', 'wb+', 'a+', 'ab+']
+        non_readable_modes = ['w', 'wb', 'a', 'ab']
+
+        for mode in readable_modes:
+            with tempfile.TemporaryFile(mode=mode) as f:
+                self.assertTrue(readable(f))
+
+        for mode in non_readable_modes:
+            with tempfile.TemporaryFile(mode=mode) as f:
+                self.assertFalse(readable(f))


### PR DESCRIPTION
Python 2 doesn't have the readable function on file objects, so
to inspect their readability we need to look at the file mode.

Fixes #27 

cc @kyleknap @jamesls