### PR TITLE
Limit in-memory chunks for downloading to non-seekable streams

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -414,3 +414,4 @@ class BoundedExecutor(object):
 TaskTag = namedtuple('TaskTag', ['name'])
 
 IN_MEMORY_UPLOAD_TAG = TaskTag('in_memory_upload')
+IN_MEMORY_DOWNLOAD_TAG = TaskTag('in_memory_download')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -463,6 +463,4 @@ class NonSeekableWriter(io.RawIOBase):
         self._fileobj.write(b)
 
     def read(self, n=-1):
-        # This is needed because python will not always return the correct
-        # kind of error even though returnable returns False.
         raise io.UnsupportedOperation("read")

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -22,6 +22,7 @@ from tests import StreamWithError
 from tests import FileSizeProvider
 from tests import RecordingSubscriber
 from tests import RecordingOSUtils
+from tests import NonSeekableWriter
 from tests import BaseGeneralInterfaceTest
 from s3transfer.compat import six
 from s3transfer.compat import SOCKET_ERROR
@@ -168,6 +169,19 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         # Ensure that the contents are correct
         bytes_io.seek(0)
         self.assertEqual(self.content, bytes_io.read())
+
+    def test_download_for_nonseekable_filelike_obj(self):
+        self.add_head_object_response()
+        self.add_successful_get_object_responses()
+
+        with open(self.filename, 'wb') as f:
+            future = self.manager.download(
+                self.bucket, self.key, NonSeekableWriter(f), self.extra_args)
+            future.result()
+
+        # Ensure that the contents are correct
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(self.content, f.read())
 
     def test_download_cleanup_on_failure(self):
         self.add_head_object_response()

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -18,6 +18,7 @@ from concurrent.futures import CancelledError
 
 from tests import assert_files_equal
 from tests import RecordingSubscriber
+from tests import NonSeekableWriter
 from tests.integration import BaseTransferManagerIntegTest
 from s3transfer.manager import TransferConfig
 
@@ -134,5 +135,33 @@ class TestDownload(BaseTransferManagerIntegTest):
         with open(download_path, 'wb') as f:
             future = transfer_manager.download(
                 self.bucket_name, '20mb.txt', f)
+            future.result()
+        assert_files_equal(filename, download_path)
+
+    def test_below_threshold_for_nonseekable_fileobj(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        self.upload_file(filename, '1mb.txt')
+
+        download_path = os.path.join(self.files.rootdir, '1mb.txt')
+        with open(download_path, 'wb') as f:
+            future = transfer_manager.download(
+                self.bucket_name, '1mb.txt', NonSeekableWriter(f))
+            future.result()
+        assert_files_equal(filename, download_path)
+
+    def test_above_threshold_for_nonseekable_fileobj(self):
+        transfer_manager = self.create_transfer_manager(self.config)
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=20 * 1024 * 1024)
+        self.upload_file(filename, '20mb.txt')
+
+        download_path = os.path.join(self.files.rootdir, '20mb.txt')
+        with open(download_path, 'wb') as f:
+            future = transfer_manager.download(
+                self.bucket_name, '20mb.txt', NonSeekableWriter(f))
             future.result()
         assert_files_equal(filename, download_path)

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -110,8 +110,8 @@ class TestDownloadFilenameOutputManager(BaseDownloadOutputManagerTest):
         self.assertTrue(
             self.download_output_manager.is_compatible(self.filename))
 
-    def test_buffers_memory_in_body(self):
-        self.assertFalse(self.download_output_manager.buffers_body_in_memory())
+    def test_get_download_task_tag(self):
+        self.assertIsNone(self.download_output_manager.get_download_task_tag())
 
     def test_get_fileobj_for_io_writes(self):
         with self.download_output_manager.get_fileobj_for_io_writes(
@@ -180,8 +180,8 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
     def test_not_compatible_for_non_filelike_obj(self):
         self.assertFalse(self.download_output_manager.is_compatible(object()))
 
-    def test_buffers_memory_in_body(self):
-        self.assertFalse(self.download_output_manager.buffers_body_in_memory())
+    def test_get_download_task_tag(self):
+        self.assertIsNone(self.download_output_manager.get_download_task_tag())
 
     def test_get_fileobj_for_io_writes(self):
         self.assertIs(
@@ -232,8 +232,10 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
         self.assertTrue(
             self.download_output_manager.is_compatible(six.BytesIO()))
 
-    def test_buffers_memory_in_body(self):
-        self.assertTrue(self.download_output_manager.buffers_body_in_memory())
+    def test_get_download_task_tag(self):
+        self.assertIs(
+            self.download_output_manager.get_download_task_tag(),
+            IN_MEMORY_DOWNLOAD_TAG)
 
     def test_submit_writes_from_internal_queue(self):
         class FakeQueue(object):

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -16,21 +16,26 @@ import shutil
 import tempfile
 
 from tests import BaseTaskTest
+from tests import BaseSubmissionTaskTest
 from tests import StreamWithError
 from tests import FileCreator
 from tests import unittest
+from tests import RecordingExecutor
+from tests import NonSeekableWriter
 from s3transfer.compat import six
 from s3transfer.compat import SOCKET_ERROR
 from s3transfer.exceptions import RetriesExceededError
 from s3transfer.download import DownloadFilenameOutputManager
 from s3transfer.download import DownloadSeekableOutputManager
 from s3transfer.download import DownloadNonSeekableOutputManager
+from s3transfer.download import DownloadSubmissionTask
 from s3transfer.download import GetObjectTask
 from s3transfer.download import IOWriteTask
 from s3transfer.download import IOStreamingWriteTask
 from s3transfer.download import IORenameFileTask
 from s3transfer.download import CompleteDownloadNOOPTask
 from s3transfer.download import DeferQueue
+from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
 from s3transfer.futures import BoundedExecutor
 from s3transfer.utils import OSUtils
 from s3transfer.utils import CallArgs
@@ -105,6 +110,9 @@ class TestDownloadFilenameOutputManager(BaseDownloadOutputManagerTest):
         self.assertTrue(
             self.download_output_manager.is_compatible(self.filename))
 
+    def test_buffers_memory_in_body(self):
+        self.assertFalse(self.download_output_manager.buffers_body_in_memory())
+
     def test_get_fileobj_for_io_writes(self):
         with self.download_output_manager.get_fileobj_for_io_writes(
                 self.future) as f:
@@ -172,6 +180,9 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
     def test_not_compatible_for_non_filelike_obj(self):
         self.assertFalse(self.download_output_manager.is_compatible(object()))
 
+    def test_buffers_memory_in_body(self):
+        self.assertFalse(self.download_output_manager.buffers_body_in_memory())
+
     def test_get_fileobj_for_io_writes(self):
         self.assertIs(
             self.download_output_manager.get_fileobj_for_io_writes(
@@ -221,6 +232,9 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
         self.assertTrue(
             self.download_output_manager.is_compatible(six.BytesIO()))
 
+    def test_buffers_memory_in_body(self):
+        self.assertTrue(self.download_output_manager.buffers_body_in_memory())
+
     def test_submit_writes_from_internal_queue(self):
         class FakeQueue(object):
             def request_writes(self, offset, data):
@@ -239,6 +253,179 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
             fileobj=fileobj, data='foo', offset=1)
         io_executor.shutdown()
         self.assertEqual(fileobj.writes, [(0, 'foo'), (3, 'bar')])
+
+
+class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
+    def setUp(self):
+        super(TestDownloadSubmissionTask, self).setUp()
+        self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'myfile')
+
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+        self.extra_args = {}
+        self.subscribers = []
+
+        # Create a stream to read from
+        self.content = b'my content'
+        self.stream = six.BytesIO(self.content)
+
+        # A list to keep track of all of the bodies sent over the wire
+        # and their order.
+
+        self.call_args = self.get_call_args()
+        self.transfer_future = self.get_transfer_future(self.call_args)
+        self.io_executor = BoundedExecutor(1000, 1)
+        self.submission_main_kwargs = {
+            'client': self.client,
+            'config': self.config,
+            'osutil': self.osutil,
+            'request_executor': self.executor,
+            'io_executor': self.io_executor,
+            'transfer_future': self.transfer_future
+        }
+        self.submission_task = self.get_download_submission_task()
+
+    def tearDown(self):
+        super(TestDownloadSubmissionTask, self).tearDown()
+        shutil.rmtree(self.tempdir)
+
+    def get_call_args(self, **kwargs):
+        default_call_args = {
+            'fileobj': self.filename, 'bucket': self.bucket,
+            'key': self.key, 'extra_args': self.extra_args,
+            'subscribers': self.subscribers
+        }
+        default_call_args.update(kwargs)
+        return CallArgs(**default_call_args)
+
+    def wrap_executor_in_recorder(self):
+        self.executor = RecordingExecutor(self.executor)
+        self.submission_main_kwargs['request_executor'] = self.executor
+
+    def use_fileobj_in_call_args(self, fileobj):
+        self.call_args = self.get_call_args(fileobj=fileobj)
+        self.transfer_future = self.get_transfer_future(self.call_args)
+        self.submission_main_kwargs['transfer_future'] = self.transfer_future
+
+    def assert_tag_for_get_object(self, tag_value):
+        submissions_to_compare = self.executor.submissions
+        if len(submissions_to_compare) > 1:
+            # If it was ranged get, make sure we do not include the join task.
+            submissions_to_compare = submissions_to_compare[:-1]
+        for submission in submissions_to_compare:
+            self.assertEqual(
+                submission['tag'], tag_value)
+
+    def add_head_object_response(self):
+        self.stubber.add_response(
+            'head_object', {'ContentLength': len(self.content)})
+
+    def add_get_responses(self):
+        chunksize = self.config.multipart_chunksize
+        for i in range(0, len(self.content), chunksize):
+            if i + chunksize > len(self.content):
+                stream = six.BytesIO(self.content[i:])
+                self.stubber.add_response('get_object', {'Body': stream})
+            else:
+                stream = six.BytesIO(self.content[i:i+chunksize])
+                self.stubber.add_response('get_object', {'Body': stream})
+
+    def configure_for_ranged_get(self):
+        self.config.multipart_threshold = 1
+        self.config.multipart_chunksize = 4
+
+    def get_download_submission_task(self):
+        return self.get_task(
+            DownloadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+
+    def wait_and_assert_completed_successfully(self, submission_task):
+        submission_task()
+        self.transfer_future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_submits_no_tag_for_get_object_filename(self):
+        self.wrap_executor_in_recorder()
+        self.add_head_object_response()
+        self.add_get_responses()
+
+        self.submission_task = self.get_download_submission_task()
+        self.wait_and_assert_completed_successfully(self.submission_task)
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_for_get_object(None)
+
+    def test_submits_no_tag_for_ranged_get_filename(self):
+        self.wrap_executor_in_recorder()
+        self.configure_for_ranged_get()
+        self.add_head_object_response()
+        self.add_get_responses()
+
+        self.submission_task = self.get_download_submission_task()
+        self.wait_and_assert_completed_successfully(self.submission_task)
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_for_get_object(None)
+
+    def test_submits_no_tag_for_get_object_fileobj(self):
+        self.wrap_executor_in_recorder()
+        self.add_head_object_response()
+        self.add_get_responses()
+
+        with open(self.filename, 'wb') as f:
+            self.use_fileobj_in_call_args(f)
+            self.submission_task = self.get_download_submission_task()
+            self.wait_and_assert_completed_successfully(self.submission_task)
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_for_get_object(None)
+
+    def test_submits_no_tag_for_ranged_get_object_fileobj(self):
+        self.wrap_executor_in_recorder()
+        self.configure_for_ranged_get()
+        self.add_head_object_response()
+        self.add_get_responses()
+
+        with open(self.filename, 'wb') as f:
+            self.use_fileobj_in_call_args(f)
+            self.submission_task = self.get_download_submission_task()
+            self.wait_and_assert_completed_successfully(self.submission_task)
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_for_get_object(None)
+
+    def tests_submits_tag_for_get_object_nonseekable_fileobj(self):
+        self.wrap_executor_in_recorder()
+        self.add_head_object_response()
+        self.add_get_responses()
+
+        with open(self.filename, 'wb') as f:
+            self.use_fileobj_in_call_args(NonSeekableWriter(f))
+            self.submission_task = self.get_download_submission_task()
+            self.wait_and_assert_completed_successfully(self.submission_task)
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_for_get_object(IN_MEMORY_DOWNLOAD_TAG)
+
+    def tests_submits_tag_for_ranged_get_object_nonseekable_fileobj(self):
+        self.wrap_executor_in_recorder()
+        self.configure_for_ranged_get()
+        self.add_head_object_response()
+        self.add_get_responses()
+
+        with open(self.filename, 'wb') as f:
+            self.use_fileobj_in_call_args(NonSeekableWriter(f))
+            self.submission_task = self.get_download_submission_task()
+            self.wait_and_assert_completed_successfully(self.submission_task)
+
+        # Make sure no tag to limit that task specifically was not associated
+        # to that task submission.
+        self.assert_tag_for_get_object(IN_MEMORY_DOWNLOAD_TAG)
 
 
 class TestGetObjectTask(BaseTaskTest):


### PR DESCRIPTION
This integrates these two PRs: https://github.com/boto/s3transfer/pull/31 and https://github.com/boto/s3transfer/pull/26

This is the final step to be able to limit non-seekable downloads while perserving use of bandwidth. I probably would not suggest looking at this PR first. The only reason I posted it is to give people a reference as to where I am going with the first two: https://github.com/boto/s3transfer/pull/30 and https://github.com/boto/s3transfer/pull/31. So I would recommend looking at those first.

cc @jamesls @JordonPhillips 