### PR TITLE
Support downloading to FIFOs

### DIFF
--- a/.changes/next-release/feature-download-40149.json
+++ b/.changes/next-release/feature-download-40149.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Support downloading to FIFOs.",
+  "category": "download"
+}

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -19,9 +19,11 @@ import stat
 import string
 import logging
 import threading
+import io
 from collections import defaultdict
 
 from s3transfer.compat import rename_file
+from s3transfer.compat import seekable
 
 
 MAX_PARTS = 10000
@@ -256,7 +258,7 @@ class OSUtils(object):
         # Block special device
         if stat.S_ISBLK(mode):
             return True
-        # FIFO.
+        # Named pipe / FIFO
         if stat.S_ISFIFO(mode):
             return True
         # Socket.
@@ -269,7 +271,7 @@ class DeferredOpenFile(object):
     def __init__(self, filename, start_byte=0, mode='rb', open_function=open):
         """A class that defers the opening of a file till needed
 
-        This is useful for deffering opening of a file till it is needed
+        This is useful for deferring opening of a file till it is needed
         in a separate thread, as there is a limit of how many open files
         there can be in a single thread for most operating systems. The
         file gets opened in the following methods: ``read()``, ``seek()``,
@@ -296,7 +298,8 @@ class DeferredOpenFile(object):
     def _open_if_needed(self):
         if self._fileobj is None:
             self._fileobj = self._open_function(self._filename, self._mode)
-            self._fileobj.seek(self._start_byte)
+            if self._start_byte != 0:
+                self._fileobj.seek(self._start_byte)
 
     @property
     def name(self):

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -223,7 +223,8 @@ class TestNonMultipartUpload(BaseUploadTest):
 
         # The upload should have used the os utility. We check this by making
         # sure that the recorded opens are as expected.
-        self.assertEqual(osutil.open_records, [(self.filename, 'rb')])
+        expected_opens = [(self.filename, 'rb')]
+        self.assertEqual(osutil.open_records, expected_opens)
 
     def test_allowed_upload_params_are_valid(self):
         op_model = self.client.meta.service_model.operation_model('PutObject')

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import os
 import shutil
-import stat
 import socket
 import tempfile
 


### PR DESCRIPTION
Previously FIFOs had been lumped in with other "special files",
but they act differently than normal files. They are non-seekable,
in-memory files which typically require an active reader and
writer.

This adds a new output manager for FIFOs which treats them as
in-memory non-seekable file objects whose source is a deferred file
handle with buffering disabled.

Resolves aws/aws-cli#2217

cc @kyleknap @jamesls