### PR TITLE
Move submission of tasks to transfer coordinator

### DIFF
--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -122,7 +122,7 @@ class CopySubmissionTask(SubmissionTask):
         progress_callbacks = get_callbacks(transfer_future, 'progress')
 
         # Submit the request of a single copy.
-        self._submit_task(
+        self._transfer_coordinator.submit(
             request_executor,
             CopyObjectTask(
                 transfer_coordinator=self._transfer_coordinator,
@@ -150,7 +150,7 @@ class CopySubmissionTask(SubmissionTask):
             if param not in self.CREATE_MULTIPART_ARGS_BLACKLIST:
                 create_multipart_extra_args[param] = val
 
-        create_multipart_future = self._submit_task(
+        create_multipart_future = self._transfer_coordinator.submit(
             request_executor,
             CreateMultipartUploadTask(
                 transfer_coordinator=self._transfer_coordinator,
@@ -187,7 +187,7 @@ class CopySubmissionTask(SubmissionTask):
                 part_size, part_number-1, num_parts, transfer_future.meta.size
             )
             part_futures.append(
-                self._submit_task(
+                self._transfer_coordinator.submit(
                     request_executor,
                     CopyPartTask(
                         transfer_coordinator=self._transfer_coordinator,
@@ -209,7 +209,7 @@ class CopySubmissionTask(SubmissionTask):
             )
 
         # Submit the request to complete the multipart upload.
-        self._submit_task(
+        self._transfer_coordinator.submit(
             request_executor,
             CompleteMultipartUploadTask(
                 transfer_coordinator=self._transfer_coordinator,

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -178,7 +178,6 @@ class DownloadSeekableOutputManager(DownloadOutputManager):
             transfer_coordinator=self._transfer_coordinator)
 
 
-
 class DownloadNonSeekableOutputManager(DownloadOutputManager):
     def __init__(self, osutil, transfer_coordinator, io_executor,
                  defer_queue=None):
@@ -206,7 +205,7 @@ class DownloadNonSeekableOutputManager(DownloadOutputManager):
             for write in writes:
                 data = write['data']
                 logger.debug("Queueing IO offset %s for fileobj: %s",
-                            write['offset'], fileobj)
+                             write['offset'], fileobj)
                 self._transfer_coordinator.submit(
                     self._io_executor,
                     IOStreamingWriteTask(

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -92,7 +92,8 @@ class DownloadOutputManager(object):
         This method may defer submission to the IO executor if necessary.
 
         """
-        future = self._io_executor.submit(
+        self._transfer_coordinator.submit(
+            self._io_executor,
             IOWriteTask(
                 self._transfer_coordinator,
                 main_kwargs={
@@ -102,7 +103,6 @@ class DownloadOutputManager(object):
                 }
             )
         )
-        self._transfer_coordinator.add_associated_future(future)
 
     def get_final_io_task(self):
         """Get the final io task to complete the download
@@ -207,7 +207,8 @@ class DownloadNonSeekableOutputManager(DownloadOutputManager):
                 data = write['data']
                 logger.debug("Queueing IO offset %s for fileobj: %s",
                             write['offset'], fileobj)
-                future = self._io_executor.submit(
+                self._transfer_coordinator.submit(
+                    self._io_executor,
                     IOStreamingWriteTask(
                         self._transfer_coordinator,
                         main_kwargs={
@@ -216,7 +217,6 @@ class DownloadNonSeekableOutputManager(DownloadOutputManager):
                         }
                     )
                 )
-                self._transfer_coordinator.add_associated_future(future)
 
 
 class DownloadSubmissionTask(SubmissionTask):
@@ -310,7 +310,7 @@ class DownloadSubmissionTask(SubmissionTask):
         progress_callbacks = get_callbacks(transfer_future, 'progress')
 
         # Submit the task to download the object.
-        download_future = self._submit_task(
+        download_future = self._transfer_coordinator.submit(
             request_executor,
             GetObjectTask(
                 transfer_coordinator=self._transfer_coordinator,
@@ -363,7 +363,7 @@ class DownloadSubmissionTask(SubmissionTask):
             extra_args.update(call_args.extra_args)
             # Submit the ranged downloads
             ranged_downloads.append(
-                self._submit_task(
+                self._transfer_coordinator.submit(
                     request_executor,
                     GetObjectTask(
                         transfer_coordinator=self._transfer_coordinator,
@@ -393,13 +393,13 @@ class DownloadSubmissionTask(SubmissionTask):
         # all of the other GetObjectTasks have completed.
         final_task = download_output_manager.get_final_io_task()
         submit_final_task = FunctionContainer(
-            self._submit_task, io_executor, final_task)
+            self._transfer_coordinator.submit, io_executor, final_task)
 
         # Submit a task to wait for all of the downloads to complete
         # and submit their downloaded content to the io executor before
         # submitting the final task to the io executor that ensures that all
         # of the io tasks have been completed.
-        self._submit_task(
+        self._transfer_coordinator.submit(
             request_executor,
             JoinFuturesTask(
                 transfer_coordinator=self._transfer_coordinator,

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -220,6 +220,31 @@ class TransferCoordinator(object):
         with self._lock:
             self._status = 'running'
 
+    def submit(self, executor, task, future_tag=None):
+        """Submits a task to a provided executor
+
+        :type executor: s3transfer.futures.BoundedExecutor
+        :param executor: The executor to submit the callable to
+
+        :type task: s3transfer.tasks.Task
+        :param task: The task to submit to the executor
+
+        :type future_tag: s3transfer.futures.FutureTag
+        :param future_tag: A future tag to associate to the task
+
+        :rtype: concurrent.futures.Future
+        :returns: A future representing the submitted task
+        """
+        logger.debug(
+            "Submitting task %s to executor %s from %s." % (
+                task, executor, self)
+        )
+        future = executor.submit(task, future_tag=future_tag)
+        # Add this created future to the list of associated future just
+        # in case it is needed during cleanups.
+        self.add_associated_future(future)
+        return future
+
     def done(self):
         """Determines if a TransferFuture has completed
 

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -196,17 +196,6 @@ class Task(object):
             kwargs[key] = result
         return kwargs
 
-    def _submit_task(self, executor, task, future_tag=None):
-        logger.debug(
-            "Submitting task %s to executor %s from task %s." % (
-                task, executor, self)
-        )
-        future = executor.submit(task, future_tag=future_tag)
-        # Add this created future to the list of associated future just
-        # in case it is needed during cleanups.
-        self._transfer_coordinator.add_associated_future(future)
-        return future
-
 
 class SubmissionTask(Task):
     """A base class for any submission task

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -498,7 +498,7 @@ class UploadSubmissionTask(SubmissionTask):
             upload_input_manager, 'put_object')
 
         # Submit the request of a single upload.
-        self._submit_task(
+        self._transfer_coordinator.submit(
             request_executor,
             PutObjectTask(
                 transfer_coordinator=self._transfer_coordinator,
@@ -521,7 +521,7 @@ class UploadSubmissionTask(SubmissionTask):
         call_args = transfer_future.meta.call_args
 
         # Submit the request to create a multipart upload.
-        create_multipart_future = self._submit_task(
+        create_multipart_future = self._transfer_coordinator.submit(
             request_executor,
             CreateMultipartUploadTask(
                 transfer_coordinator=self._transfer_coordinator,
@@ -548,7 +548,7 @@ class UploadSubmissionTask(SubmissionTask):
 
         for part_number, fileobj in part_iterator:
             part_futures.append(
-                self._submit_task(
+                self._transfer_coordinator.submit(
                     request_executor,
                     UploadPartTask(
                         transfer_coordinator=self._transfer_coordinator,
@@ -569,7 +569,7 @@ class UploadSubmissionTask(SubmissionTask):
             )
 
         # Submit the request to complete the multipart upload.
-        self._submit_task(
+        self._transfer_coordinator.submit(
             request_executor,
             CompleteMultipartUploadTask(
                 transfer_coordinator=self._transfer_coordinator,

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -472,10 +472,12 @@ class SlidingWindowSemaphore(object):
                 # We can't do anything right now because we're still waiting
                 # for the min sequence for the tag to be released.  We have
                 # to queue this for pending release.
-                self._pending_release.setdefault(tag, []).append(sequence_number)
+                self._pending_release.setdefault(
+                    tag, []).append(sequence_number)
                 self._pending_release[tag].sort(reverse=True)
             else:
-                raise ValueError("Attempted to release unknown sequence number "
-                                 "%s for tag: %s" % (sequence_number, tag))
+                raise ValueError(
+                    "Attempted to release unknown sequence number "
+                    "%s for tag: %s" % (sequence_number, tag))
         finally:
             self._condition.release()

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -148,7 +148,8 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
     def setUp(self):
         super(TestDownloadSeekableOutputManager, self).setUp()
         self.download_output_manager = DownloadSeekableOutputManager(
-            self.osutil, self.transfer_coordinator, io_executor=self.io_executor)
+            self.osutil, self.transfer_coordinator,
+            io_executor=self.io_executor)
 
         # Create a fileobj to write to
         self.fileobj = open(self.filename, 'wb')
@@ -513,10 +514,11 @@ class TestDeferQueue(unittest.TestCase):
         writes = self.q.request_writes(offset=0, data='a')
         self.assertEqual(
             writes,
-            [{'offset': 0, 'data': 'a'},
-             {'offset': 1, 'data': 'b'},
-             {'offset': 2, 'data': 'c'},
-             {'offset': 3, 'data': 'd'},
+            [
+                {'offset': 0, 'data': 'a'},
+                {'offset': 1, 'data': 'b'},
+                {'offset': 2, 'data': 'c'},
+                {'offset': 3, 'data': 'd'}
             ]
         )
 
@@ -528,8 +530,9 @@ class TestDeferQueue(unittest.TestCase):
         writes = self.q.request_writes(offset=0, data='a')
         self.assertEqual(
             writes,
-            [{'offset': 0, 'data': 'a'},
-             {'offset': 1, 'data': 'b'},
+            [
+                {'offset': 0, 'data': 'a'},
+                {'offset': 1, 'data': 'b'},
             ]
         )
 
@@ -538,8 +541,9 @@ class TestDeferQueue(unittest.TestCase):
         writes = self.q.request_writes(offset=0, data='abcde')
         self.assertEqual(
             writes,
-            [{'offset': 0, 'data': 'abcde'},
-             {'offset': 5, 'data': 'hello world'},
+            [
+                {'offset': 0, 'data': 'abcde'},
+                {'offset': 5, 'data': 'hello world'},
             ]
         )
 
@@ -579,9 +583,10 @@ class TestDeferQueue(unittest.TestCase):
 
         self.assertEqual(
             self.q.request_writes(offset=0, data='a'),
-            [{'offset': 0, 'data': 'a'},
-             # Note we're seeing 'b' 'c', and not 'X', 'Y'.
-             {'offset': 1, 'data': 'b'},
-             {'offset': 2, 'data': 'c'},
+            [
+                {'offset': 0, 'data': 'a'},
+                # Note we're seeing 'b' 'c', and not 'X', 'Y'.
+                {'offset': 1, 'data': 'b'},
+                {'offset': 2, 'data': 'c'},
             ]
         )

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -158,6 +158,22 @@ class TestTransferCoordinator(unittest.TestCase):
         self.transfer_coordinator.announce_done()
         self.assertEqual(self.transfer_coordinator.status, 'success')
 
+    def test_submit(self):
+        # Submit a callable to the transfer coordinator. It should submit it
+        # to the executor.
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = self.transfer_coordinator.submit(
+                executor,
+                return_call_args,
+                future_tag='my-tag'
+            )
+        # Make sure the future got associated to the transfer coordinator
+        self.assertEqual(
+            self.transfer_coordinator.associated_futures, [future])
+        # Make sure the future got submit and executed as well by checking its
+        # result value which should include the provided future tag.
+        self.assertEqual(future.result(), ((), {'future_tag': 'my-tag'}))
+
     def test_done(self):
         # These should result in not done state:
         # queued

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -58,7 +58,7 @@ class ReturnKwargsTask(Task):
 class SubmitMoreTasksTask(Task):
     def _main(self, executor, tasks_to_submit):
         for task_to_submit in tasks_to_submit:
-            self._submit_task(executor, task_to_submit)
+            self._transfer_coordinator.submit(executor, task_to_submit)
 
 
 class NOOPSubmissionTask(SubmissionTask):
@@ -70,7 +70,7 @@ class ExceptionSubmissionTask(SubmissionTask):
     def _submit(self, transfer_future, executor=None, tasks_to_submit=None):
         if executor and tasks_to_submit:
             for task_to_submit in tasks_to_submit:
-                self._submit_task(executor, task_to_submit)
+                self._transfer_coordinator.submit(executor, task_to_submit)
             # We want to sleep for a small of time to allow the provided tasks
             # to be executed before the task exception when submitting is
             # raised.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -419,7 +419,6 @@ class TestSlidingWindowSemaphore(unittest.TestCase):
         self.assertEqual(sem.acquire('a', blocking=False), 5)
         self.assertEqual(sem.current_count(), 0)
 
-
     def test_counter_release_only_on_min_element(self):
         sem = SlidingWindowSemaphore(3)
         sem.acquire('a', blocking=False)
@@ -556,9 +555,11 @@ class TestThreadingPropertiesForSlidingWindowSemaphore(unittest.TestCase):
         sem = SlidingWindowSemaphore(2)
         sem.acquire('a', blocking=False)
         sem.acquire('a', blocking=False)
+
         def acquire():
             # This next call to acquire will block.
             self.assertEqual(sem.acquire('a', blocking=True), 2)
+
         t = threading.Thread(target=acquire)
         self.threads.append(t)
         # Starting the thread will block the sem.acquire()
@@ -591,11 +592,13 @@ class TestThreadingPropertiesForSlidingWindowSemaphore(unittest.TestCase):
         sem = SlidingWindowSemaphore(5)
         num_threads = 10
         num_iterations = 50
+
         def acquire():
             for _ in range(num_iterations):
                 num = sem.acquire('a', blocking=True)
                 time.sleep(0.001)
                 sem.release('a', num)
+
         for i in range(num_threads):
             t = threading.Thread(target=acquire)
             self.threads.append(t)


### PR DESCRIPTION
Introduced submit() method for tasks to submit other tasks to executors
in order to ensure task submission happens under one function.

Brought up because of comments in this PR: https://github.com/boto/s3transfer/pull/25 

I also fixed some flake8 issues that I noticed...

cc @jamesls @JordonPhillips 