### PR TITLE
Integrating Semaphores into Executor

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -79,9 +79,9 @@ class TransferFuture(object):
 
 class TransferMeta(object):
     """Holds metadata about the TransferFuture"""
-    def __init__(self, call_args=None, id=None):
+    def __init__(self, call_args=None, transfer_id=None):
         self._call_args = call_args
-        self._id = id
+        self._transfer_id = transfer_id
         self._size = None
         self._user_context = {}
 
@@ -91,9 +91,9 @@ class TransferMeta(object):
         return self._call_args
 
     @property
-    def id(self):
+    def transfer_id(self):
         """The unique id of the transfer"""
-        return self._id
+        return self._transfer_id
 
     @property
     def size(self):
@@ -117,8 +117,8 @@ class TransferMeta(object):
 
 class TransferCoordinator(object):
     """A helper class for managing TransferFuture"""
-    def __init__(self, id=None):
-        self.id = id
+    def __init__(self, transfer_id=None):
+        self.transfer_id = transfer_id
         self._status = 'queued'
         self._result = None
         self._exception = None
@@ -245,7 +245,7 @@ class TransferCoordinator(object):
         """
         logger.debug(
             "Submitting task %s to executor %s for transfer request: %s." % (
-                task, executor, self.id)
+                task, executor, self.transfer_id)
         )
         future = executor.submit(task, tag=tag)
         # Add this created future to the list of associated future just

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -78,8 +78,9 @@ class TransferFuture(object):
 
 class TransferMeta(object):
     """Holds metadata about the TransferFuture"""
-    def __init__(self, call_args=None):
+    def __init__(self, call_args=None, id=None):
         self._call_args = call_args
+        self._id = id
         self._size = None
         self._user_context = {}
 
@@ -87,6 +88,11 @@ class TransferMeta(object):
     def call_args(self):
         """The call args used in the transfer request"""
         return self._call_args
+
+    @property
+    def id(self):
+        """The unique id of the transfer"""
+        return self._id
 
     @property
     def size(self):
@@ -110,7 +116,8 @@ class TransferMeta(object):
 
 class TransferCoordinator(object):
     """A helper class for managing TransferFuture"""
-    def __init__(self):
+    def __init__(self, id=None):
+        self.id = id
         self._status = 'queued'
         self._result = None
         self._exception = None
@@ -236,8 +243,8 @@ class TransferCoordinator(object):
         :returns: A future representing the submitted task
         """
         logger.debug(
-            "Submitting task %s to executor %s from %s." % (
-                task, executor, self)
+            "Submitting task %s to executor %s for transfer request: %s." % (
+                task, executor, self.id)
         )
         future = executor.submit(task, future_tag=future_tag)
         # Add this created future to the list of associated future just

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -119,6 +119,14 @@ class TransferConfig(object):
         self.io_chunksize = io_chunksize
         self.num_download_attempts = num_download_attempts
         self.max_in_memory_upload_chunks = max_in_memory_upload_chunks
+        self._validate_attrs_are_nonzero()
+
+    def _validate_attrs_are_nonzero(self):
+        for attr, attr_val, in self.__dict__.items():
+            if attr_val <= 0:
+                raise ValueError(
+                    'Provided parameter %s of value %s must be greater than '
+                    '0.' % (attr, attr_val))
 
 
 class TransferManager(object):

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -382,7 +382,7 @@ class TransferManager(object):
     def _get_future_with_components(self, call_args):
         transfer_id = self._id_counter
         # Creates a new transfer future along with its components
-        transfer_coordinator = TransferCoordinator(id=transfer_id)
+        transfer_coordinator = TransferCoordinator(transfer_id=transfer_id)
         # Track the transfer coordinator for transfers to manage.
         self._coordinator_controller.add_transfer_coordinator(
             transfer_coordinator)
@@ -392,7 +392,7 @@ class TransferManager(object):
             self._coordinator_controller.remove_transfer_coordinator,
             transfer_coordinator)
         components = {
-            'meta': TransferMeta(call_args, id=transfer_id),
+            'meta': TransferMeta(call_args, transfer_id=transfer_id),
             'coordinator': transfer_coordinator
         }
         transfer_future = TransferFuture(**components)

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -20,6 +20,7 @@ from s3transfer.utils import disable_upload_callbacks
 from s3transfer.utils import enable_upload_callbacks
 from s3transfer.utils import CallArgs
 from s3transfer.utils import OSUtils
+from s3transfer.utils import TaskSemaphore
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.futures import BoundedExecutor
 from s3transfer.futures import TransferFuture
@@ -40,8 +41,8 @@ class TransferConfig(object):
                  multipart_chunksize=8 * MB,
                  max_request_concurrency=10,
                  max_submission_concurrency=5,
-                 max_request_queue_size=0,
-                 max_submission_queue_size=0,
+                 max_request_queue_size=1000,
+                 max_submission_queue_size=1000,
                  max_io_queue_size=1000,
                  io_chunksize=64 * KB,
                  num_download_attempts=5,
@@ -185,8 +186,9 @@ class TransferManager(object):
         self._request_executor = BoundedExecutor(
             max_size=self._config.max_request_queue_size,
             max_num_threads=self._config.max_request_concurrency,
-            tag_max_sizes={
-                IN_MEMORY_UPLOAD_TAG: self._config.max_in_memory_upload_chunks
+            tag_semaphores={
+                IN_MEMORY_UPLOAD_TAG: TaskSemaphore(
+                    self._config.max_in_memory_upload_chunks)
             }
         )
 

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -91,7 +91,7 @@ class Task(object):
     @property
     def transfer_id(self):
         """The id for the transfer request that the task belongs to"""
-        return self._transfer_coordinator.id
+        return self._transfer_coordinator.transfer_id
 
     def _get_kwargs_with_params_to_include(self, kwargs, include):
         filtered_kwargs = {}

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -88,6 +88,11 @@ class Task(object):
             self._main_kwargs, params_to_display)
         return '%s(%s)' % (self.__class__.__name__, main_kwargs_to_display)
 
+    @property
+    def transfer_id(self):
+        """The id for the transfer request that the task belongs to"""
+        return self._transfer_coordinator.id
+
     def _get_kwargs_with_params_to_include(self, kwargs, include):
         filtered_kwargs = {}
         for param in include:

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -494,7 +494,7 @@ class UploadSubmissionTask(SubmissionTask):
         call_args = transfer_future.meta.call_args
 
         # Get any tags that need to be associated to the put object task
-        put_object_future_tag = self._get_upload_future_tag(
+        put_object_tag = self._get_upload_task_tag(
             upload_input_manager, 'put_object')
 
         # Submit the request of a single upload.
@@ -512,7 +512,7 @@ class UploadSubmissionTask(SubmissionTask):
                 },
                 is_final=True
             ),
-            future_tag=put_object_future_tag
+            tag=put_object_tag
         )
 
     def _submit_multipart_request(self, client, config, osutil,
@@ -540,7 +540,7 @@ class UploadSubmissionTask(SubmissionTask):
 
         # Get any tags that need to be associated to the submitted task
         # for upload the data
-        upload_part_future_tag = self._get_upload_future_tag(
+        upload_part_tag = self._get_upload_task_tag(
             upload_input_manager, 'upload_part')
 
         part_iterator = upload_input_manager.yield_upload_part_bodies(
@@ -564,7 +564,7 @@ class UploadSubmissionTask(SubmissionTask):
                             'upload_id': create_multipart_future
                         }
                     ),
-                    future_tag=upload_part_future_tag
+                    tag=upload_part_tag
                 )
             )
 
@@ -595,11 +595,11 @@ class UploadSubmissionTask(SubmissionTask):
                 upload_parts_args[key] = value
         return upload_parts_args
 
-    def _get_upload_future_tag(self, upload_input_manager, operation_name):
-        future_tag = None
+    def _get_upload_task_tag(self, upload_input_manager, operation_name):
+        tag = None
         if upload_input_manager.stores_body_in_memory(operation_name):
-            future_tag = IN_MEMORY_UPLOAD_TAG
-        return future_tag
+            tag = IN_MEMORY_UPLOAD_TAG
+        return tag
 
 
 class PutObjectTask(Task):

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -389,7 +389,39 @@ class NoResourcesAvailable(Exception):
     pass
 
 
-class SlidingWindowSemaphore(object):
+class TaskSemaphore(object):
+    def __init__(self, count):
+        """A semaphore for the purpose of limiting the number of tasks
+
+        :param count: The size of semaphore
+        """
+        self._semaphore = threading.Semaphore(count)
+
+    def acquire(self, tag, blocking=True):
+        """Acquire the semaphore
+
+        :param tag: A tag identifying what is acquiring the semaphore
+        :param block: If True, block until it can be acquired. If False,
+            do not block and raise an exception if cannot be aquired.
+
+        :returns: A token (can be None) to use when releasing the semaphore
+        """
+        logger.debug("Acquiring %s", tag)
+        if not self._semaphore.acquire(blocking):
+            raise NoResourcesAvailable("Cannot acquire tag '%s'" % tag)
+
+    def release(self, tag, acquire_token):
+        """Release the semaphore
+
+        :param tag: A tag identifying what is releasing the semaphore
+        :param acquire_token:  The token returned from when the semaphore was
+            acquired.
+        """
+        logger.debug("Releasing acquire %s/%s" % (tag, acquire_token))
+        self._semaphore.release()
+
+
+class SlidingWindowSemaphore(TaskSemaphore):
     """A semaphore used to coordinate sequential resource access.
 
     This class is similar to the stdlib BoundedSemaphore:
@@ -447,7 +479,8 @@ class SlidingWindowSemaphore(object):
         finally:
             self._condition.release()
 
-    def release(self, tag, sequence_number):
+    def release(self, tag, acquire_token):
+        sequence_number = acquire_token
         logger.debug("Releasing acquire %s/%s", tag, sequence_number)
         self._condition.acquire()
         try:

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -400,7 +400,10 @@ class TaskSemaphore(object):
     def acquire(self, tag, blocking=True):
         """Acquire the semaphore
 
-        :param tag: A tag identifying what is acquiring the semaphore
+        :param tag: A tag identifying what is acquiring the semaphore. Note
+            that this is not really needed to directly use this class but is
+            needed for API compatibility with the SlidingWindowSemaphore
+            implementation.
         :param block: If True, block until it can be acquired. If False,
             do not block and raise an exception if cannot be aquired.
 
@@ -415,7 +418,9 @@ class TaskSemaphore(object):
 
         :param tag: A tag identifying what is releasing the semaphore
         :param acquire_token:  The token returned from when the semaphore was
-            acquired.
+            acquired. Note that this is not really needed to directly use this
+            class but is needed for API compatibility with the
+            SlidingWindowSemaphore implementation.
         """
         logger.debug("Releasing acquire %s/%s" % (tag, acquire_token))
         self._semaphore.release()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -363,7 +363,7 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
         for param, value in call_kwargs.items():
             self.assertEqual(value, getattr(future.meta.call_args, param))
 
-    def test_has_id_associated_to_future(self):
+    def test_has_transfer_id_associated_to_future(self):
         self._setup_default_stubbed_responses()
         call_kwargs = self.create_call_kwargs()
         future = self.method(**call_kwargs)
@@ -371,11 +371,18 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
         # before we try to clean up resources in the tearDown.
         future.result()
 
-        # Assert that an id was associated to the future.
+        # Assert that an transfer id was associated to the future.
         # Since there is only one transfer request is made for that transfer
         # manager the id will be zero since it will be the first transfer
         # request made for that transfer manager.
-        self.assertEqual(future.meta.id, 0)
+        self.assertEqual(future.meta.transfer_id, 0)
+
+        # If we make a second request, the transfer id should have incremented
+        # by one for that new TransferFuture.
+        self._setup_default_stubbed_responses()
+        future = self.method(**call_kwargs)
+        future.result()
+        self.assertEqual(future.meta.transfer_id, 1)
 
     def test_invalid_extra_args(self):
         with self.assertRaisesRegexp(ValueError, 'Invalid extra_args'):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,6 +27,7 @@ from botocore.stub import Stubber
 from botocore.compat import six
 
 from s3transfer.manager import TransferConfig
+from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.futures import TransferCoordinator
 from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferFuture
@@ -34,6 +35,7 @@ from s3transfer.futures import BoundedExecutor
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
 from s3transfer.utils import CallArgs
+from s3transfer.utils import TaskSemaphore
 
 
 def assert_files_equal(first, second):
@@ -202,13 +204,13 @@ class RecordingExecutor(object):
         self._executor = executor
         self.submissions = []
 
-    def submit(self, fn, *args, **kwargs):
-        future = self._executor.submit(fn, *args, **kwargs)
+    def submit(self, task, tag=None, block=True):
+        future = self._executor.submit(task, tag, block)
         self.submissions.append(
             {
-                'fn': fn,
-                'args': args,
-                'kwargs': kwargs
+                'task': task,
+                'tag': tag,
+                'block': block
             }
         )
         return future
@@ -265,7 +267,8 @@ class BaseSubmissionTaskTest(BaseTaskTest):
         super(BaseSubmissionTaskTest, self).setUp()
         self.config = TransferConfig()
         self.osutil = OSUtils()
-        self.executor = BoundedExecutor(0, 1)
+        self.executor = BoundedExecutor(
+            1000, 1, {IN_MEMORY_UPLOAD_TAG: TaskSemaphore(10)})
 
     def tearDown(self):
         super(BaseSubmissionTaskTest, self).tearDown()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -360,6 +360,20 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
         for param, value in call_kwargs.items():
             self.assertEqual(value, getattr(future.meta.call_args, param))
 
+    def test_has_id_associated_to_future(self):
+        self._setup_default_stubbed_responses()
+        call_kwargs = self.create_call_kwargs()
+        future = self.method(**call_kwargs)
+        # The result is called so we ensure that the entire process executes
+        # before we try to clean up resources in the tearDown.
+        future.result()
+
+        # Assert that an id was associated to the future.
+        # Since there is only one transfer request is made for that transfer
+        # manager the id will be zero since it will be the first transfer
+        # request made for that transfer manager.
+        self.assertEqual(future.meta.id, 0)
+
     def test_invalid_extra_args(self):
         with self.assertRaisesRegexp(ValueError, 'Invalid extra_args'):
             self.method(

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -87,7 +87,7 @@ class BaseDownloadOutputManagerTest(BaseTaskTest):
 
         self.call_args = CallArgs(fileobj=self.filename)
         self.future = self.get_transfer_future(self.call_args)
-        self.io_executor = BoundedExecutor(0, 1)
+        self.io_executor = BoundedExecutor(1000, 1)
 
     def tearDown(self):
         super(BaseDownloadOutputManagerTest, self).tearDown()
@@ -230,7 +230,7 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
                 ]
 
         q = FakeQueue()
-        io_executor = BoundedExecutor(0, 1)
+        io_executor = BoundedExecutor(1000, 1)
         manager = DownloadNonSeekableOutputManager(
             self.osutil, self.transfer_coordinator, io_executor=io_executor,
             defer_queue=q)
@@ -249,7 +249,7 @@ class TestGetObjectTask(BaseTaskTest):
         self.extra_args = {}
         self.callbacks = []
         self.max_attempts = 5
-        self.io_executor = BoundedExecutor(0, 1)
+        self.io_executor = BoundedExecutor(1000, 1)
         self.content = b'my content'
         self.stream = six.BytesIO(self.content)
         self.fileobj = WriteCollector()

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -99,6 +99,10 @@ class TestTransferMeta(unittest.TestCase):
         # Assert the that call args provided is the same as is returned
         self.assertIs(transfer_meta.call_args, call_args)
 
+    def test_id(self):
+        transfer_meta = TransferMeta(id=1)
+        self.assertEqual(transfer_meta.id, 1)
+
     def test_user_context(self):
         self.transfer_meta.user_context['foo'] = 'bar'
         self.assertEqual(self.transfer_meta.user_context, {'foo': 'bar'})
@@ -107,6 +111,10 @@ class TestTransferMeta(unittest.TestCase):
 class TestTransferCoordinator(unittest.TestCase):
     def setUp(self):
         self.transfer_coordinator = TransferCoordinator()
+
+    def test_id(self):
+        transfer_coordinator = TransferCoordinator(id=1)
+        self.assertEqual(transfer_coordinator.id, 1)
 
     def test_initial_status(self):
         # A TransferCoordinator with no progress should have the status

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -111,9 +111,9 @@ class TestTransferMeta(unittest.TestCase):
         # Assert the that call args provided is the same as is returned
         self.assertIs(transfer_meta.call_args, call_args)
 
-    def test_id(self):
-        transfer_meta = TransferMeta(id=1)
-        self.assertEqual(transfer_meta.id, 1)
+    def test_transfer_id(self):
+        transfer_meta = TransferMeta(transfer_id=1)
+        self.assertEqual(transfer_meta.transfer_id, 1)
 
     def test_user_context(self):
         self.transfer_meta.user_context['foo'] = 'bar'
@@ -124,9 +124,9 @@ class TestTransferCoordinator(unittest.TestCase):
     def setUp(self):
         self.transfer_coordinator = TransferCoordinator()
 
-    def test_id(self):
-        transfer_coordinator = TransferCoordinator(id=1)
-        self.assertEqual(transfer_coordinator.id, 1)
+    def test_transfer_id(self):
+        transfer_coordinator = TransferCoordinator(transfer_id=1)
+        self.assertEqual(transfer_coordinator.transfer_id, 1)
 
     def test_initial_status(self):
         # A TransferCoordinator with no progress should have the status

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -17,11 +17,18 @@ from concurrent.futures import ThreadPoolExecutor
 from tests import unittest
 from tests import TransferCoordinatorWithInterrupt
 from s3transfer.futures import TransferCoordinator
+from s3transfer.manager import TransferConfig
 from s3transfer.manager import TransferCoordinatorController
 
 
 class FutureResultException(Exception):
     pass
+
+
+class TestTransferConfig(unittest.TestCase):
+    def test_exception_on_zero_attr_value(self):
+        with self.assertRaises(ValueError):
+            TransferConfig(max_request_queue_size=0)
 
 
 class TestTransferCoordinatorController(unittest.TestCase):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -81,7 +81,7 @@ class ExceptionSubmissionTask(SubmissionTask):
 class TestSubmissionTask(BaseSubmissionTaskTest):
     def setUp(self):
         super(TestSubmissionTask, self).setUp()
-        self.executor = BoundedExecutor(0, 5)
+        self.executor = BoundedExecutor(1000, 5)
         self.call_args = CallArgs(subscribers=[])
         self.transfer_future = self.get_transfer_future(self.call_args)
         self.main_kwargs = {'transfer_future': self.transfer_future}
@@ -293,7 +293,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
 
 class TestTask(unittest.TestCase):
     def setUp(self):
-        self.transfer_coordinator = TransferCoordinator()
+        self.id = 1
+        self.transfer_coordinator = TransferCoordinator(id=self.id)
 
     def test_repr(self):
         main_kwargs = {
@@ -308,6 +309,12 @@ class TestTask(unittest.TestCase):
             repr(task),
             'ReturnKwargsTask(%s)' % {'bucket': 'mybucket'}
         )
+
+    def test_transfer_id(self):
+        task = SuccessTask(self.transfer_coordinator)
+        # Make sure that the id is the one provided to the id associated
+        # to the transfer coordinator.
+        self.assertEqual(task.transfer_id, self.id)
 
     def test_context_status_transitioning_success(self):
         # The status should be set to running.

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -294,7 +294,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
 class TestTask(unittest.TestCase):
     def setUp(self):
         self.transfer_id = 1
-        self.transfer_coordinator = TransferCoordinator(id=self.transfer_id)
+        self.transfer_coordinator = TransferCoordinator(
+            transfer_id=self.transfer_id)
 
     def test_repr(self):
         main_kwargs = {

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -293,8 +293,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
 
 class TestTask(unittest.TestCase):
     def setUp(self):
-        self.id = 1
-        self.transfer_coordinator = TransferCoordinator(id=self.id)
+        self.transfer_id = 1
+        self.transfer_coordinator = TransferCoordinator(id=self.transfer_id)
 
     def test_repr(self):
         main_kwargs = {
@@ -314,7 +314,7 @@ class TestTask(unittest.TestCase):
         task = SuccessTask(self.transfer_coordinator)
         # Make sure that the id is the one provided to the id associated
         # to the transfer coordinator.
-        self.assertEqual(task.transfer_id, self.id)
+        self.assertEqual(task.transfer_id, self.transfer_id)
 
     def test_context_status_transitioning_success(self):
         # The status should be set to running.

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -427,12 +427,12 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
 
     def assert_tag_value_for_put_object(self, tag_value):
         self.assertEqual(
-            self.executor.submissions[0]['kwargs']['future_tag'], tag_value)
+            self.executor.submissions[0]['tag'], tag_value)
 
     def assert_tag_value_for_upload_parts(self, tag_value):
         for submission in self.executor.submissions[1:-1]:
             self.assertEqual(
-                submission['kwargs']['future_tag'], tag_value)
+                submission['tag'], tag_value)
 
     def test_provide_file_size_on_put(self):
         self.call_args.subscribers.append(FileSizeProvider(len(self.content)))


### PR DESCRIPTION
In order to support the SlidingWindowSemaphore and fix https://github.com/boto/s3transfer/issues/20, I decided to rip out the current implementation on how we bound the executors and replace it with a semaphore approach.

The PR builds off of: https://github.com/boto/s3transfer/pull/30. You can look at that one or look at both of the PR's via this one.

The larger changes in this PR include:

* Add a unique identifier for each transfer request.
* Instead of relying on current.futures.wait to wait for futures to complete we use semaphores to bound the limits. 


cc @jamesls @JordonPhillips 