### PR TITLE
Remove resetting of associated future set

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -296,14 +296,7 @@ class TransferCoordinator(object):
         if self.status != 'success':
             self._run_failure_cleanups()
         self._done_event.set()
-        self._remove_associated_futures()
         self._run_done_callbacks()
-
-    def _remove_associated_futures(self):
-        # Once the process is done, we want to empty the list so we do
-        # not hold onto too many completed futures.
-        with self._associated_futures_lock:
-            self._associated_futures = set()
 
     def _run_done_callbacks(self):
         # Run the callbacks and remove the callbacks from the internal

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -304,18 +304,6 @@ class TestTransferCoordinator(unittest.TestCase):
             self.transfer_coordinator.associated_futures,
             set([first_future, second_future]))
 
-    def test_associated_futures_on_done(self):
-        future = object()
-        self.transfer_coordinator.add_associated_future(future)
-        self.assertEqual(
-            self.transfer_coordinator.associated_futures, set([future]))
-
-        self.transfer_coordinator.announce_done()
-        # When the transfer completes that means all of the futures have
-        # completed as well, leaving no need to keep the completed futures
-        # around as the transfer is done.
-        self.assertEqual(self.transfer_coordinator.associated_futures, set())
-
     def test_done_callbacks_on_done(self):
         done_callback_invocations = []
         callback = FunctionContainer(


### PR DESCRIPTION
The resetting of the future set was not needed and was actually causing issues
in the done callbacks attached to removing associated futures. The reason it
was there in the first place was because we were not adding done callbacks
to remove a future's association before this was added.

Take the case if the task is the final task. If the task is final it
will completely reset the set of associated futures, but a done
callback would have been attached to the future to complete after that
task is complete. The problem is the task will first wipe out its
associated future set and then try to remove itself from the set,
which will cause an error in the callback because the set is empty.

cc @jamesls @JordonPhillips 