### PR TITLE
Set exception on future

### DIFF
--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -27,6 +27,10 @@ class InvalidSubscriberMethodError(Exception):
     pass
 
 
+class TransferNotDoneError(Exception):
+    pass
+
+
 class FatalError(CancelledError):
     """A CancelledError raised from an error in the TransferManager"""
     pass

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -77,6 +77,9 @@ class TransferFuture(object):
         """Cancels the request associated with the TransferFuture"""
         self._coordinator.cancel()
 
+    def set_exception(self, exception):
+        self._coordinator.set_exception(exception)
+
 
 class TransferMeta(object):
     """Holds metadata about the TransferFuture"""
@@ -197,9 +200,8 @@ class TransferCoordinator(object):
         Implies the TransferFuture failed.
         """
         with self._lock:
-            if not self.done():
-                self._exception = exception
-                self._status = 'failed'
+            self._exception = exception
+            self._status = 'failed'
 
     def result(self):
         """Waits until TransferFuture is done and returns the result

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -83,7 +83,7 @@ class TransferFuture(object):
             raise TransferNotDoneError(
                 'set_exception can only be called once the transfer is '
                 'complete.')
-        self._coordinator.set_exception(exception)
+        self._coordinator.set_exception(exception, override=True)
 
 
 class TransferMeta(object):
@@ -199,13 +199,16 @@ class TransferCoordinator(object):
             self._result = result
             self._status = 'success'
 
-    def set_exception(self, exception):
+    def set_exception(self, exception, override=False):
         """Set an exception for the TransferFuture
 
         Implies the TransferFuture failed.
+
+        :param exception: The exception that cause the transfer to fail.
+        :param override: If True, override any existing state.
         """
         with self._lock:
-            if self._exception is None:
+            if not self.done() or override:
                 self._exception = exception
                 self._status = 'failed'
 

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -199,19 +199,17 @@ class TestTransferCoordinator(unittest.TestCase):
         with self.assertRaises(exception_result):
             self.transfer_coordinator.result()
 
-    def test_exception_can_override_done_state(self):
+    def test_exception_cannot_override_done_state(self):
         self.transfer_coordinator.set_result('foo')
         self.transfer_coordinator.set_exception(RuntimeError)
         # It status should be success even after the exception is set because
         # success is a done state.
-        self.assertEqual(self.transfer_coordinator.status, 'failed')
+        self.assertEqual(self.transfer_coordinator.status, 'success')
 
-    def test_exception_cannot_be_overwriten(self):
-        self.transfer_coordinator.set_exception(RuntimeError)
-        self.transfer_coordinator.announce_done()
-        self.transfer_coordinator.set_exception(ValueError)
-        with self.assertRaises(RuntimeError):
-            self.transfer_coordinator.result()
+    def test_exception_can_override_done_state_with_override_flag(self):
+        self.transfer_coordinator.set_result('foo')
+        self.transfer_coordinator.set_exception(RuntimeError, override=True)
+        self.assertEqual(self.transfer_coordinator.status, 'failed')
 
     def test_cancel(self):
         self.assertEqual(self.transfer_coordinator.status, 'not-started')

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -97,6 +97,16 @@ class TestTransferFuture(unittest.TestCase):
         self.assertTrue(self.future.done())
         self.assertEqual(self.coordinator.status, 'cancelled')
 
+    def test_set_exception(self):
+        # Set the result such that there is no exception
+        self.coordinator.set_result('result')
+        self.coordinator.announce_done()
+        self.assertEqual(self.future.result(), 'result')
+
+        self.future.set_exception(ValueError())
+        with self.assertRaises(ValueError):
+            self.future.result()
+
 
 class TestTransferMeta(unittest.TestCase):
     def setUp(self):
@@ -178,12 +188,12 @@ class TestTransferCoordinator(unittest.TestCase):
         with self.assertRaises(exception_result):
             self.transfer_coordinator.result()
 
-    def test_exception_cannot_override_done_state(self):
+    def test_exception_can_override_done_state(self):
         self.transfer_coordinator.set_result('foo')
         self.transfer_coordinator.set_exception(RuntimeError)
         # It status should be success even after the exception is set because
         # succes is a done state.
-        self.assertEqual(self.transfer_coordinator.status, 'success')
+        self.assertEqual(self.transfer_coordinator.status, 'failed')
 
     def test_cancel(self):
         self.assertEqual(self.transfer_coordinator.status, 'not-started')


### PR DESCRIPTION
This allows setting a future to the failure state by setting
the exception. This can be useful in callbacks.

cc @kyleknap @jamesls