### PR TITLE
Fix issue when uploading a previously seeked file

### DIFF
--- a/.changes/next-release/bugfix-seekableupload-86608.json
+++ b/.changes/next-release/bugfix-seekableupload-86608.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fix issue where seeked position of seekable file for a nonmultipart upload was not being taken into account.",
+  "type": "bugfix",
+  "category": "seekable upload"
+}

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -155,6 +155,17 @@ class TestNonMultipartUpload(BaseUploadTest):
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
 
+    def test_upload_for_seekable_filelike_obj_that_has_been_seeked(self):
+        self.add_put_object_response_with_default_expected_params()
+        bytes_io = six.BytesIO(self.content)
+        seek_pos = 5
+        bytes_io.seek(seek_pos)
+        future = self.manager.upload(
+            bytes_io, self.bucket, self.key, self.extra_args)
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assertEqual(b''.join(self.sent_bodies), self.content[seek_pos:])
+
     def test_upload_for_non_seekable_filelike_obj(self):
         self.add_put_object_response_with_default_expected_params()
         body = NonSeekableReader(self.content)
@@ -325,6 +336,19 @@ class TestMultipartUpload(BaseUploadTest):
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_upload_part_bodies_were_correct()
+
+    def test_upload_for_seekable_filelike_obj_that_has_been_seeked(self):
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params()
+        bytes_io = six.BytesIO(self.content)
+        seek_pos = 1
+        bytes_io.seek(seek_pos)
+        future = self.manager.upload(
+            bytes_io, self.bucket, self.key, self.extra_args)
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assertEqual(b''.join(self.sent_bodies), self.content[seek_pos:])
 
     def test_upload_for_non_seekable_filelike_obj(self):
         self.add_create_multipart_response_with_default_expected_params()

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -265,6 +265,22 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
         self.assertTrue(
             self.upload_input_manager.stores_body_in_memory('upload_part'))
 
+    def test_get_put_object_body(self):
+        start_pos = 3
+        self.fileobj.seek(start_pos)
+        adjusted_size = len(self.content) - start_pos
+        self.future.meta.provide_transfer_size(adjusted_size)
+        read_file_chunk = self.upload_input_manager.get_put_object_body(
+            self.future)
+
+        read_file_chunk.enable_callback()
+        # The fact that the file was seeked to start should be taken into
+        # account in length and content for the read file chunk.
+        self.assertEqual(len(read_file_chunk), adjusted_size)
+        self.assertEqual(read_file_chunk.read(), self.content[start_pos:])
+        self.assertEqual(
+            self.recording_subscriber.calculate_bytes_seen(), adjusted_size)
+
 
 class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
     def setUp(self):


### PR DESCRIPTION
The current position was not being taken into account when providing
the full file size thus the ReadFileChunk wrapper was using an improper
size when calculating length and how much more is needed to be read. Note
that this does not affect the multipart uploads because the original file
object is not used and instead data is chunked out to separate file objects
from the starting position, but a sanity test was added just in case.

Fixes https://github.com/boto/boto3/issues/784

cc @jamesls @JordonPhillips 