### PR TITLE
Add support for scripts that spin up processes

### DIFF
--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -73,14 +73,11 @@ def run_benchmark(pid, output_file, data_interval):
                 p.kill()
                 break
             time.sleep(data_interval)
-
-            # Sometimes processes can spin up their own processes. We want
-            # to track these.
-            processes_to_track = [p] + p.children(recursive=True)
+            process_to_measure = _get_underlying_python_process(p)
             try:
                 # Collect the memory and cpu usage.
-                memory_used = _get_memory_used(processes_to_track)
-                cpu_percent = _get_cpu_used(processes_to_track)
+                memory_used = process_to_measure.memory_info().rss
+                cpu_percent = process_to_measure.cpu_percent()
                 current_net = psutil.net_io_counters(pernic=True)[INTERFACE]
             except psutil.AccessDenied:
                 # Trying to get process information from a closed process will
@@ -106,18 +103,15 @@ def run_benchmark(pid, output_file, data_interval):
     return 0
 
 
-def _get_memory_used(processes):
-    memory_used = 0
-    for process in processes:
-        memory_used += process.memory_info().rss
-    return memory_used
-
-
-def _get_cpu_used(processes):
-    cpu_used = 0
-    for process in processes:
-        cpu_used += process.cpu_percent()
-    return cpu_used
+def _get_underlying_python_process(process):
+    # For some scripts such as the streaming CLI commands, the process is
+    # nested under a shell script that does not account for the python process.
+    # We want to always be measuring the python process.
+    children = process.children(recursive=True)
+    for child_process in children:
+        if 'python' in child_process.name():
+            return child_process
+    return process
 
 
 def main():

--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -109,7 +109,7 @@ def _get_underlying_python_process(process):
     # We want to always be measuring the python process.
     children = process.children(recursive=True)
     for child_process in children:
-        if 'python' in child_process.name():
+        if 'python' in child_process.name().lower():
             return child_process
     return process
 

--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -59,8 +59,6 @@ def benchmark(args):
 
 
 def run_script(args):
-    # Run the script in a separate process.
-    script_args = args.script.split(' ')
     return subprocess.Popen(args.script, shell=True)
 
 
@@ -76,10 +74,13 @@ def run_benchmark(pid, output_file, data_interval):
                 break
             time.sleep(data_interval)
 
+            # Sometimes processes can spin up their own processes. We want
+            # to track these.
+            processes_to_track = [p] + p.children(recursive=True)
             try:
                 # Collect the memory and cpu usage.
-                memory_used = p.memory_info().rss
-                cpu_percent = p.cpu_percent()
+                memory_used = _get_memory_used(processes_to_track)
+                cpu_percent = _get_cpu_used(processes_to_track)
                 current_net = psutil.net_io_counters(pernic=True)[INTERFACE]
             except psutil.AccessDenied:
                 # Trying to get process information from a closed process will
@@ -103,6 +104,20 @@ def run_benchmark(pid, output_file, data_interval):
                 recv_rate]) + '\n')
             f.flush()
     return 0
+
+
+def _get_memory_used(processes):
+    memory_used = 0
+    for process in processes:
+        memory_used += process.memory_info().rss
+    return memory_used
+
+
+def _get_cpu_used(processes):
+    cpu_used = 0
+    for process in processes:
+        cpu_used += process.cpu_percent()
+    return cpu_used
 
 
 def main():


### PR DESCRIPTION
Before was not able to accurately track aws cli streaming operations relative to memory usage and cpu usage because the streaming tasks spin off processes in piping inputs and outputs. Now with this PR it is possible to track these numbers.

cc @jamesls @JordonPhillips 