### PR TITLE
Add null handler to s3transfer

### DIFF
--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -145,7 +145,15 @@ from s3transfer.exceptions import RetriesExceededError, S3UploadFailedError
 __author__ = 'Amazon Web Services'
 __version__ = '0.1.1'
 
+
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+
 logger = logging.getLogger(__name__)
+logger.addHandler(NullHandler())
+
 queue = six.moves.queue
 
 MB = 1024 * 1024


### PR DESCRIPTION
Related to: https://github.com/boto/boto3/issues/757

Also noted in python docs to do this: https://docs.python.org/3.3/howto/logging.html#configuring-logging-for-a-library

cc @jamesls @JordonPhillips 