### PR TITLE
Create own version of ThreadPoolExecutor

### DIFF
--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -47,12 +47,16 @@ if six.PY3:
     # ConnectionError
     SOCKET_ERROR = ConnectionError
     MAXINT = None
+    TimeoutError = TimeoutError
 else:
     def accepts_kwargs(func):
         return inspect.getargspec(func)[2]
 
     SOCKET_ERROR = socket.error
     MAXINT = sys.maxint
+
+    class TimeoutError(Exception):
+        pass
 
 
 def seekable(fileobj):

--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -18,6 +18,7 @@ import socket
 
 from botocore.compat import six
 
+queue = six.moves.queue
 
 if sys.platform.startswith('win'):
     def rename_file(current_filename, new_filename):

--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from concurrent.futures import CancelledError
 
+from s3transfer.compat import TimeoutError
+
 
 class RetriesExceededError(Exception):
     def __init__(self, last_exception, msg='Max Retries Exceeded'):


### PR DESCRIPTION
The reason this was done was that concurrent.futures version was too
complicated for what was needed and because of that there was a fair
amount of undesired deadlocks from features that we do not even care
about.

This version fo ThreadPoolExecutor is much simpler in the sense that
it spins up all of its threads at once, only has submit(), does not
concern itself with waiters, and does not register any atexit callbacks.

@JordonPhillips you can use this branch for the ``ExecutorFuture`` work
that you are doing.

cc @jamesls @JordonPhillips 