### PR TITLE
Add message to cancel()

### DIFF
--- a/.changes/next-release/feature-cancel-20853.json
+++ b/.changes/next-release/feature-cancel-20853.json
@@ -1,0 +1,5 @@
+{
+  "category": "cancel", 
+  "type": "feature", 
+  "description": "Expose messages for cancels"
+}

--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from concurrent.futures import CancelledError
 
 
 class RetriesExceededError(Exception):

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -17,6 +17,7 @@ import logging
 import threading
 
 from s3transfer.compat import MAXINT
+from s3transfer.exceptions import CancelledError
 from s3transfer.utils import FunctionContainer
 from s3transfer.utils import TaskSemaphore
 
@@ -220,13 +221,16 @@ class TransferCoordinator(object):
                 raise self._exception
             return self._result
 
-    def cancel(self):
-        """Cancels the TransferFuture"""
+    def cancel(self, msg=''):
+        """Cancels the TransferFuture
+
+        :param msg: The message to attach to the cancellation
+        """
         with self._lock:
             if not self.done():
                 should_announce_done = False
-                logger.debug('TransferCoordinator cancel() called')
-                self._exception = futures.CancelledError
+                logger.debug('%s cancel(%s) called', self, msg)
+                self._exception = CancelledError(msg)
                 if self._status == 'not-started':
                     should_announce_done = True
                 self._status = 'cancelled'

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -562,14 +562,17 @@ class TransferCoordinatorController(object):
         with self._lock:
             self._tracked_transfer_coordinators.remove(transfer_coordinator)
 
-    def cancel(self):
+    def cancel(self, msg=''):
         """Cancels all inprogress transfers
 
         This cancels the inprogress transfers by calling cancel() on all
         tracked transfer coordinators.
+
+        :params msg: The message to pass on to each transfer coordinator that
+            gets cancelled.
         """
         for transfer_coordinator in self.tracked_transfer_coordinators:
-            transfer_coordinator.cancel()
+            transfer_coordinator.cancel(msg)
 
     def wait(self):
         """Wait until there are no more inprogress transfers

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -515,13 +515,15 @@ class TransferManager(object):
             # wrapped in a try statement because this can be interrupted
             # with a KeyboardInterrupt that needs to be caught.
             self._coordinator_controller.wait()
-        finally:
+        except KeyboardInterrupt as e:
             # If not errors were raised in the try block, the cancel should
             # have no coordinators it needs to run cancel on. If there was
             # an error raised in the try statement we want to cancel all of
             # the inflight transfers before shutting down to speed that
             # process up.
-            self._coordinator_controller.cancel()
+            self._coordinator_controller.cancel('keyboard interrupt')
+            raise e
+        finally:
             # Shutdown all of the executors.
             self._submission_executor.shutdown()
             self._request_executor.shutdown()

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -486,9 +486,9 @@ class TransferManager(object):
         # all of the inprogress futures in the shutdown.
         if exc_type:
             cancel = True
-            cancel_msg = exc_value
-            if exc_type == KeyboardInterrupt:
-                cancel_msg = 'keyboard interrupt'
+            cancel_msg = str(exc_value)
+            if not cancel_msg:
+                cancel_msg = repr(exc_value)
         self.shutdown(cancel, cancel_msg)
 
     def shutdown(self, cancel=False, cancel_msg=''):
@@ -515,14 +515,14 @@ class TransferManager(object):
             # wrapped in a try statement because this can be interrupted
             # with a KeyboardInterrupt that needs to be caught.
             self._coordinator_controller.wait()
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             # If not errors were raised in the try block, the cancel should
             # have no coordinators it needs to run cancel on. If there was
             # an error raised in the try statement we want to cancel all of
             # the inflight transfers before shutting down to speed that
             # process up.
-            self._coordinator_controller.cancel('keyboard interrupt')
-            raise e
+            self._coordinator_controller.cancel('KeyboardInterrupt()')
+            raise
         finally:
             # Shutdown all of the executors.
             self._submission_executor.shutdown()

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -80,6 +80,7 @@ class TestTransferManager(StubbedClientTest):
         except KeyboardInterrupt:
             # At least one of the submitted futures should have been
             # cancelled.
-            with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
+            with self.assertRaisesRegexp(
+                    CancelledError, 'KeyboardInterrupt()'):
                 for future in futures:
                     future.result()

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -1,0 +1,85 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import StubbedClientTest
+from s3transfer.exceptions import CancelledError
+from s3transfer.manager import TransferManager
+from s3transfer.manager import TransferConfig
+
+
+class ArbitraryException(Exception):
+    pass
+
+
+class TestTransferManager(StubbedClientTest):
+    def test_error_in_context_manager_cancels_incomplete_transfers(self):
+        # The purpose of this test is to make sure if an error is raised
+        # in the body of the context manager, incomplete transfers will
+        # be cancelled with value of the exception wrapped by a CancelledError
+
+        # NOTE: The fact that delete() was chosen to test this is arbitrary
+        # other than it is the easiet to set up for the stubber.
+        # The specific operation is not important to the purpose of this test.
+        num_transfers = 100
+        futures = []
+        ref_exception_msg = 'arbitrary exception'
+
+        for _ in range(num_transfers):
+            self.stubber.add_response('delete_object', {})
+
+        manager = TransferManager(
+            self.client,
+            TransferConfig(
+                max_request_concurrency=1, max_submission_concurrency=1)
+        )
+        try:
+            with manager:
+                for i in range(num_transfers):
+                    futures.append(manager.delete('mybucket', 'mykey'))
+                raise ArbitraryException(ref_exception_msg)
+        except ArbitraryException:
+            # At least one of the submitted futures should have been
+            # cancelled.
+            with self.assertRaisesRegexp(CancelledError, ref_exception_msg):
+                for future in futures:
+                    future.result()
+
+    def test_cntrl_c_in_context_manager_cancels_incomplete_transfers(self):
+        # The purpose of this test is to make sure if an error is raised
+        # in the body of the context manager, incomplete transfers will
+        # be cancelled with value of the exception wrapped by a CancelledError
+
+        # NOTE: The fact that delete() was chosen to test this is arbitrary
+        # other than it is the easiet to set up for the stubber.
+        # The specific operation is not important to the purpose of this test.
+        num_transfers = 100
+        futures = []
+
+        for _ in range(num_transfers):
+            self.stubber.add_response('delete_object', {})
+
+        manager = TransferManager(
+            self.client,
+            TransferConfig(
+                max_request_concurrency=1, max_submission_concurrency=1)
+        )
+        try:
+            with manager:
+                for i in range(num_transfers):
+                    futures.append(manager.delete('mybucket', 'mykey'))
+                raise KeyboardInterrupt()
+        except KeyboardInterrupt:
+            # At least one of the submitted futures should have been
+            # cancelled.
+            with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
+                for future in futures:
+                    future.result()

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -91,7 +91,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         )
 
         # Make sure the future was cancelled because of the KeyboardInterrupt
-        with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
+        with self.assertRaisesRegexp(CancelledError, 'KeyboardInterrupt()'):
             future.result()
 
         # Make sure the actual file and the temporary do not exist
@@ -139,7 +139,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         )
 
         # Make sure at least one of the futures got cancelled
-        with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
+        with self.assertRaisesRegexp(CancelledError, 'KeyboardInterrupt()'):
             for future in futures:
                 future.result()
 

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -91,7 +91,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         )
 
         # Make sure the future was cancelled because of the KeyboardInterrupt
-        with self.assertRaises(CancelledError):
+        with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
             future.result()
 
         # Make sure the actual file and the temporary do not exist
@@ -139,7 +139,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         )
 
         # Make sure at least one of the futures got cancelled
-        with self.assertRaises(CancelledError):
+        with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
             for future in futures:
                 future.result()
 

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -84,7 +84,8 @@ class TestUpload(BaseTransferManagerIntegTest):
             self.skipTest(
                 'Upload completed before interrupted and therefore '
                 'could not cancel the upload')
-        except CancelledError:
+        except CancelledError as e:
+            self.assertEqual(str(e), 'keyboard interrupt')
             # If the transfer did get cancelled,
             # make sure the object does not exist.
             self.assertFalse(self.object_exists('20mb.txt'))
@@ -128,7 +129,7 @@ class TestUpload(BaseTransferManagerIntegTest):
         )
 
         # Make sure at least one of the futures got cancelled
-        with self.assertRaises(CancelledError):
+        with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
             for future in futures:
                 future.result()
         # For the transfer that did get cancelled, make sure the object

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -85,7 +85,7 @@ class TestUpload(BaseTransferManagerIntegTest):
                 'Upload completed before interrupted and therefore '
                 'could not cancel the upload')
         except CancelledError as e:
-            self.assertEqual(str(e), 'keyboard interrupt')
+            self.assertEqual(str(e), 'KeyboardInterrupt()')
             # If the transfer did get cancelled,
             # make sure the object does not exist.
             self.assertFalse(self.object_exists('20mb.txt'))
@@ -129,7 +129,7 @@ class TestUpload(BaseTransferManagerIntegTest):
         )
 
         # Make sure at least one of the futures got cancelled
-        with self.assertRaisesRegexp(CancelledError, 'keyboard interrupt'):
+        with self.assertRaisesRegexp(CancelledError, 'KeyboardInterrupt()'):
             for future in futures:
                 future.result()
         # For the transfer that did get cancelled, make sure the object

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -12,11 +12,11 @@
 # language governing permissions and limitations under the License.
 import time
 from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import CancelledError
 
 from tests import unittest
 from tests import RecordingExecutor
 from tests import TransferCoordinatorWithInterrupt
+from s3transfer.exceptions import CancelledError
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferCoordinator
@@ -192,6 +192,13 @@ class TestTransferCoordinator(unittest.TestCase):
         # is no longer set.
         self.assertEqual(self.transfer_coordinator.status, 'cancelled')
         with self.assertRaises(CancelledError):
+            self.transfer_coordinator.result()
+
+    def test_cancel_with_message(self):
+        message = 'my message'
+        self.transfer_coordinator.cancel(message)
+        self.transfer_coordinator.announce_done()
+        with self.assertRaisesRegexp(CancelledError, message):
             self.transfer_coordinator.result()
 
     def test_cancel_cannot_override_done_state(self):

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from tests import unittest
 from tests import TransferCoordinatorWithInterrupt
+from s3transfer.exceptions import CancelledError
 from s3transfer.futures import TransferCoordinator
 from s3transfer.manager import TransferConfig
 from s3transfer.manager import TransferCoordinatorController
@@ -74,6 +75,16 @@ class TestTransferCoordinatorController(unittest.TestCase):
         self.coordinator_controller.cancel()
         # Check that coordinator got canceled
         self.assert_coordinator_is_cancelled(transfer_coordinator)
+
+    def test_cancel_with_message(self):
+        message = 'my cancel message'
+        transfer_coordinator = TransferCoordinator()
+        self.coordinator_controller.add_transfer_coordinator(
+            transfer_coordinator)
+        self.coordinator_controller.cancel(message)
+        transfer_coordinator.announce_done()
+        with self.assertRaisesRegexp(CancelledError, message):
+            transfer_coordinator.result()
 
     def test_wait_for_done_transfer_coordinators(self):
         # Create a coordinator and add it to the canceler


### PR DESCRIPTION
This builds off of this PR: https://github.com/boto/s3transfer/pull/55 so that one should get reviewed first.

The main changes that I exposed a message so that you can gain some introspection on why a transfer got cancelled. This is very useful for subscribers and calling future.result() because a general ``CancelledError`` is not too insightful and I plan to use this in the integration to the CLI to track fatal errors.

cc @jamesls @JordonPhillips 