### PR TITLE
Remove use of unique_id() for handler registration

### DIFF
--- a/.changes/next-release/bugfix-TransferManager-18519.json
+++ b/.changes/next-release/bugfix-TransferManager-18519.json
@@ -1,0 +1,5 @@
+{
+  "category": "TransferManager", 
+  "type": "bugfix", 
+  "description": "Fix memory leak when using same client to create multiple TransferManagers"
+}

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -470,12 +470,12 @@ class TransferManager(object):
     def _register_handlers(self):
         # Register handlers to enable/disable callbacks on uploads.
         event_name = 'request-created.s3'
-        enable_id = 's3upload-callback-enable'
-        disable_id = 's3upload-callback-disable'
         self._client.meta.events.register_first(
-            event_name, disable_upload_callbacks, unique_id=disable_id)
+            event_name, disable_upload_callbacks,
+            unique_id='s3upload-callback-disable')
         self._client.meta.events.register_last(
-            event_name, enable_upload_callbacks, unique_id=enable_id)
+            event_name, enable_upload_callbacks,
+            unique_id='s3upload-callback-enable')
 
     def __enter__(self):
         return self

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -14,7 +14,6 @@ import copy
 import logging
 import threading
 
-from s3transfer.utils import unique_id
 from s3transfer.utils import get_callbacks
 from s3transfer.utils import disable_upload_callbacks
 from s3transfer.utils import enable_upload_callbacks
@@ -471,8 +470,8 @@ class TransferManager(object):
     def _register_handlers(self):
         # Register handlers to enable/disable callbacks on uploads.
         event_name = 'request-created.s3'
-        enable_id = unique_id('s3upload-callback-enable')
-        disable_id = unique_id('s3upload-callback-disable')
+        enable_id = 's3upload-callback-enable'
+        disable_id = 's3upload-callback-disable'
         self._client.meta.events.register_first(
             event_name, disable_upload_callbacks, unique_id=disable_id)
         self._client.meta.events.register_last(

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -33,15 +33,6 @@ MIN_UPLOAD_CHUNKSIZE = 5 * (1024 ** 2)
 logger = logging.getLogger(__name__)
 
 
-def unique_id(name):
-    """
-    Generate a unique ID that includes the given name,
-    a timestamp and a random number.
-    """
-    return '{0}-{1}-{2}'.format(name, int(time.time()),
-                                random.randint(0, 10000))
-
-
 def random_file_extension(num_digits=8):
     return ''.join(random.choice(string.hexdigits) for _ in range(num_digits))
 


### PR DESCRIPTION
The ``unique_id()`` was not needed because the same enable/disable callback
handler can be used across ``TransferManagers``. When using ``unique_id()``, it
would cause a memory leak when the same client was used for multiple
``TransferManagers`` as the handler would always get registered on
instantiation.

Fixes https://github.com/boto/boto3/issues/819

cc @jamesls @JordonPhillips 