### PR TITLE
Add support for downloading to special files

### DIFF
--- a/.changes/next-release/bugfix-Download-21108.json
+++ b/.changes/next-release/bugfix-Download-21108.json
@@ -1,0 +1,5 @@
+{
+  "category": "Download", 
+  "type": "bugfix", 
+  "description": "Add support for downloading to special UNIX file by name"
+}

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -15,6 +15,7 @@ import time
 import functools
 import math
 import os
+import stat
 import string
 import logging
 import threading
@@ -242,6 +243,35 @@ class OSUtils(object):
 
     def rename_file(self, current_filename, new_filename):
         rename_file(current_filename, new_filename)
+
+    def is_special_file(cls, filename):
+        """Checks to see if a file is a special UNIX file.
+
+        It checks if the file is a character special device, block special
+        device, FIFO, or socket.
+
+        :param filename: Name of the file
+
+        :returns: True if the file is a special file. False, if is not.
+        """
+        # If it does not exist, it must be a new file so it cannot be
+        # a special file.
+        if not os.path.exists(filename):
+            return False
+        mode = os.stat(filename).st_mode
+        # Character special device.
+        if stat.S_ISCHR(mode):
+            return True
+        # Block special device
+        if stat.S_ISBLK(mode):
+            return True
+        # FIFO.
+        if stat.S_ISFIFO(mode):
+            return True
+        # Socket.
+        if stat.S_ISSOCK(mode):
+            return True
+        return False
 
 
 class DeferredOpenFile(object):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,6 +14,7 @@ import io
 import hashlib
 import math
 import os
+import platform
 import shutil
 import string
 import tempfile
@@ -63,6 +64,22 @@ def random_bucket_name(prefix='s3transfer', num_chars=10):
     base = string.ascii_lowercase + string.digits
     random_bytes = bytearray(os.urandom(num_chars))
     return prefix + ''.join([base[b % len(base)] for b in random_bytes])
+
+
+def skip_if_windows(reason):
+    """Decorator to skip tests that should not be run on windows.
+
+    Example usage:
+
+        @skip_if_windows("Not valid")
+        def test_some_non_windows_stuff(self):
+            self.assertEqual(...)
+
+    """
+    def decorator(func):
+        return unittest.skipIf(
+            platform.system() not in ['Darwin', 'Linux'], reason)(func)
+    return decorator
 
 
 class StreamWithError(object):

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,0 +1,44 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import shutil
+import stat
+import socket
+import tempfile
+
+from tests import unittest
+from tests import skip_if_windows
+from s3transfer.utils import OSUtils
+
+
+@skip_if_windows('Windows does not support UNIX special files')
+class TestOSUtilsSpecialFiles(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.tempdir, 'myfile')
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_character_device(self):
+        self.assertTrue(OSUtils().is_special_file('/dev/null'))
+
+    def test_fifo(self):
+        mode = 0o600 | stat.S_IFIFO
+        os.mknod(self.filename, mode)
+        self.assertTrue(OSUtils().is_special_file(self.filename))
+
+    def test_socket(self):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(self.filename)
+        self.assertTrue(OSUtils().is_special_file(self.filename))

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -34,8 +34,7 @@ class TestOSUtilsSpecialFiles(unittest.TestCase):
         self.assertTrue(OSUtils().is_special_file('/dev/null'))
 
     def test_fifo(self):
-        mode = 0o600 | stat.S_IFIFO
-        os.mknod(self.filename, mode)
+        os.mkfifo(self.filename)
         self.assertTrue(OSUtils().is_special_file(self.filename))
 
     def test_socket(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -260,6 +260,14 @@ class TestOSUtils(BaseUtilsTest):
         self.assertFalse(os.path.exists(self.filename))
         self.assertTrue(os.path.exists(new_filename))
 
+    def test_is_special_file_for_normal_file(self):
+        self.assertFalse(OSUtils().is_special_file(self.filename))
+
+    def test_is_special_file_for_non_existant_file(self):
+        non_existant_filename = os.path.join(self.tempdir, 'no-exist')
+        self.assertFalse(os.path.exists(non_existant_filename))
+        self.assertFalse(OSUtils().is_special_file(non_existant_filename))
+
 
 class TestDefferedOpenFile(BaseUtilsTest):
     def setUp(self):


### PR DESCRIPTION
For UNIX special files like /dev/null, we cannot write to a temporary file and move it over. We need to open the file and write to it directly. Testing this with the CLI and downloading to /dev/null works fine.

Two things to note that comments would be great about:
* I decide if it is a special file name through the ``is_compatible`` methods. I decided to create a new class instead of have it built into ``DownloadFilenameOutputManager`` because it would be a good amount of branching logic based on if we are downloading to a temporary file or not. The one compensation that had to be made is that I had to add osutils as a part of the signature to ``is_compatible``, which I think is fine because it makes sense if you want to introspect the fileobj a bit more in the future to determine compatibility.
* I was having trouble unit testing all of the ``is_special_file`` cases without patching or creating these special files. There is not a great way to test them other than trying them out by hand, which I did when I first implemented it in the CLI (and this is a complete copy and paste). Any suggestions on this would be great. 

cc @jamesls @JordonPhillips 