### PR TITLE
Fix various deadlock issues when debugging

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -167,8 +167,7 @@ class TransferCoordinator(object):
             * failed - An exception other than CancelledError was thrown
             * success - No exceptions were thrown and is done.
         """
-        with self._lock:
-            return self._status
+        return self._status
 
     def set_result(self, result):
         """Set a result for the TransferFuture


### PR DESCRIPTION
The key here is that to not include something that will obtain a lock during the formatting as the logger itself acquires a lock as well. There are two places where this happened:

1)  ``concurrent.futures.Future.__repr__``. To fix that I added an ``ExecutorFuture`` which essentially wraps around ``concurrent.futures.Future``. It allows us to do things. First and most immediate, ``__repr__`` of ``Future`` uses a lock and that can cause deadlocks with logging if you are logging the object. Second, it allows to move off of ``concurrent.futures`` in the future since the rest of this codebase now relies on ``ExecutorFuture``.
2) ``TransferCoordinator.status`` unnecessarily used a lock

cc @jamesls @JordonPhillips 



