### PR TITLE
Add option to print summary as json

### DIFF
--- a/scripts/performance/summarize
+++ b/scripts/performance/summarize
@@ -183,7 +183,7 @@ class Summarizer(object):
             ['Average CPU (percent)', '%.1f' % self.average_cpu,
              self.std_dev_average_cpu],
         ]
-        result = tabulate(
+        return tabulate(
             table,
             headers=[
                 'Metric over %s run(s)' % (self.total_files),
@@ -192,13 +192,11 @@ class Summarizer(object):
             ],
             tablefmt="grid"
         )
-        return result
 
     def summarize_as_json(self):
         """Return JSON summary of processed data.
 
         :return: str of formatted JSON
-
         """
         return json.dumps({
             'total_time': self.total_time,
@@ -304,7 +302,7 @@ def main():
         result = summarizer.summarize_as_table()
     else:
         result = summarizer.summarize_as_json()
-    print result
+    print(result)
 
 
 if __name__ == '__main__':

--- a/scripts/performance/summarize
+++ b/scripts/performance/summarize
@@ -46,9 +46,26 @@ And will have a similar output:
     +------------------------+----------+----------------------+
     | Average CPU (percent)  | 27.5     | 3.03068181818        |
     +------------------------+----------+----------------------+
+
+
+You can also specify the ``--output-format json`` option to print the
+summary as JSON instead of a pretty printed table::
+
+    {
+      "total_time": 72.76999998092651,
+      "std_dev_average_memory": 0.0,
+      "std_dev_total_time": 0.0,
+      "average_memory": 56884518.57534247,
+      "std_dev_average_cpu": 0.0,
+      "std_dev_max_memory": 0.0,
+      "average_cpu": 61.19315068493151,
+      "max_memory": 58331136.0
+    }
+
 """
 import argparse
 import csv
+import json
 from math import sqrt
 
 from tabulate import tabulate
@@ -110,8 +127,7 @@ class Summarizer(object):
 
     @property
     def max_memory(self):
-        return human_readable_size(
-            self._average_across_all_files('max_memory'))
+        return self._average_across_all_files('max_memory')
 
     @property
     def average_cpu(self):
@@ -119,8 +135,7 @@ class Summarizer(object):
 
     @property
     def average_memory(self):
-        return human_readable_size(
-            self._average_across_all_files('average_memory'))
+        return self._average_across_all_files('average_memory')
 
     @property
     def std_dev_total_time(self):
@@ -132,8 +147,7 @@ class Summarizer(object):
 
     @property
     def std_dev_max_memory(self):
-        return human_readable_size(
-            self._standard_deviation_across_all_files('max_memory'))
+        return self._standard_deviation_across_all_files('max_memory')
 
     @property
     def std_dev_average_cpu(self):
@@ -141,8 +155,7 @@ class Summarizer(object):
 
     @property
     def std_dev_average_memory(self):
-        return human_readable_size(
-            self._standard_deviation_across_all_files('average_memory'))
+        return self._standard_deviation_across_all_files('average_memory')
 
     def _average_across_all_files(self, name):
         return sum(self._totals[name])/len(self._totals[name])
@@ -153,30 +166,50 @@ class Summarizer(object):
         sq_differences = [difference ** 2 for difference in differences]
         return sqrt(sum(sq_differences)/len(self._totals[name]))
 
-    def summarize(self):
-        """Prints out the processed data"""
+    def summarize_as_table(self):
+        """Formats the processed data as pretty printed table.
+
+        :return: str of formatted table
+        """
+        h = human_readable_size
         table = [
             ['Total Time (seconds)', '%.3f' % self.total_time,
              self.std_dev_total_time],
-            ['Maximum Memory', self.max_memory, self.std_dev_max_memory],
+            ['Maximum Memory', h(self.max_memory), h(self.std_dev_max_memory)],
             ['Maximum CPU (percent)',  '%.1f' % self.max_cpu,
              self.std_dev_max_cpu],
-            ['Average Memory', self.average_memory,
-             self.std_dev_average_memory],
+            ['Average Memory', h(self.average_memory),
+             h(self.std_dev_average_memory)],
             ['Average CPU (percent)', '%.1f' % self.average_cpu,
              self.std_dev_average_cpu],
         ]
-        print(
-            tabulate(
-                table,
-                headers=[
-                    'Metric over %s run(s)' % (self.total_files),
-                    'Mean',
-                    'Standard Deviation'
-                ],
-                tablefmt="grid"
-            )
+        result = tabulate(
+            table,
+            headers=[
+                'Metric over %s run(s)' % (self.total_files),
+                'Mean',
+                'Standard Deviation'
+            ],
+            tablefmt="grid"
         )
+        return result
+
+    def summarize_as_json(self):
+        """Return JSON summary of processed data.
+
+        :return: str of formatted JSON
+
+        """
+        return json.dumps({
+            'total_time': self.total_time,
+            'std_dev_total_time': self.std_dev_total_time,
+            'max_memory': self.max_memory,
+            'std_dev_max_memory': self.std_dev_max_memory,
+            'average_memory': self.average_memory,
+            'std_dev_average_memory': self.std_dev_average_memory,
+            'average_cpu': self.average_cpu,
+            'std_dev_average_cpu': self.std_dev_average_cpu,
+        }, indent=2)
 
     def process(self, args):
         """Processes the data from the CSV file"""
@@ -256,10 +289,23 @@ def main():
             'across all of the files for each metric.'
         )
     )
+    parser.add_argument(
+        '-f', '--output-format', default='table', choices=['table', 'json'],
+        help=(
+            'Specify what output format to use for displaying results. '
+            'By default, a pretty printed table is used, but you can also '
+            'specify "json" to display pretty printed JSON.'
+        )
+    )
     args = parser.parse_args()
     summarizer = Summarizer()
     summarizer.process(args)
-    summarizer.summarize()
+    if args.output_format == 'table':
+        result = summarizer.summarize_as_table()
+    else:
+        result = summarizer.summarize_as_json()
+    print result
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The JSON format also does not format the numerical data to
human readable numbers.  This makes it easier to compare numerical
differences across multiple summaries.

cc @kyleknap @JordonPhillips 