### PR TITLE
Update allowed parameters

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -162,7 +162,7 @@ class TransferManager(object):
         'GrantFullControl',
         'GrantRead',
         'GrantReadACP',
-        'GrantWriteACL',
+        'GrantWriteACP',
         'Metadata',
         'RequestPayer',
         'ServerSideEncryption',
@@ -171,6 +171,7 @@ class TransferManager(object):
         'SSECustomerKey',
         'SSECustomerKeyMD5',
         'SSEKMSKeyId',
+        'WebsiteRedirectLocation'
     ]
 
     ALLOWED_COPY_ARGS = ALLOWED_UPLOAD_ARGS + [

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -246,6 +246,11 @@ class TestNonMultipartCopy(BaseCopyTest):
         future.result()
         self.stubber.assert_no_pending_responses()
 
+    def test_allowed_copy_params_are_valid(self):
+        op_model = self.client.meta.service_model.operation_model('CopyObject')
+        for allowed_upload_arg in self._manager.ALLOWED_COPY_ARGS:
+            self.assertIn(allowed_upload_arg, op_model.input_shape.members)
+
 
 class TestMultipartCopy(BaseCopyTest):
     __test__ = True

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -338,6 +338,11 @@ class TestNonRangedDownload(BaseDownloadTest):
         with open(self.filename, 'rb') as f:
             self.assertEqual(self.content, f.read())
 
+    def test_allowed_copy_params_are_valid(self):
+        op_model = self.client.meta.service_model.operation_model('GetObject')
+        for allowed_upload_arg in self._manager.ALLOWED_DOWNLOAD_ARGS:
+            self.assertIn(allowed_upload_arg, op_model.input_shape.members)
+
 
 class TestRangedDownload(BaseDownloadTest):
     # TODO: If you want to add tests outside of this test class and still

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -198,6 +198,11 @@ class TestNonMultipartUpload(BaseUploadTest):
         # sure that the recorded opens are as expected.
         self.assertEqual(osutil.open_records, [(self.filename, 'rb')])
 
+    def test_allowed_upload_params_are_valid(self):
+        op_model = self.client.meta.service_model.operation_model('PutObject')
+        for allowed_upload_arg in self._manager.ALLOWED_UPLOAD_ARGS:
+            self.assertIn(allowed_upload_arg, op_model.input_shape.members)
+
 
 class TestMultipartUpload(BaseUploadTest):
     __test__ = True


### PR DESCRIPTION
GrantWriteACL should be GrantWriteACP and needed to include
WebsiteRedirectLocation as valid parameter for uploads and copies.

Here is the documentation for all of the necessary operations:
https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.put_object
https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.copy_object
https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.complete_multipart_upload

Noticed this when I was working on porting ``s3transfer`` into the CLI.

cc @jamesls @JordonPhillips 