### PR TITLE
Use deferred files when opening files

### DIFF
--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -34,6 +34,7 @@ from s3transfer.utils import calculate_range_parameter
 from s3transfer.utils import FunctionContainer
 from s3transfer.utils import CountCallbackInvoker
 from s3transfer.utils import StreamReaderProgress
+from s3transfer.utils import DeferredOpenFile
 from s3transfer.tasks import Task
 from s3transfer.tasks import SubmissionTask
 
@@ -190,7 +191,8 @@ class DownloadFilenameOutputManager(DownloadOutputManager):
         return f
 
     def _get_fileobj(self, filename):
-        f = self._osutil.open(filename, 'wb')
+        f = DeferredOpenFile(filename, mode='wb')
+        f.OPEN_METHOD = self._osutil.open
         # Make sure the file gets closed and we remove the temporary file
         # if anything goes wrong during the process.
         self._transfer_coordinator.add_failure_cleanup(f.close)

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -191,8 +191,8 @@ class DownloadFilenameOutputManager(DownloadOutputManager):
         return f
 
     def _get_fileobj(self, filename):
-        f = DeferredOpenFile(filename, mode='wb')
-        f.OPEN_METHOD = self._osutil.open
+        f = DeferredOpenFile(
+            filename, mode='wb', open_method=self._osutil.open)
         # Make sure the file gets closed and we remove the temporary file
         # if anything goes wrong during the process.
         self._transfer_coordinator.add_failure_cleanup(f.close)

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -192,7 +192,7 @@ class DownloadFilenameOutputManager(DownloadOutputManager):
 
     def _get_fileobj(self, filename):
         f = DeferredOpenFile(
-            filename, mode='wb', open_method=self._osutil.open)
+            filename, mode='wb', open_function=self._osutil.open)
         # Make sure the file gets closed and we remove the temporary file
         # if anything goes wrong during the process.
         self._transfer_coordinator.add_failure_cleanup(f.close)

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -278,8 +278,8 @@ class UploadFilenameInputManager(UploadInputManager):
             yield part_number, read_file_chunk
 
     def _get_deferred_open_file(self, fileobj, start_byte):
-        fileobj = DeferredOpenFile(fileobj, start_byte)
-        fileobj.OPEN_METHOD = self._osutil.open
+        fileobj = DeferredOpenFile(
+            fileobj, start_byte, open_method=self._osutil.open)
         return fileobj
 
     def _get_put_object_fileobj_with_full_size(self, transfer_future):

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -279,7 +279,7 @@ class UploadFilenameInputManager(UploadInputManager):
 
     def _get_deferred_open_file(self, fileobj, start_byte):
         fileobj = DeferredOpenFile(
-            fileobj, start_byte, open_method=self._osutil.open)
+            fileobj, start_byte, open_function=self._osutil.open)
         return fileobj
 
     def _get_put_object_fileobj_with_full_size(self, transfer_future):

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -275,9 +275,7 @@ class OSUtils(object):
 
 
 class DeferredOpenFile(object):
-    OPEN_METHOD = open
-
-    def __init__(self, filename, start_byte=0, mode='rb'):
+    def __init__(self, filename, start_byte=0, mode='rb', open_method=open):
         """A class that defers the opening of a file till needed
 
         This is useful for deffering opening of a file till it is needed
@@ -294,15 +292,19 @@ class DeferredOpenFile(object):
 
         :type mode: str
         :param mode: The mode to use to open the file
+
+        :type open_method: function
+        :param open_method: The function to use to open the file
         """
         self._filename = filename
         self._fileobj = None
         self._start_byte = start_byte
         self._mode = mode
+        self._open_method = open_method
 
     def _open_if_needed(self):
         if self._fileobj is None:
-            self._fileobj = self.OPEN_METHOD(self._filename, self._mode)
+            self._fileobj = self._open_method(self._filename, self._mode)
             self._fileobj.seek(self._start_byte)
 
     @property

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -275,7 +275,7 @@ class OSUtils(object):
 
 
 class DeferredOpenFile(object):
-    def __init__(self, filename, start_byte=0, mode='rb', open_method=open):
+    def __init__(self, filename, start_byte=0, mode='rb', open_function=open):
         """A class that defers the opening of a file till needed
 
         This is useful for deffering opening of a file till it is needed
@@ -293,18 +293,18 @@ class DeferredOpenFile(object):
         :type mode: str
         :param mode: The mode to use to open the file
 
-        :type open_method: function
-        :param open_method: The function to use to open the file
+        :type open_function: function
+        :param open_function: The function to use to open the file
         """
         self._filename = filename
         self._fileobj = None
         self._start_byte = start_byte
         self._mode = mode
-        self._open_method = open_method
+        self._open_function = open_function
 
     def _open_if_needed(self):
         if self._fileobj is None:
-            self._fileobj = self._open_method(self._filename, self._mode)
+            self._fileobj = self._open_function(self._filename, self._mode)
             self._fileobj.seek(self._start_byte)
 
     @property

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -277,7 +277,7 @@ class OSUtils(object):
 class DeferredOpenFile(object):
     OPEN_METHOD = open
 
-    def __init__(self, filename, start_byte=0):
+    def __init__(self, filename, start_byte=0, mode='rb'):
         """A class that defers the opening of a file till needed
 
         This is useful for deffering opening of a file till it is needed
@@ -291,19 +291,31 @@ class DeferredOpenFile(object):
 
         :type start_byte: int
         :param start_byte: The byte to seek to when the file is opened.
+
+        :type mode: str
+        :param mode: The mode to use to open the file
         """
         self._filename = filename
         self._fileobj = None
         self._start_byte = start_byte
+        self._mode = mode
 
     def _open_if_needed(self):
         if self._fileobj is None:
-            self._fileobj = self.OPEN_METHOD(self._filename, 'rb')
+            self._fileobj = self.OPEN_METHOD(self._filename, self._mode)
             self._fileobj.seek(self._start_byte)
+
+    @property
+    def name(self):
+        return self._filename
 
     def read(self, amount=None):
         self._open_if_needed()
         return self._fileobj.read(amount)
+
+    def write(self, data):
+        self._open_if_needed()
+        self._fileobj.write(data)
 
     def seek(self, where):
         self._open_if_needed()

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -77,6 +77,9 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         }
 
     def create_stubbed_responses(self):
+        # We want to make sure the beginning of the stream is always used
+        # incase this gets called twice.
+        self.stream.seek(0)
         return [
             {
                 'method': 'head_object',

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -294,11 +294,28 @@ class TestDefferedOpenFile(BaseUtilsTest):
         deferred_open_file.OPEN_METHOD = self.counting_open_method
         self.assertEqual(self.open_called_count, 0)
 
+    def test_name(self):
+        self.assertEqual(self.deferred_open_file.name, self.filename)
+
     def test_read(self):
         content = self.deferred_open_file.read(2)
         self.assertEqual(content, self.contents[0:2])
         content = self.deferred_open_file.read(2)
         self.assertEqual(content, self.contents[2:4])
+        self.assertEqual(self.open_called_count, 1)
+
+    def test_write(self):
+        self.deferred_open_file = DeferredOpenFile(self.filename, mode='wb')
+        self.deferred_open_file.OPEN_METHOD = self.counting_open_method
+
+        write_content = b'foo'
+        self.deferred_open_file.write(write_content)
+        self.deferred_open_file.write(write_content)
+        self.deferred_open_file.close()
+        # Both of the writes should now be in the file.
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(f.read(), write_content*2)
+        # Open should have only been called once.
         self.assertEqual(self.open_called_count, 1)
 
     def test_seek(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -276,9 +276,9 @@ class TestDefferedOpenFile(BaseUtilsTest):
         self.contents = b'my contents'
         with open(self.filename, 'wb') as f:
             f.write(self.contents)
-        self.deferred_open_file = DeferredOpenFile(self.filename)
+        self.deferred_open_file = DeferredOpenFile(
+            self.filename, open_method=self.counting_open_method)
         self.open_called_count = 0
-        self.deferred_open_file.OPEN_METHOD = self.counting_open_method
 
     def tearDown(self):
         self.deferred_open_file.close()
@@ -289,9 +289,9 @@ class TestDefferedOpenFile(BaseUtilsTest):
         return open(filename, mode)
 
     def test_instantiation_does_not_open_file(self):
-        deferred_open_file = DeferredOpenFile(self.filename)
+        DeferredOpenFile(
+            self.filename, open_method=self.counting_open_method)
         self.open_called_count = 0
-        deferred_open_file.OPEN_METHOD = self.counting_open_method
         self.assertEqual(self.open_called_count, 0)
 
     def test_name(self):
@@ -305,8 +305,8 @@ class TestDefferedOpenFile(BaseUtilsTest):
         self.assertEqual(self.open_called_count, 1)
 
     def test_write(self):
-        self.deferred_open_file = DeferredOpenFile(self.filename, mode='wb')
-        self.deferred_open_file.OPEN_METHOD = self.counting_open_method
+        self.deferred_open_file = DeferredOpenFile(
+            self.filename, mode='wb', open_method=self.counting_open_method)
 
         write_content = b'foo'
         self.deferred_open_file.write(write_content)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -277,20 +277,20 @@ class TestDefferedOpenFile(BaseUtilsTest):
         with open(self.filename, 'wb') as f:
             f.write(self.contents)
         self.deferred_open_file = DeferredOpenFile(
-            self.filename, open_method=self.counting_open_method)
+            self.filename, open_function=self.counting_open_function)
         self.open_called_count = 0
 
     def tearDown(self):
         self.deferred_open_file.close()
         super(TestDefferedOpenFile, self).tearDown()
 
-    def counting_open_method(self, filename, mode):
+    def counting_open_function(self, filename, mode):
         self.open_called_count += 1
         return open(filename, mode)
 
     def test_instantiation_does_not_open_file(self):
         DeferredOpenFile(
-            self.filename, open_method=self.counting_open_method)
+            self.filename, open_function=self.counting_open_function)
         self.open_called_count = 0
         self.assertEqual(self.open_called_count, 0)
 
@@ -306,7 +306,8 @@ class TestDefferedOpenFile(BaseUtilsTest):
 
     def test_write(self):
         self.deferred_open_file = DeferredOpenFile(
-            self.filename, mode='wb', open_method=self.counting_open_method)
+            self.filename, mode='wb',
+            open_function=self.counting_open_function)
 
         write_content = b'foo'
         self.deferred_open_file.write(write_content)


### PR DESCRIPTION
If the files were opened in the submission task, it would cause too many file handles to be opened. Now this gets opened in the IOExecutor which has a limit of 1000 tasks and should not be an issue because most OS's have a max of 1024 open file handles.

cc @jamesls @JordonPhillips 