### PR TITLE
Increase io_chunksize default

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -44,7 +44,7 @@ class TransferConfig(object):
                  max_request_queue_size=1000,
                  max_submission_queue_size=1000,
                  max_io_queue_size=1000,
-                 io_chunksize=64 * KB,
+                 io_chunksize=256 * KB,
                  num_download_attempts=5,
                  max_in_memory_upload_chunks=10):
         """Configurations for the transfer mangager


### PR DESCRIPTION
This proves to significantly improve speed where the download bandwidth speed is high. The value appears to be a sweet spot with the other default configuration values as the io queue is no longer the bottleneck under these sorts of environments.

Also see the testing notes from this PR: https://github.com/boto/boto3/pull/725

cc @jamesls @JordonPhillips 