### PR TITLE
Add delete() method to the transfer manager

### DIFF
--- a/.changes/next-release/feature-delete-32199.json
+++ b/.changes/next-release/feature-delete-32199.json
@@ -1,0 +1,5 @@
+{
+  "category": "delete", 
+  "type": "feature", 
+  "description": "Add a ``.delete()`` method to the transfer manager."
+}

--- a/s3transfer/delete.py
+++ b/s3transfer/delete.py
@@ -1,0 +1,73 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from s3transfer.tasks import Task
+from s3transfer.tasks import SubmissionTask
+
+
+class DeleteSubmissionTask(SubmissionTask):
+    """Task for submitting tasks to execute an object deletion."""
+
+    def _submit(self, client, config, osutil, request_executor,
+                transfer_future):
+        """
+        :param client: The client associated with the transfer manager
+
+        :type config: s3transfer.manager.TransferConfig
+        :param config: The transfer config associated with the transfer
+            manager
+
+        :type osutil: s3transfer.utils.OSUtil
+        :param osutil: The os utility associated to the transfer manager
+
+        :type request_executor: s3transfer.futures.BoundedExecutor
+        :param request_executor: The request executor associated with the
+            transfer manager
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The transfer future associated with the
+            transfer request that tasks are being submitted for
+        """
+        call_args = transfer_future.meta.call_args
+
+        self._transfer_coordinator.submit(
+            request_executor,
+            DeleteObjectTask(
+                transfer_coordinator=self._transfer_coordinator,
+                main_kwargs={
+                    'client': client,
+                    'bucket': call_args.bucket,
+                    'key': call_args.key,
+                    'extra_args': call_args.extra_args,
+                },
+                is_final=True
+            )
+        )
+
+
+class DeleteObjectTask(Task):
+    def _main(self, client, bucket, key, extra_args):
+        """
+
+        :param client: The S3 client to use when calling DeleteObject
+
+        :type bucket: str
+        :param bucket: The name of the bucket.
+
+        :type key: str
+        :param key: The name of the object to delete.
+
+        :type extra_args: dict
+        :param extra_args: Extra arguments to pass to the DeleteObject call.
+
+        """
+        client.delete_object(Bucket=bucket, Key=key, **extra_args)

--- a/s3transfer/delete.py
+++ b/s3transfer/delete.py
@@ -17,8 +17,7 @@ from s3transfer.tasks import SubmissionTask
 class DeleteSubmissionTask(SubmissionTask):
     """Task for submitting tasks to execute an object deletion."""
 
-    def _submit(self, client, config, osutil, request_executor,
-                transfer_future):
+    def _submit(self, client, request_executor, transfer_future, **kwargs):
         """
         :param client: The client associated with the transfer manager
 

--- a/tests/functional/test_delete.py
+++ b/tests/functional/test_delete.py
@@ -1,0 +1,59 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import BaseGeneralInterfaceTest
+from s3transfer.manager import TransferManager
+
+
+class TestDeleteObject(BaseGeneralInterfaceTest):
+
+    __test__ = True
+
+    def setUp(self):
+        super(TestDeleteObject, self).setUp()
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+        self.manager = TransferManager(self.client)
+
+    @property
+    def method(self):
+        """The transfer manager method to invoke i.e. upload()"""
+        return self.manager.delete
+
+    def create_call_kwargs(self):
+        """The kwargs to be passed to the transfer manager method"""
+        return {
+            'bucket': self.bucket,
+            'key': self.key,
+        }
+
+    def create_invalid_extra_args(self):
+        return {
+            'BadKwargs': True,
+        }
+
+    def create_stubbed_responses(self):
+        """A list of stubbed responses that will cause the request to succeed
+
+        The elements of this list is a dictionary that will be used as key
+        word arguments to botocore.Stubber.add_response(). For example::
+
+            [{'method': 'put_object', 'service_response': {}}]
+        """
+        return [{
+            'method': 'delete_object',
+            'service_response': {},
+            'expected_params': {'Bucket': self.bucket, 'Key': self.key},
+        }]
+
+    def create_expected_progress_callback_info(self):
+        return []

--- a/tests/functional/test_delete.py
+++ b/tests/functional/test_delete.py
@@ -57,3 +57,9 @@ class TestDeleteObject(BaseGeneralInterfaceTest):
 
     def create_expected_progress_callback_info(self):
         return []
+
+    def test_known_allowed_args_in_input_shape(self):
+        op_model = self.client.meta.service_model.operation_model(
+            'DeleteObject')
+        for allowed_arg in self.manager.ALLOWED_DELETE_ARGS:
+            self.assertIn(allowed_arg, op_model.input_shape.members)

--- a/tests/integration/test_delete.py
+++ b/tests/integration/test_delete.py
@@ -29,12 +29,3 @@ class TestDeleteObject(BaseTransferManagerIntegTest):
         future.result()
 
         self.assertFalse(self.object_exists(key_name))
-
-    def test_error_when_object_does_not_exist(self):
-        transfer_manager = self.create_transfer_manager()
-        future = transfer_manager.delete(bucket=self.bucket_name,
-                                         key='does_not_exist')
-        # The underlying DeleteObject API doesn't return any indication
-        # if you try to delete an object that does not exist.
-        result = future.result()
-        self.assertIsNone(result)

--- a/tests/integration/test_delete.py
+++ b/tests/integration/test_delete.py
@@ -1,0 +1,40 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import RecordingSubscriber
+from tests.integration import BaseTransferManagerIntegTest
+from s3transfer.manager import TransferConfig
+
+
+class TestDeleteObject(BaseTransferManagerIntegTest):
+
+    def test_can_delete_object(self):
+        key_name = 'mykey'
+        self.client.put_object(Bucket=self.bucket_name,
+                               Key=key_name, Body=b'hello world')
+        self.assertTrue(self.object_exists(key_name))
+
+        transfer_manager = self.create_transfer_manager()
+        future = transfer_manager.delete(bucket=self.bucket_name,
+                                         key=key_name)
+        future.result()
+
+        self.assertFalse(self.object_exists(key_name))
+
+    def test_error_when_object_does_not_exist(self):
+        transfer_manager = self.create_transfer_manager()
+        future = transfer_manager.delete(bucket=self.bucket_name,
+                                         key='does_not_exist')
+        # The underlying DeleteObject API doesn't return any indication
+        # if you try to delete an object that does not exist.
+        result = future.result()
+        self.assertIsNone(result)

--- a/tests/unit/test_delete.py
+++ b/tests/unit/test_delete.py
@@ -1,0 +1,61 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import BaseTaskTest
+from s3transfer.delete import DeleteObjectTask
+
+
+class TestDeleteObjectTask(BaseTaskTest):
+    def setUp(self):
+        super(TestDeleteObjectTask, self).setUp()
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+        self.extra_args = {}
+        self.callbacks = []
+
+    def get_delete_task(self, **kwargs):
+        default_kwargs = {
+            'client': self.client, 'bucket': self.bucket, 'key': self.key,
+            'extra_args': self.extra_args,
+        }
+        default_kwargs.update(kwargs)
+        return self.get_task(DeleteObjectTask, main_kwargs=default_kwargs)
+
+    def test_main(self):
+        self.stubber.add_response(
+            'delete_object', service_response={},
+            expected_params={
+                'Bucket': self.bucket, 'Key': self.key,
+            }
+        )
+        task = self.get_delete_task()
+        task()
+
+        self.stubber.assert_no_pending_responses()
+
+    def test_extra_args(self):
+        self.extra_args['MFA'] = 'mfa-code'
+        self.extra_args['VersionId'] = '12345'
+        self.stubber.add_response(
+            'delete_object', service_response={},
+            expected_params={
+                'Bucket': self.bucket, 'Key': self.key,
+                # These extra_args should be injected into the
+                # expected params for the delete_object call.
+                'MFA': 'mfa-code',
+                'VersionId': '12345',
+            }
+        )
+        task = self.get_delete_task()
+        task()
+
+        self.stubber.assert_no_pending_responses()


### PR DESCRIPTION
The one thing worth noting is that `on_progress` callbacks are not invoked when an object is deleted.  A case could be made to invoke `on_progress` with the size of the object being deleted, but you'd have to make a `head_object` call to retrieve the size, and it doesn't seem worth the overhead just to get `on_progress` callbacks working for `delete`.  I added a note in the docstring to make this clear.


cc @kyleknap @JordonPhillips 