### PR TITLE
Introduce DownloadChunkIterator

### DIFF
--- a/.changes/next-release/bugfix-download-27205.json
+++ b/.changes/next-release/bugfix-download-27205.json
@@ -1,0 +1,5 @@
+{
+  "category": "download", 
+  "type": "bugfix", 
+  "description": "Fix issue where S3 Object was not downloaded to disk when empty"
+}

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -508,8 +508,7 @@ class GetObjectTask(Task):
                     response['Body'], callbacks)
 
                 current_index = start_index
-                chunks = DownloadChunkIterator(
-                    streaming_body, io_chunksize, response)
+                chunks = DownloadChunkIterator(streaming_body, io_chunksize)
                 for chunk in chunks:
                     # If the transfer is done because of a cancellation
                     # or error somewhere else, stop trying to submit more
@@ -615,16 +614,14 @@ class CompleteDownloadNOOPTask(Task):
 
 
 class DownloadChunkIterator(object):
-    def __init__(self, body, chunksize, response):
+    def __init__(self, body, chunksize):
         """Iterator to chunk out a downloaded S3 stream
 
         :param body: A readable file-like object
         :param chunksize: The amount to read each time
-        :param response: A S3 GetObject response
         """
         self._body = body
         self._chunksize = chunksize
-        self._response = response
         self._num_reads = 0
 
     def __iter__(self):
@@ -635,9 +632,9 @@ class DownloadChunkIterator(object):
         self._num_reads += 1
         if chunk:
             return chunk
-        elif self._num_reads == 1 and not self._response.get('ContentLength'):
+        elif self._num_reads == 1:
             # Even though the response may have not had any
-            # content, we still want to account for the object's
+            # content, we still want to account for an empty object's
             # existance so return the empty chunk for that initial
             # read.
             return chunk

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -346,6 +346,19 @@ class TestNonRangedDownload(BaseDownloadTest):
         for allowed_upload_arg in self._manager.ALLOWED_DOWNLOAD_ARGS:
             self.assertIn(allowed_upload_arg, op_model.input_shape.members)
 
+    def test_download_empty_object(self):
+        self.content = b''
+        self.stream = six.BytesIO(self.content)
+        self.add_head_object_response()
+        self.add_successful_get_object_responses()
+        future = self.manager.download(
+            self.bucket, self.key, self.filename, self.extra_args)
+        future.result()
+
+        # Ensure that the empty file exists
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(b'', f.read())
+
 
 class TestRangedDownload(BaseDownloadTest):
     # TODO: If you want to add tests outside of this test class and still

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -795,7 +795,7 @@ class TestDownloadChunkIterator(unittest.TestCase):
         content = b'my content'
         body = six.BytesIO(content)
         ref_chunks = []
-        for chunk in DownloadChunkIterator(body, len(content), {}):
+        for chunk in DownloadChunkIterator(body, len(content)):
             ref_chunks.append(chunk)
         self.assertEqual(ref_chunks, [b'my content'])
 
@@ -803,14 +803,14 @@ class TestDownloadChunkIterator(unittest.TestCase):
         content = b'1234'
         body = six.BytesIO(content)
         ref_chunks = []
-        for chunk in DownloadChunkIterator(body, 3, {}):
+        for chunk in DownloadChunkIterator(body, 3):
             ref_chunks.append(chunk)
         self.assertEqual(ref_chunks, [b'123', b'4'])
 
     def test_empty_content(self):
         body = six.BytesIO(b'')
         ref_chunks = []
-        for chunk in DownloadChunkIterator(body, 3, {'ContentLength': 0}):
+        for chunk in DownloadChunkIterator(body, 3):
             ref_chunks.append(chunk)
         self.assertEqual(ref_chunks, [b''])
 


### PR DESCRIPTION
Additional logic was need to account for downloading empty objects where we still want to return the empty byte string once for the empty object. Without this logic, users cannot download an empty object by filename.

cc @jamesls @JordonPhillips 