### PR TITLE
Add ability to configure io chunksize

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -29,8 +29,8 @@ from s3transfer.download import DownloadSubmissionTask
 from s3transfer.upload import UploadSubmissionTask
 from s3transfer.copies import CopySubmissionTask
 
-
-MB = 1024 * 1024
+KB = 1024
+MB = KB * KB
 logger = logging.getLogger(__name__)
 
 
@@ -43,6 +43,7 @@ class TransferConfig(object):
                  max_request_queue_size=0,
                  max_submission_queue_size=0,
                  max_io_queue_size=1000,
+                 io_chunksize=64 * KB,
                  num_download_attempts=5,
                  max_in_memory_upload_chunks=10):
         """Configurations for the transfer mangager
@@ -77,6 +78,10 @@ class TransferConfig(object):
             means that there is no maximum. The default size for each element
             in this queue is 8 KB.
 
+        :param io_chunksize: The max size of each chunk in the io queue.
+            Currently, this is size used when reading from the downloaded
+            stream as well.
+
         :param num_download_attempts: The number of download attempts that
             will be tried upon errors with downloading an object in S3. Note
             that these retries account for errors that occur when streamming
@@ -110,6 +115,7 @@ class TransferConfig(object):
         self.max_request_queue_size = max_request_queue_size
         self.max_submission_queue_size = max_submission_queue_size
         self.max_io_queue_size = max_io_queue_size
+        self.io_chunksize = io_chunksize
         self.num_download_attempts = num_download_attempts
         self.max_in_memory_upload_chunks = max_in_memory_upload_chunks
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -128,12 +128,6 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
                 }
             )
 
-    def set_stream_chunk_size(self, chunk_size):
-        previous_chunk_size = GetObjectTask.STREAM_CHUNK_SIZE
-        GetObjectTask.STREAM_CHUNK_SIZE = chunk_size
-        self.addCleanup(
-            setattr, GetObjectTask, 'STREAM_CHUNK_SIZE',  previous_chunk_size)
-
     def test_download_temporary_file_does_not_exist(self):
         self.add_head_object_response()
         self.add_successful_get_object_responses()
@@ -248,8 +242,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         recorder_subscriber = RecordingSubscriber()
         # Set the streaming to a size that is smaller than the data we
         # currently provide to it to simulate rewinds of callbacks.
-        new_chunk_size = 3
-        self.set_stream_chunk_size(new_chunk_size)
+        self.config.io_chunksize = 3
         future = self.manager.download(
             subscribers=[recorder_subscriber], **self.create_call_kwargs())
         future.result()

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -253,6 +253,7 @@ class TestGetObjectTask(BaseTaskTest):
         self.stream = six.BytesIO(self.content)
         self.fileobj = WriteCollector()
         self.osutil = OSUtils()
+        self.io_chunksize = 64 * (1024 ** 2)
         self.download_output_manager = DownloadSeekableOutputManager(
             self.osutil, self.transfer_coordinator, self.io_executor)
 
@@ -263,6 +264,7 @@ class TestGetObjectTask(BaseTaskTest):
             'callbacks': self.callbacks,
             'max_attempts': self.max_attempts,
             'download_output_manager': self.download_output_manager,
+            'io_chunksize': self.io_chunksize,
         }
         default_kwargs.update(kwargs)
         return self.get_task(GetObjectTask, main_kwargs=default_kwargs)
@@ -303,8 +305,7 @@ class TestGetObjectTask(BaseTaskTest):
             'get_object', service_response={'Body': self.stream},
             expected_params={'Bucket': self.bucket, 'Key': self.key}
         )
-        task = self.get_download_task()
-        task.STREAM_CHUNK_SIZE = 1
+        task = self.get_download_task(io_chunksize=1)
         task()
 
         self.stubber.assert_no_pending_responses()
@@ -375,8 +376,7 @@ class TestGetObjectTask(BaseTaskTest):
             'get_object', service_response={'Body': self.stream},
             expected_params={'Bucket': self.bucket, 'Key': self.key}
         )
-        task = self.get_download_task()
-        task.STREAM_CHUNK_SIZE = 1
+        task = self.get_download_task(io_chunksize=1)
         task()
 
         self.stubber.assert_no_pending_responses()


### PR DESCRIPTION
This is very important for environments that have very fast bandwidth and slow disk writes because if the io chunksize is too small it starts to become the bottleneck when downloading files.

This will be used to help address this issue: https://github.com/boto/boto3/issues/691 as io chunksize configuration is needed to reach the CLI-level performance on those types of environments.

The reason we just do not update the default ``STREAM_CHUNK_SIZE`` to 1MB is that will totally destroy the granularity of callbacks and is not great for slow connections.

As more evidence for this change, the functional tests even needed the change as we would currently patch and return the value of ``STREAM_CHUNKS_SIZE`` in some of the functional download tests, which is a little hacky.

cc @jamesls @JordonPhillips 