### PR TITLE
Add UnexpectedCancelledError

### DIFF
--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -27,6 +27,6 @@ class InvalidSubscriberMethodError(Exception):
     pass
 
 
-class UnexpectedCancelledError(CancelledError):
-    """A CancelledError that the user did not explicitly set"""
+class FatalError(CancelledError):
+    """A CancelledError raised from an error in the TransferManager"""
     pass

--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -25,3 +25,8 @@ class S3UploadFailedError(Exception):
 
 class InvalidSubscriberMethodError(Exception):
     pass
+
+
+class UnexpectedCancelledError(CancelledError):
+    """A CancelledError that the user did not explicitly set"""
+    pass

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -18,6 +18,7 @@ import threading
 
 from s3transfer.compat import MAXINT
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import UnexpectedCancelledError
 from s3transfer.utils import FunctionContainer
 from s3transfer.utils import TaskSemaphore
 
@@ -221,16 +222,23 @@ class TransferCoordinator(object):
                 raise self._exception
             return self._result
 
-    def cancel(self, msg=''):
+    def cancel(self, msg='', by_user=True):
         """Cancels the TransferFuture
 
         :param msg: The message to attach to the cancellation
+        :param by_user: Whether or not if the cancel() was called by the user.
+            Cancel can be called by the context manager of the TransferManager
+            if it encounters an error inside. If True a CancelledError will be
+            used. Otherwise, an UnexpectedCancelledError is used.
         """
         with self._lock:
             if not self.done():
                 should_announce_done = False
                 logger.debug('%s cancel(%s) called', self, msg)
-                self._exception = CancelledError(msg)
+                exception_cls = CancelledError
+                if not by_user:
+                    exception_cls = UnexpectedCancelledError
+                self._exception = exception_cls(msg)
                 if self._status == 'not-started':
                     should_announce_done = True
                 self._status = 'cancelled'

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -22,6 +22,8 @@ from s3transfer.utils import CallArgs
 from s3transfer.utils import OSUtils
 from s3transfer.utils import TaskSemaphore
 from s3transfer.utils import SlidingWindowSemaphore
+from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import FatalError
 from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.futures import BoundedExecutor
@@ -482,7 +484,7 @@ class TransferManager(object):
     def __exit__(self, exc_type, exc_value, *args):
         cancel = False
         cancel_msg = ''
-        by_user = False
+        cancel_exc_type = FatalError
         # If a exception was raised in the context handler, signal to cancel
         # all of the inprogress futures in the shutdown.
         if exc_type:
@@ -492,9 +494,9 @@ class TransferManager(object):
                 cancel_msg = repr(exc_value)
             # If it was a KeyboardInterrupt, the cancellation was initiated
             # by the user.
-            if exc_type == KeyboardInterrupt:
-                by_user = True
-        self._shutdown(cancel, cancel_msg, by_user)
+            if isinstance(exc_value, KeyboardInterrupt):
+                cancel_exc_type = CancelledError
+        self._shutdown(cancel, cancel_msg, cancel_exc_type)
 
     def shutdown(self, cancel=False, cancel_msg=''):
         """Shutdown the TransferManager
@@ -513,11 +515,11 @@ class TransferManager(object):
         """
         self._shutdown(cancel, cancel, cancel_msg)
 
-    def _shutdown(self, cancel, cancel_msg, by_user=True):
+    def _shutdown(self, cancel, cancel_msg, exc_type=CancelledError):
         if cancel:
             # Cancel all in-flight transfers if requested, before waiting
             # for them to complete.
-            self._coordinator_controller.cancel(cancel_msg, by_user)
+            self._coordinator_controller.cancel(cancel_msg, exc_type)
         try:
             # Wait until there are no more in-progress transfers. This is
             # wrapped in a try statement because this can be interrupted
@@ -580,7 +582,7 @@ class TransferCoordinatorController(object):
         with self._lock:
             self._tracked_transfer_coordinators.remove(transfer_coordinator)
 
-    def cancel(self, msg='', by_user=True):
+    def cancel(self, msg='', exc_type=CancelledError):
         """Cancels all inprogress transfers
 
         This cancels the inprogress transfers by calling cancel() on all
@@ -589,12 +591,10 @@ class TransferCoordinatorController(object):
         :param msg: The message to pass on to each transfer coordinator that
             gets cancelled.
 
-        :param by_user: True if the user explictly called cancel. Otherwise,
-            False for the case if an non-KeyboardInterrupt was encountered
-            in the context manager of the TransferManager.
+        :param exc_type: The type of exception to set for the cancellation
         """
         for transfer_coordinator in self.tracked_transfer_coordinators:
-            transfer_coordinator.cancel(msg, by_user)
+            transfer_coordinator.cancel(msg, exc_type)
 
     def wait(self):
         """Wait until there are no more inprogress transfers

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -572,17 +572,21 @@ class TransferCoordinatorController(object):
         with self._lock:
             self._tracked_transfer_coordinators.remove(transfer_coordinator)
 
-    def cancel(self, msg=''):
+    def cancel(self, msg='', by_user=True):
         """Cancels all inprogress transfers
 
         This cancels the inprogress transfers by calling cancel() on all
         tracked transfer coordinators.
 
-        :params msg: The message to pass on to each transfer coordinator that
+        :param msg: The message to pass on to each transfer coordinator that
             gets cancelled.
+
+        :param by_user: True if the user explictly called cancel. Otherwise,
+            False for the case if an non-KeyboardInterrupt was encountered
+            in the context manager of the TransferManager.
         """
         for transfer_coordinator in self.tracked_transfer_coordinators:
-            transfer_coordinator.cancel(msg)
+            transfer_coordinator.cancel(msg, by_user)
 
     def wait(self):
         """Wait until there are no more inprogress transfers

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import StubbedClientTest
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import UnexpectedCancelledError
 from s3transfer.manager import TransferManager
 from s3transfer.manager import TransferConfig
 
@@ -49,7 +50,8 @@ class TestTransferManager(StubbedClientTest):
         except ArbitraryException:
             # At least one of the submitted futures should have been
             # cancelled.
-            with self.assertRaisesRegexp(CancelledError, ref_exception_msg):
+            with self.assertRaisesRegexp(
+                    UnexpectedCancelledError, ref_exception_msg):
                 for future in futures:
                     future.result()
 

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import StubbedClientTest
 from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import UnexpectedCancelledError
+from s3transfer.exceptions import FatalError
 from s3transfer.manager import TransferManager
 from s3transfer.manager import TransferConfig
 
@@ -50,8 +50,7 @@ class TestTransferManager(StubbedClientTest):
         except ArbitraryException:
             # At least one of the submitted futures should have been
             # cancelled.
-            with self.assertRaisesRegexp(
-                    UnexpectedCancelledError, ref_exception_msg):
+            with self.assertRaisesRegexp(FatalError, ref_exception_msg):
                 for future in futures:
                     future.result()
 

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -17,7 +17,7 @@ from tests import unittest
 from tests import RecordingExecutor
 from tests import TransferCoordinatorWithInterrupt
 from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import UnexpectedCancelledError
+from s3transfer.exceptions import FatalError
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferCoordinator
@@ -202,11 +202,11 @@ class TestTransferCoordinator(unittest.TestCase):
         with self.assertRaisesRegexp(CancelledError, message):
             self.transfer_coordinator.result()
 
-    def test_cancel_not_by_user(self):
+    def test_cancel_with_provided_exception(self):
         message = 'my message'
-        self.transfer_coordinator.cancel(message, by_user=False)
+        self.transfer_coordinator.cancel(message, exc_type=FatalError)
         self.transfer_coordinator.announce_done()
-        with self.assertRaisesRegexp(UnexpectedCancelledError, message):
+        with self.assertRaisesRegexp(FatalError, message):
             self.transfer_coordinator.result()
 
     def test_cancel_cannot_override_done_state(self):

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -17,6 +17,7 @@ from tests import unittest
 from tests import RecordingExecutor
 from tests import TransferCoordinatorWithInterrupt
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import UnexpectedCancelledError
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferCoordinator
@@ -199,6 +200,13 @@ class TestTransferCoordinator(unittest.TestCase):
         self.transfer_coordinator.cancel(message)
         self.transfer_coordinator.announce_done()
         with self.assertRaisesRegexp(CancelledError, message):
+            self.transfer_coordinator.result()
+
+    def test_cancel_not_by_user(self):
+        message = 'my message'
+        self.transfer_coordinator.cancel(message, by_user=False)
+        self.transfer_coordinator.announce_done()
+        with self.assertRaisesRegexp(UnexpectedCancelledError, message):
             self.transfer_coordinator.result()
 
     def test_cancel_cannot_override_done_state(self):

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -17,6 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 from tests import unittest
 from tests import TransferCoordinatorWithInterrupt
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import UnexpectedCancelledError
 from s3transfer.futures import TransferCoordinator
 from s3transfer.manager import TransferConfig
 from s3transfer.manager import TransferCoordinatorController
@@ -84,6 +85,16 @@ class TestTransferCoordinatorController(unittest.TestCase):
         self.coordinator_controller.cancel(message)
         transfer_coordinator.announce_done()
         with self.assertRaisesRegexp(CancelledError, message):
+            transfer_coordinator.result()
+
+    def test_cancel_not_by_user(self):
+        message = 'my cancel message'
+        transfer_coordinator = TransferCoordinator()
+        self.coordinator_controller.add_transfer_coordinator(
+            transfer_coordinator)
+        self.coordinator_controller.cancel(message, by_user=False)
+        transfer_coordinator.announce_done()
+        with self.assertRaisesRegexp(UnexpectedCancelledError, message):
             transfer_coordinator.result()
 
     def test_wait_for_done_transfer_coordinators(self):

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -17,7 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 from tests import unittest
 from tests import TransferCoordinatorWithInterrupt
 from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import UnexpectedCancelledError
+from s3transfer.exceptions import FatalError
 from s3transfer.futures import TransferCoordinator
 from s3transfer.manager import TransferConfig
 from s3transfer.manager import TransferCoordinatorController
@@ -87,14 +87,14 @@ class TestTransferCoordinatorController(unittest.TestCase):
         with self.assertRaisesRegexp(CancelledError, message):
             transfer_coordinator.result()
 
-    def test_cancel_not_by_user(self):
+    def test_cancel_with_provided_exception(self):
         message = 'my cancel message'
         transfer_coordinator = TransferCoordinator()
         self.coordinator_controller.add_transfer_coordinator(
             transfer_coordinator)
-        self.coordinator_controller.cancel(message, by_user=False)
+        self.coordinator_controller.cancel(message, exc_type=FatalError)
         transfer_coordinator.announce_done()
-        with self.assertRaisesRegexp(UnexpectedCancelledError, message):
+        with self.assertRaisesRegexp(FatalError, message):
             transfer_coordinator.result()
 
     def test_wait_for_done_transfer_coordinators(self):


### PR DESCRIPTION
Introduced a new type of ``CancelledError`` called ``UnexpectedCancelledError`` that differentiates between a cancellation by the user or cntrl-c and a general error hit in the context manger of the TransferManager.

cc @jamesls @JordonPhillips 