### PR TITLE
Fix hanging issue when hanging on many files

### DIFF
--- a/.changes/next-release/bugfix-CntrlC-76505.json
+++ b/.changes/next-release/bugfix-CntrlC-76505.json
@@ -1,0 +1,5 @@
+{
+  "category": "Cntrl-C", 
+  "type": "bugfix", 
+  "description": "Fix issue of hangs when Cntrl-C happens for many queued transfers"
+}

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -195,8 +195,8 @@ class TransferCoordinator(object):
 
         Implies the TransferFuture failed.
         """
-        if not self.done():
-            with self._lock:
+        with self._lock:
+            if not self.done():
                 self._exception = exception
                 self._status = 'failed'
 
@@ -222,8 +222,8 @@ class TransferCoordinator(object):
 
     def cancel(self):
         """Cancels the TransferFuture"""
-        if not self.done():
-            with self._lock:
+        with self._lock:
+            if not self.done():
                 should_announce_done = False
                 logger.debug('TransferCoordinator cancel() called')
                 self._exception = futures.CancelledError

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -131,6 +131,10 @@ class TransferCoordinator(object):
         self._done_callbacks_lock = threading.Lock()
         self._failure_cleanups_lock = threading.Lock()
 
+    def __repr__(self):
+        return '%s(transfer_id=%s)' % (
+            self.__class__.__name__, self.transfer_id)
+
     @property
     def exception(self):
         return self._exception

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -235,12 +235,19 @@ class TransferCoordinator(object):
 
     def set_status_to_queued(self):
         """Sets the TransferFutrue's status to running"""
-        self._status = 'queued'
+        self._transition_to_non_done_state('queued')
 
     def set_status_to_running(self):
         """Sets the TransferFuture's status to running"""
+        self._transition_to_non_done_state('running')
+
+    def _transition_to_non_done_state(self, desired_state):
         with self._lock:
-            self._status = 'running'
+            if self.done():
+                raise RuntimeError(
+                    'Unable to transition from done state %s to non-done '
+                    'state %s.' % (self.status, desired_state))
+            self._status = desired_state
 
     def submit(self, executor, task, tag=None):
         """Submits a task to a provided executor

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -586,6 +586,13 @@ class TransferCoordinatorController(object):
             # If Keyboard interrupt is raised while waiting for
             # the result, then exit out of the wait and raise the
             # exception
+            if transfer_coordinator:
+                logger.debug(
+                    'On KeyboardInterrupt was waiting for '
+                    '%s of status %s and associated futures %s',
+                    transfer_coordinator,
+                    transfer_coordinator.status,
+                    transfer_coordinator.associated_futures)
             raise
         except Exception:
             # A general exception could have been thrown because

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -588,11 +588,8 @@ class TransferCoordinatorController(object):
             # exception
             if transfer_coordinator:
                 logger.debug(
-                    'On KeyboardInterrupt was waiting for '
-                    '%s of status %s and associated futures %s',
-                    transfer_coordinator,
-                    transfer_coordinator.status,
-                    transfer_coordinator.associated_futures)
+                    'On KeyboardInterrupt was waiting for %s',
+                    transfer_coordinator)
             raise
         except Exception:
             # A general exception could have been thrown because

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -579,6 +579,7 @@ class TransferCoordinatorController(object):
         a KeyboardInterrupt.
         """
         try:
+            transfer_coordinator = None
             for transfer_coordinator in self.tracked_transfer_coordinators:
                 transfer_coordinator.result()
         except KeyboardInterrupt:

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -240,6 +240,8 @@ class SubmissionTask(Task):
             to the _submit() method
         """
         try:
+            self._transfer_coordinator.set_status_to_queued()
+
             # Before submitting any tasks, run all of the on_queued callbacks
             on_queued_callbacks = get_callbacks(transfer_future, 'queued')
             for on_queued_callback in on_queued_callbacks:

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -85,7 +85,9 @@ class Task(object):
         ]
         main_kwargs_to_display = self._get_kwargs_with_params_to_include(
             self._main_kwargs, params_to_display)
-        return '%s(%s)' % (self.__class__.__name__, main_kwargs_to_display)
+        return '%s(transfer_id=%s, %s)' % (
+            self.__class__.__name__, self._transfer_coordinator.transfer_id,
+            main_kwargs_to_display)
 
     @property
     def transfer_id(self):

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -84,7 +84,11 @@ class TestDownload(BaseTransferManagerIntegTest):
         # This means that it should take less than a couple second after
         # sleeping to exit.
         max_allowed_exit_time = sleep_time + 1
-        self.assertTrue(end_time - start_time < max_allowed_exit_time)
+        self.assertLess(
+            end_time - start_time, max_allowed_exit_time,
+            "Failed to exit under %s. Instead exited in %s." % (
+                max_allowed_exit_time, end_time - start_time)
+        )
 
         # Make sure the future was cancelled because of the KeyboardInterrupt
         with self.assertRaises(CancelledError):
@@ -128,7 +132,11 @@ class TestDownload(BaseTransferManagerIntegTest):
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple seconds to exit.
         max_allowed_exit_time = 2
-        self.assertTrue(end_time - start_time < max_allowed_exit_time)
+        self.assertLess(
+            end_time - start_time, max_allowed_exit_time,
+            "Failed to exit under %s. Instead exited in %s." % (
+                max_allowed_exit_time, end_time - start_time)
+        )
 
         # Make sure at least one of the futures got cancelled
         with self.assertRaises(CancelledError):

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -95,6 +95,51 @@ class TestDownload(BaseTransferManagerIntegTest):
         possible_matches = glob.glob('%s*' % download_path)
         self.assertEqual(possible_matches, [])
 
+    def test_many_files_exits_quicky_on_exception(self):
+        # Set the max request queue size and number of submission threads
+        # to something small to simulate having a large queue
+        # of transfer requests to complete and it is backed up.
+        self.config.max_request_queue_size = 1
+        self.config.max_submission_concurrency = 1
+        transfer_manager = self.create_transfer_manager(self.config)
+
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        self.upload_file(filename, '1mb.txt')
+
+        filenames = []
+        futures = []
+        for i in range(10):
+            filenames.append(
+                os.path.join(self.files.rootdir, 'file'+str(i)))
+
+        try:
+            with transfer_manager:
+                start_time = time.time()
+                for filename in filenames:
+                    futures.append(transfer_manager.download(
+                        self.bucket_name, '1mb.txt', filename))
+                # Raise an exception which should cause the preceeding
+                # transfer to cancel and exit quickly
+                raise KeyboardInterrupt()
+        except KeyboardInterrupt:
+            pass
+        end_time = time.time()
+        # The maximum time allowed for the transfer manager to exit.
+        # This means that it should take less than a couple seconds to exit.
+        max_allowed_exit_time = 2
+        self.assertTrue(end_time - start_time < max_allowed_exit_time)
+
+        # Make sure at least one of the futures got cancelled
+        with self.assertRaises(CancelledError):
+            for future in futures:
+                future.result()
+
+        # For the transfer that did get cancelled, make sure the temporary
+        # file got removed.
+        possible_matches = glob.glob('%s*' % future.meta.call_args.fileobj)
+        self.assertEqual(possible_matches, [])
+
     def test_progress_subscribers_on_download(self):
         subscriber = RecordingSubscriber()
         transfer_manager = self.create_transfer_manager(self.config)

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -73,7 +73,11 @@ class TestUpload(BaseTransferManagerIntegTest):
         # This means that it should take less than a couple second after
         # sleeping to exit.
         max_allowed_exit_time = sleep_time + 2
-        self.assertTrue(end_time - start_time < max_allowed_exit_time)
+        self.assertLess(
+            end_time - start_time, max_allowed_exit_time,
+            "Failed to exit under %s. Instead exited in %s." % (
+                max_allowed_exit_time, end_time - start_time)
+        )
 
         try:
             future.result()
@@ -117,7 +121,11 @@ class TestUpload(BaseTransferManagerIntegTest):
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple seconds to exit.
         max_allowed_exit_time = 2
-        self.assertTrue(end_time - start_time < max_allowed_exit_time)
+        self.assertLess(
+            end_time - start_time, max_allowed_exit_time,
+            "Failed to exit under %s. Instead exited in %s." % (
+                max_allowed_exit_time, end_time - start_time)
+        )
 
         # Make sure at least one of the futures got cancelled
         with self.assertRaises(CancelledError):

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -515,6 +515,7 @@ class TestGetObjectTask(BaseTaskTest):
             'io_chunksize': self.io_chunksize,
         }
         default_kwargs.update(kwargs)
+        self.transfer_coordinator.set_status_to_queued()
         return self.get_task(GetObjectTask, main_kwargs=default_kwargs)
 
     def assert_io_writes(self, expected_writes):

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -142,9 +142,19 @@ class TestTransferCoordinator(unittest.TestCase):
         self.transfer_coordinator.set_status_to_queued()
         self.assertEqual(self.transfer_coordinator.status, 'queued')
 
+    def test_cannot_set_status_to_queued_from_done_state(self):
+        self.transfer_coordinator.set_exception(RuntimeError)
+        with self.assertRaises(RuntimeError):
+            self.transfer_coordinator.set_status_to_queued()
+
     def test_status_running(self):
         self.transfer_coordinator.set_status_to_running()
         self.assertEqual(self.transfer_coordinator.status, 'running')
+
+    def test_cannot_set_status_to_running_from_done_state(self):
+        self.transfer_coordinator.set_exception(RuntimeError)
+        with self.assertRaises(RuntimeError):
+            self.transfer_coordinator.set_status_to_running()
 
     def test_set_result(self):
         success_result = 'foo'

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -128,6 +128,11 @@ class TestTransferCoordinator(unittest.TestCase):
         transfer_coordinator = TransferCoordinator(transfer_id=1)
         self.assertEqual(transfer_coordinator.transfer_id, 1)
 
+    def test_repr(self):
+        transfer_coordinator = TransferCoordinator(transfer_id=1)
+        self.assertEqual(
+            repr(transfer_coordinator), 'TransferCoordinator(transfer_id=1)')
+
     def test_initial_status(self):
         # A TransferCoordinator with no progress should have the status
         # of queued

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -135,7 +135,11 @@ class TestTransferCoordinator(unittest.TestCase):
 
     def test_initial_status(self):
         # A TransferCoordinator with no progress should have the status
-        # of queued
+        # of not-started
+        self.assertEqual(self.transfer_coordinator.status, 'not-started')
+
+    def test_set_status_to_queued(self):
+        self.transfer_coordinator.set_status_to_queued()
         self.assertEqual(self.transfer_coordinator.status, 'queued')
 
     def test_status_running(self):
@@ -170,10 +174,11 @@ class TestTransferCoordinator(unittest.TestCase):
         self.assertEqual(self.transfer_coordinator.status, 'success')
 
     def test_cancel(self):
+        self.assertEqual(self.transfer_coordinator.status, 'not-started')
         self.transfer_coordinator.cancel()
-        self.transfer_coordinator.announce_done()
         # This should set the state to cancelled and raise the CancelledError
-        # exception.
+        # exception and should have also set the done event so that result()
+        # is no longer set.
         self.assertEqual(self.transfer_coordinator.status, 'cancelled')
         with self.assertRaises(CancelledError):
             self.transfer_coordinator.result()

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -297,6 +297,22 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
         self.assertEqual(self.transfer_coordinator.status, 'failed')
         self.assertEqual(invocations_of_cleanup, ['cleanup happened'])
 
+    def test_submission_task_announces_done_if_cancelled_before_main(self):
+        invocations_of_done = []
+        done_callback = FunctionContainer(
+            invocations_of_done.append, 'done announced')
+        self.transfer_coordinator.add_done_callback(done_callback)
+
+        self.transfer_coordinator.cancel()
+        submission_task = self.get_task(
+            NOOPSubmissionTask, main_kwargs=self.main_kwargs)
+        submission_task()
+
+        # Because the submission task was cancelled before being run
+        # it did not submit any extra tasks so a result it is responsible
+        # for making sure it announces done as nothing else will.
+        self.assertEqual(invocations_of_done, ['done announced'])
+
 
 class TestTask(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -331,7 +331,8 @@ class TestTask(unittest.TestCase):
         # a desired parameter to include.
         self.assertEqual(
             repr(task),
-            'ReturnKwargsTask(%s)' % {'bucket': 'mybucket'}
+            'ReturnKwargsTask(transfer_id=%s, %s)' % (
+                self.transfer_id, {'bucket': 'mybucket'})
         )
 
     def test_transfer_id(self):


### PR DESCRIPTION
This PR fixes an issue where if there is a bunch of transfer queued up in the submission executor and a Cntrl-C cancels the entire transfer, the entire transfer will hang. Essentially it boils down to the fact in the ``TransferManager.__exit__`` we will call ``TransferFutures.result()`` for all transfers that have not completed. Then if a transfer has been queued but not processed by the submission executor, the submission task's ``_main()`` will not be called because it will see that the transfer is cancelled. The problem though is that done needs to be announced to unblock ``TransferFutures.result()`` and the submission task relies on the tasks it submits to announce done. So if the submission task never submits tasks, done will never be announced.

The fix is to announce done in the submission task if we know its ``_main()`` is going to be skipped over. 

Among this change I did the following to compliment it:
* I added integration tests to catch this. I added them before implementing the fix and they were failing pretty much every time so that was good.
* I added transfer_id to the repr of ``Task`` and ``TransferCoordinator``. This will make it easier for us to determine what tasks are coordinators are related to a specific transfer and debugging for the future.
* Added some debugging in the ``wait()`` where if the transfer was hanging it will tell us what transfer it was waiting on before the user hit Cntrl-C and give us a better indication on what may be hanging in the future.

cc @jamesls @JordonPhillips 