### PR TITLE
Fix a memory leak from future association 

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -114,7 +114,7 @@ class TransferCoordinator(object):
         self._status = 'queued'
         self._result = None
         self._exception = None
-        self._associated_futures = []
+        self._associated_futures = set()
         self._failure_cleanups = []
         self._done_callbacks = []
         self._done_event = threading.Event()
@@ -243,6 +243,7 @@ class TransferCoordinator(object):
         # Add this created future to the list of associated future just
         # in case it is needed during cleanups.
         self.add_associated_future(future)
+        future.add_done_callback(self.remove_associated_future)
         return future
 
     def done(self):
@@ -256,7 +257,12 @@ class TransferCoordinator(object):
     def add_associated_future(self, future):
         """Adds a future to be associated with the TransferFuture"""
         with self._associated_futures_lock:
-            self._associated_futures.append(future)
+            self._associated_futures.add(future)
+
+    def remove_associated_future(self, future):
+        """Removes a future's association to the TransferFuture"""
+        with self._associated_futures_lock:
+            self._associated_futures.remove(future)
 
     def add_done_callback(self, function, *args, **kwargs):
         """Add a done callback to be invoked when transfer is done"""
@@ -289,7 +295,7 @@ class TransferCoordinator(object):
         # Once the process is done, we want to empty the list so we do
         # not hold onto too many completed futures.
         with self._associated_futures_lock:
-            self._associated_futures = []
+            self._associated_futures = set()
 
     def _run_done_callbacks(self):
         # Run the callbacks and remove the callbacks from the internal


### PR DESCRIPTION
We never disassociated the futures until the entire a particular transfer request actually finished. This is a **big** issue for downloads because the io tasks store the data in the task and since their futures never lose reference because of the association that memory never gets cleared up. You do not really notice this for smaller files (< 1GB) but I discovered this when I started to test large downloads ~10GB.

Note that this based off of all of the previous PR's so it may take a while to get this merged, but really only the last commit needs to be reviewed for this specific PR.

cc @jamesls @JordonPhillips 