### PR TITLE
Add aggregated progress callbacks to uploads

### DIFF
--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -18,6 +18,7 @@ import math
 
 from botocore.stub import ANY
 
+from tests import unittest
 from tests import BaseTaskTest
 from tests import BaseSubmissionTaskTest
 from tests import FileSizeProvider
@@ -27,6 +28,7 @@ from tests import NonSeekableReader
 from s3transfer.compat import six
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.manager import TransferConfig
+from s3transfer.upload import AggregatedProgressCallback
 from s3transfer.upload import InterruptReader
 from s3transfer.upload import UploadFilenameInputManager
 from s3transfer.upload import UploadSeekableInputManager
@@ -77,6 +79,50 @@ class BaseUploadTest(BaseTaskTest):
     def collect_body(self, params, **kwargs):
         if 'Body' in params:
             self.sent_bodies.append(params['Body'].read())
+
+
+class TestAggregatedProgressCallback(unittest.TestCase):
+    def setUp(self):
+        self.aggregated_amounts = []
+        self.threshold = 3
+        self.aggregated_progress_callback = AggregatedProgressCallback(
+            self.callback, self.threshold)
+
+    def callback(self, bytes_transferred):
+        self.aggregated_amounts.append(bytes_transferred)
+
+    def test_under_threshold(self):
+        one_under_threshold_amount = self.threshold - 1
+        self.aggregated_progress_callback(one_under_threshold_amount)
+        self.assertEqual(self.aggregated_amounts, [])
+        self.aggregated_progress_callback(1)
+        self.assertEqual(self.aggregated_amounts, [self.threshold])
+
+    def test_at_threshold(self):
+        self.aggregated_progress_callback(self.threshold)
+        self.assertEqual(self.aggregated_amounts, [self.threshold])
+
+    def test_over_threshold(self):
+        over_threshold_amount = self.threshold + 1
+        self.aggregated_progress_callback(over_threshold_amount)
+        self.assertEqual(self.aggregated_amounts, [over_threshold_amount])
+
+    def test_flush(self):
+        under_threshold_amount = self.threshold - 1
+        self.aggregated_progress_callback(under_threshold_amount)
+        self.assertEqual(self.aggregated_amounts, [])
+        self.aggregated_progress_callback.flush()
+        self.assertEqual(self.aggregated_amounts, [under_threshold_amount])
+
+    def test_flush_with_nothing_to_flush(self):
+        under_threshold_amount = self.threshold - 1
+        self.aggregated_progress_callback(under_threshold_amount)
+        self.assertEqual(self.aggregated_amounts, [])
+        self.aggregated_progress_callback.flush()
+        self.assertEqual(self.aggregated_amounts, [under_threshold_amount])
+        # Flushing again should do nothing as it was just flushed
+        self.aggregated_progress_callback.flush()
+        self.assertEqual(self.aggregated_amounts, [under_threshold_amount])
 
 
 class TestInterruptReader(BaseUploadTest):
@@ -177,7 +223,8 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         read_file_chunk.enable_callback()
         # The file-like object provided back should be the same as the content
         # of the file.
-        self.assertEqual(read_file_chunk.read(), self.content)
+        with read_file_chunk:
+            self.assertEqual(read_file_chunk.read(), self.content)
         # The file-like object should also have been wrapped with the
         # on_queued callbacks to track the amount of bytes being transferred.
         self.assertEqual(
@@ -211,9 +258,10 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
             self.assertEqual(part_number, expected_part_number)
             read_file_chunk.enable_callback()
             # Ensure that the body is correct for that part.
-            self.assertEqual(
-                read_file_chunk.read(),
-                self._get_expected_body_for_part(part_number))
+            with read_file_chunk:
+                self.assertEqual(
+                    read_file_chunk.read(),
+                    self._get_expected_body_for_part(part_number))
             expected_part_number += 1
 
         # All of the file-like object should also have been wrapped with the
@@ -277,8 +325,9 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
         read_file_chunk.enable_callback()
         # The fact that the file was seeked to start should be taken into
         # account in length and content for the read file chunk.
-        self.assertEqual(len(read_file_chunk), adjusted_size)
-        self.assertEqual(read_file_chunk.read(), self.content[start_pos:])
+        with read_file_chunk:
+            self.assertEqual(len(read_file_chunk), adjusted_size)
+            self.assertEqual(read_file_chunk.read(), self.content[start_pos:])
         self.assertEqual(
             self.recording_subscriber.calculate_bytes_seen(), adjusted_size)
 


### PR DESCRIPTION
The ``on_progress`` callbacks for uploads are too grainular (like 8KB). This is a problem for faster network environments because if you have any synchronization mechanisms in place for on_progress, it will slow down the transfer substantially because the ``read() ``is often much faster than the mechanisms that may be getting invoked in the callback. The abstraction
aggregates these smaller progress updates into a larger one to help ensure that these slower mechanisms are not called too often. The default of 256KB was chosen as it is still pretty grainular for non-multipart uploads and there is not too much of improvement past that value based off of testing.

I tested this on a couple of machines and I have seen quite a bit of improvements in the CLI integration:
1) Speed. Like I described in the paragraph above
2) Memory. When there are callback for every 8KB, it floods the result queue and the processor cannot keep up.
3) CPU. With 8KB being sent every time, it eats a lot of CPU when constantly having to fight for the lock over the result queue.


cc @jamesls @JordonPhillips 