### PR TITLE
Remove unnecessary lock

### DIFF
--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -216,10 +216,9 @@ class TransferCoordinator(object):
 
         # Once done waiting, raise an exception if present or return the
         # final result.
-        with self._lock:
-            if self._exception:
-                raise self._exception
-            return self._result
+        if self._exception:
+            raise self._exception
+        return self._result
 
     def cancel(self, msg='', exc_type=CancelledError):
         """Cancels the TransferFuture

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -195,6 +195,23 @@ class TestTransferCoordinator(unittest.TestCase):
         with self.assertRaises(CancelledError):
             self.transfer_coordinator.result()
 
+    def test_cancel_can_run_done_callbacks_that_uses_result(self):
+        exceptions = []
+
+        def capture_exception(transfer_coordinator, captured_exceptions):
+            try:
+                transfer_coordinator.result()
+            except Exception as e:
+                captured_exceptions.append(e)
+
+        self.assertEqual(self.transfer_coordinator.status, 'not-started')
+        self.transfer_coordinator.add_done_callback(
+            capture_exception, self.transfer_coordinator, exceptions)
+        self.transfer_coordinator.cancel()
+
+        self.assertEqual(len(exceptions), 1)
+        self.assertIsInstance(exceptions[0], CancelledError)
+
     def test_cancel_with_message(self):
         message = 'my message'
         self.transfer_coordinator.cancel(message)


### PR DESCRIPTION
The lock can be removed because it is guaranteed that the done state along with the result/error before the done event is announced. Having this lock around started causing a deadlock in the case where the main thread would call cancel, the task had not started so done gets announced, when done gets announced it runs the done callbacks, and if one of these done callbacks used the ``result()`` it would cause a deadlock where ``cancel()`` already had the lock and result() was unnecessarily requiring the lock. I also considered switching it to an ``RLock``, but it seemed like we should not be introducing if it is not needed as of now.

cc @jamesls @JordonPhillips 