### PR TITLE
Adjust chunksize if necessary

### DIFF
--- a/.changes/next-release/feature-chunksize-86881.json
+++ b/.changes/next-release/feature-chunksize-86881.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "chunksize",
+  "description": "Automatically adjust the chunksize if it doesn't meet S3s requirements."
+}

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -19,6 +19,7 @@ from s3transfer.tasks import CreateMultipartUploadTask
 from s3transfer.tasks import CompleteMultipartUploadTask
 from s3transfer.utils import get_callbacks
 from s3transfer.utils import calculate_range_parameter
+from s3transfer.utils import ChunksizeAdjuster
 
 
 class CopySubmissionTask(SubmissionTask):
@@ -166,6 +167,9 @@ class CopySubmissionTask(SubmissionTask):
         # Determine how many parts are needed based on filesize and
         # desired chunksize.
         part_size = config.multipart_chunksize
+        adjuster = ChunksizeAdjuster()
+        part_size = adjuster.adjust_chunksize(
+            part_size, transfer_future.meta.size)
         num_parts = int(
             math.ceil(transfer_future.meta.size / float(part_size)))
 

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -13,6 +13,7 @@
 import random
 import time
 import functools
+import math
 import os
 import string
 import logging
@@ -22,6 +23,12 @@ from collections import defaultdict
 from s3transfer.compat import rename_file
 
 
+MAX_PARTS = 10000
+# The maximum file size you can upload via S3 per request.
+# See: http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
+# and: http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+MAX_SINGLE_UPLOAD_SIZE = 5 * (1024 ** 3)
+MIN_UPLOAD_CHUNKSIZE = 5 * (1024 ** 2)
 logger = logging.getLogger(__name__)
 
 
@@ -567,3 +574,58 @@ class SlidingWindowSemaphore(TaskSemaphore):
                     "%s for tag: %s" % (sequence_number, tag))
         finally:
             self._condition.release()
+
+
+class ChunksizeAdjuster(object):
+    def __init__(self, max_size=MAX_SINGLE_UPLOAD_SIZE,
+                 min_size=MIN_UPLOAD_CHUNKSIZE, max_parts=MAX_PARTS):
+        self.max_size = max_size
+        self.min_size = min_size
+        self.max_parts = max_parts
+
+    def adjust_chunksize(self, current_chunksize, file_size=None):
+        """Get a chunksize close to current that fits within all S3 limits.
+
+        :type current_chunksize: int
+        :param current_chunksize: The currently configured chunksize.
+
+        :type file_size: int or None
+        :param file_size: The size of the file to upload. This might be None
+            if the object being transferred has an unknown size.
+
+        :returns: A valid chunksize that fits within configured limits.
+        """
+        chunksize = current_chunksize
+        if file_size is not None:
+            chunksize = self._adjust_for_max_parts(chunksize, file_size)
+        return self._adjust_for_chunksize_limits(chunksize)
+
+    def _adjust_for_chunksize_limits(self, current_chunksize):
+        if current_chunksize > self.max_size:
+            logger.debug(
+                "Chunksize greater than maximum chunksize. "
+                "Setting to %s from %s." % (self.max_size, current_chunksize))
+            return self.max_size
+        elif current_chunksize < self.min_size:
+            logger.debug(
+                "Chunksize less than minimum chunksize. "
+                "Setting to %s from %s." % (self.min_size, current_chunksize))
+            return self.min_size
+        else:
+            return current_chunksize
+
+    def _adjust_for_max_parts(self, current_chunksize, file_size):
+        chunksize = current_chunksize
+        num_parts = int(math.ceil(file_size / float(chunksize)))
+
+        while num_parts > self.max_parts:
+            chunksize *= 2
+            num_parts = int(math.ceil(file_size / float(chunksize)))
+
+        if chunksize != current_chunksize:
+            logger.debug(
+                "Chunksize would result in the number of parts exceeding the "
+                "maximum. Setting to %s from %s." %
+                (chunksize, current_chunksize))
+
+        return chunksize

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -203,7 +203,7 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # Get an iterator that will yield all of the bodies and their
         # respective part number.
         part_iterator = self.upload_input_manager.yield_upload_part_bodies(
-            self.future, self.config)
+            self.future, self.config.multipart_chunksize)
         expected_part_number = 1
         for part_number, read_file_chunk in part_iterator:
             # Ensure that the part number is as expected
@@ -229,7 +229,7 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # Get an iterator that will yield all of the bodies and their
         # respective part number.
         part_iterator = self.upload_input_manager.yield_upload_part_bodies(
-            self.future, self.config)
+            self.future, self.config.multipart_chunksize)
 
         # Set an exception in the transfer coordinator
         self.transfer_coordinator.set_exception(InterruptionError)
@@ -303,8 +303,9 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
                 self.future, self.config))
 
         # Get a list of all the parts that would be sent.
-        parts = list(self.upload_input_manager.yield_upload_part_bodies(
-            self.future, self.config))
+        parts = list(
+            self.upload_input_manager.yield_upload_part_bodies(
+                self.future, self.config.multipart_chunksize))
 
         # Assert that the actual number of parts is what we would expect
         # based on the configuration.

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -36,6 +36,7 @@ from s3transfer.upload import PutObjectTask
 from s3transfer.upload import UploadPartTask
 from s3transfer.utils import CallArgs
 from s3transfer.utils import OSUtils
+from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE
 
 
 class InterruptionError(Exception):
@@ -366,7 +367,9 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         super(TestUploadSubmissionTask, self).setUp()
         self.tempdir = tempfile.mkdtemp()
         self.filename = os.path.join(self.tempdir, 'myfile')
-        self.content = b'my content'
+        self.content = b'0' * (MIN_UPLOAD_CHUNKSIZE * 3)
+        self.config.multipart_chunksize = MIN_UPLOAD_CHUNKSIZE
+        self.config.multipart_threshold = MIN_UPLOAD_CHUNKSIZE * 5
 
         with open(self.filename, 'wb') as f:
             f.write(self.content)
@@ -493,7 +496,6 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         # Set up for a multipart upload.
         self.add_multipart_upload_stubbed_responses()
         self.config.multipart_threshold = 1
-        self.config.multipart_chunksize = 4
 
         self.submission_task = self.get_task(
             UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
@@ -527,7 +529,6 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         # Set up for a multipart upload.
         self.add_multipart_upload_stubbed_responses()
         self.config.multipart_threshold = 1
-        self.config.multipart_chunksize = 4
 
         with open(self.filename, 'rb') as f:
             self.use_fileobj_in_call_args(f)


### PR DESCRIPTION
This will adjust the chunksize of an upload or copy if it is too small, too
large, or if it looks like max parts will be exceeded. This is unnecessary
for downloads since there are no such restrictions for ranged downloading.

cc @kyleknap @jamesls