### PR TITLE
Add non-threaded executor implementation

### DIFF
--- a/.changes/next-release/feature-TransferManager-2387.json
+++ b/.changes/next-release/feature-TransferManager-2387.json
@@ -1,0 +1,5 @@
+{
+  "category": "``TransferManager``", 
+  "type": "feature", 
+  "description": "Expose ability to use own executor class for ``TransferManager``"
+}

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -14,9 +14,11 @@ from concurrent import futures
 from collections import namedtuple
 import copy
 import logging
+import sys
 import threading
 
 from s3transfer.compat import MAXINT
+from s3transfer.compat import six
 from s3transfer.exceptions import CancelledError, TransferNotDoneError
 from s3transfer.utils import FunctionContainer
 from s3transfer.utils import TaskSemaphore
@@ -465,6 +467,76 @@ class ExecutorFuture(object):
 
     def done(self):
         return self._future.done()
+
+
+class NonThreadedExecutor(object):
+    """A drop-in replacement non-threaded version of ThreadPoolExecutor"""
+    def __init__(self, max_workers=None):
+        pass
+
+    def submit(self, fn, *args, **kwargs):
+        future = NonThreadedExecutorFuture()
+        try:
+            result = fn(*args, **kwargs)
+            future.set_result(result)
+        except BaseException:
+            e, tb = sys.exc_info()[1:]
+            logger.debug(
+                'Setting exception for %s to %s with traceback %s',
+                future, e, tb
+            )
+            future.set_exception_info(e, tb)
+        return future
+
+    def shutdown(self, wait=True):
+        pass
+
+
+class NonThreadedExecutorFuture(object):
+    """The Future returned from NonThreadedExecutor
+
+    Note that this future is **not** thread-safe as it is being used
+    from the context of a non-threaded environment.
+    """
+    def __init__(self):
+        self._result = None
+        self._exception = None
+        self._traceback = None
+        self._done = False
+        self._done_callbacks = []
+
+    def set_result(self, result):
+        self._result = result
+        self._set_done()
+
+    def set_exception_info(self, exception, traceback):
+        self._exception = exception
+        self._traceback = traceback
+        self._set_done()
+
+    def result(self, timeout=None):
+        if self._exception:
+            six.reraise(
+                type(self._exception), self._exception, self._traceback)
+        return self._result
+
+    def _set_done(self):
+        self._done = True
+        for done_callback in self._done_callbacks:
+            self._invoke_done_callback(done_callback)
+        self._done_callbacks = []
+
+    def _invoke_done_callback(self, done_callback):
+        return done_callback(self)
+
+    def done(self):
+        return self._done
+
+    def add_done_callback(self, fn):
+        if self._done:
+            self._invoke_done_callback(fn)
+        else:
+            self._done_callbacks.append(fn)
 
 
 TaskTag = namedtuple('TaskTag', ['name'])

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -370,7 +370,7 @@ class BoundedExecutor(object):
     EXECUTOR_CLS = futures.ThreadPoolExecutor
 
     def __init__(self, max_size, max_num_threads, tag_semaphores=None,
-                 underlying_executor_cls=None):
+                 executor_cls=None):
         """An executor implentation that has a maximum queued up tasks
 
         The executor will block if the number of tasks that have been
@@ -389,16 +389,15 @@ class BoundedExecutor(object):
             tag and the value is the semaphore to use when limiting the
             number of tasks the executor is processing at a time.
 
-        :type underlying_executor_cls: BaseExecutor
-        :param underlying_executor_cls: The underlying executor class that
+        :type executor_cls: BaseExecutor
+        :param underlying_executor_cls: The executor class that
             get bounded by this executor. If None is provided, the
             concurrent.futures.ThreadPoolExecutor class is used.
         """
         self._max_num_threads = max_num_threads
-        if not underlying_executor_cls:
-            underlying_executor_cls = self.EXECUTOR_CLS
-        self._executor = underlying_executor_cls(
-            max_workers=self._max_num_threads)
+        if not executor_cls:
+            executor_cls = self.EXECUTOR_CLS
+        self._executor = executor_cls(max_workers=self._max_num_threads)
         self._semaphore = TaskSemaphore(max_size)
         self._tag_semaphores = tag_semaphores
 

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -497,7 +497,7 @@ class NonThreadedExecutor(BaseExecutor):
         try:
             result = fn(*args, **kwargs)
             future.set_result(result)
-        except BaseException:
+        except Exception:
             e, tb = sys.exc_info()[1:]
             logger.debug(
                 'Setting exception for %s to %s with traceback %s',

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -395,7 +395,7 @@ class BoundedExecutor(object):
             concurrent.futures.ThreadPoolExecutor class is used.
         """
         self._max_num_threads = max_num_threads
-        if not executor_cls:
+        if executor_cls is None:
             executor_cls = self.EXECUTOR_CLS
         self._executor = executor_cls(max_workers=self._max_num_threads)
         self._semaphore = TaskSemaphore(max_size)

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -226,7 +226,7 @@ class TransferManager(object):
                 IN_MEMORY_DOWNLOAD_TAG: SlidingWindowSemaphore(
                     self._config.max_in_memory_download_chunks)
             },
-            underlying_executor_cls=executor_cls
+            executor_cls=executor_cls
         )
 
         # The executor responsible for submitting the necessary tasks to
@@ -234,7 +234,7 @@ class TransferManager(object):
         self._submission_executor = BoundedExecutor(
             max_size=self._config.max_submission_queue_size,
             max_num_threads=self._config.max_submission_concurrency,
-            underlying_executor_cls=executor_cls
+            executor_cls=executor_cls
 
         )
 
@@ -243,7 +243,7 @@ class TransferManager(object):
         self._io_executor = BoundedExecutor(
             max_size=self._config.max_io_queue_size,
             max_num_threads=1,
-            underlying_executor_cls=executor_cls
+            executor_cls=executor_cls
         )
         self._register_handlers()
 

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -193,13 +193,17 @@ class TransferManager(object):
         'RequestPayer',
     ]
 
-    def __init__(self, client, config=None, osutil=None):
+    def __init__(self, client, config=None, osutil=None, executor_cls=None):
         """A transfer manager interface for Amazon S3
 
         :param client: Client to be used by the manager
         :param config: TransferConfig to associate specific configurations
         :param osutil: OSUtils object to use for os-related behavior when
             using with transfer manager.
+
+        :type executor_cls: s3transfer.futures.BaseExecutor
+        :param executor_cls: The class of executor to use with the transfer
+            manager. By default, concurrent.futures.ThreadPoolExecutor is used.
         """
         self._client = client
         self._config = config
@@ -221,21 +225,25 @@ class TransferManager(object):
                     self._config.max_in_memory_upload_chunks),
                 IN_MEMORY_DOWNLOAD_TAG: SlidingWindowSemaphore(
                     self._config.max_in_memory_download_chunks)
-            }
+            },
+            underlying_executor_cls=executor_cls
         )
 
         # The executor responsible for submitting the necessary tasks to
         # perform the desired transfer
         self._submission_executor = BoundedExecutor(
             max_size=self._config.max_submission_queue_size,
-            max_num_threads=self._config.max_submission_concurrency
+            max_num_threads=self._config.max_submission_concurrency,
+            underlying_executor_cls=executor_cls
+
         )
 
         # There is one thread available for writing to disk. It will handle
         # downloads for all files.
         self._io_executor = BoundedExecutor(
             max_size=self._config.max_io_queue_size,
-            max_num_threads=1
+            max_num_threads=1,
+            underlying_executor_cls=executor_cls
         )
         self._register_handlers()
 

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -253,7 +253,7 @@ class SubmissionTask(Task):
             # Call the submit method to start submitting tasks to execute the
             # transfer.
             self._submit(transfer_future=transfer_future, **kwargs)
-        except Exception as e:
+        except BaseException as e:
             # If there was an exception rasied during the submission of task
             # there is a chance that the final task that signals if a transfer
             # is done and too run the cleanup may never have been submitted in

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -258,6 +258,12 @@ class SubmissionTask(Task):
             # there is a chance that the final task that signals if a transfer
             # is done and too run the cleanup may never have been submitted in
             # the first place so we need to account accordingly.
+            #
+            # Note that BaseException is caught, instead of Exception, because
+            # for some implmentations of executors, specifically the serial
+            # implementation, the SubmissionTask is directly exposed to
+            # KeyboardInterupts and so need to cleanup and signal done
+            # for those as well.
 
             # Set the exception, that caused the process to fail.
             self._log_and_set_exception(e)

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -262,7 +262,7 @@ class SubmissionTask(Task):
             # Note that BaseException is caught, instead of Exception, because
             # for some implmentations of executors, specifically the serial
             # implementation, the SubmissionTask is directly exposed to
-            # KeyboardInterupts and so need to cleanup and signal done
+            # KeyboardInterupts and so needs to cleanup and signal done
             # for those as well.
 
             # Set the exception, that caused the process to fail.

--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -20,5 +20,5 @@ run('nosetests --with-xunit --cover-erase --with-coverage '
     '--cover-package s3transfer --cover-xml -v integration')
 
 # Run the serial implementation of s3transfer
-os.environ['USE_SERIAL_IMPLEMENTATION'] = 'True'
+os.environ['USE_SERIAL_EXECUTOR'] = 'True'
 run('nosetests -v integration', env=os.environ)

--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -12,9 +12,13 @@ REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
 os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
 
-def run(command):
-    return check_call(command, shell=True)
+def run(command, env=None):
+    return check_call(command, shell=True, env=env)
 
 
 run('nosetests --with-xunit --cover-erase --with-coverage '
     '--cover-package s3transfer --cover-xml -v integration')
+
+# Run the serial implementation of s3transfer
+os.environ['USE_SERIAL_IMPLEMENTATION'] = 'True'
+run('nosetests -v integration', env=os.environ)

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -20,5 +20,5 @@ run('nosetests --with-coverage --cover-erase --cover-package s3transfer '
     '--with-xunit --cover-xml -v unit/ functional/')
 
 # Run the serial implementation of s3transfer
-os.environ['USE_SERIAL_IMPLEMENTATION'] = 'True'
+os.environ['USE_SERIAL_EXECUTOR'] = 'True'
 run('nosetests -v functional/', env=os.environ)

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -12,9 +12,13 @@ REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
 os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
 
-def run(command):
-    return check_call(command, shell=True)
+def run(command, env=None):
+    return check_call(command, shell=True, env=env)
 
 
 run('nosetests --with-coverage --cover-erase --cover-package s3transfer '
     '--with-xunit --cover-xml -v unit/ functional/')
+
+# Run the serial implementation of s3transfer
+os.environ['USE_SERIAL_IMPLEMENTATION'] = 'True'
+run('nosetests -v functional/', env=os.environ)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,11 +34,21 @@ from s3transfer.futures import TransferCoordinator
 from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferFuture
 from s3transfer.futures import BoundedExecutor
+from s3transfer.futures import NonThreadedExecutor
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
 from s3transfer.utils import CallArgs
 from s3transfer.utils import TaskSemaphore
 from s3transfer.utils import SlidingWindowSemaphore
+
+
+def setup_package():
+    if is_serial_implementation():
+        BoundedExecutor.EXECUTOR_CLS = NonThreadedExecutor
+
+
+def is_serial_implementation():
+    return os.environ.get('USE_SERIAL_IMPLEMENTATION', False)
 
 
 def assert_files_equal(first, second):
@@ -79,6 +89,14 @@ def skip_if_windows(reason):
     def decorator(func):
         return unittest.skipIf(
             platform.system() not in ['Darwin', 'Linux'], reason)(func)
+    return decorator
+
+
+def skip_if_using_serial_implementation(reason):
+    """Decorator to skip tests when running as the serial implementation"""
+    def decorator(func):
+        return unittest.skipIf(
+            is_serial_implementation(), reason)(func)
     return decorator
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,9 +42,16 @@ from s3transfer.utils import TaskSemaphore
 from s3transfer.utils import SlidingWindowSemaphore
 
 
+ORIGINAL_EXECUTOR_CLS = BoundedExecutor.EXECUTOR_CLS
+
+
 def setup_package():
     if is_serial_implementation():
         BoundedExecutor.EXECUTOR_CLS = NonThreadedExecutor
+
+
+def teardown_package():
+    BoundedExecutor.EXECUTOR_CLS = ORIGINAL_EXECUTOR_CLS
 
 
 def is_serial_implementation():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -48,7 +48,7 @@ def setup_package():
 
 
 def is_serial_implementation():
-    return os.environ.get('USE_SERIAL_IMPLEMENTATION', False)
+    return os.environ.get('USE_SERIAL_EXECUTOR', False)
 
 
 def assert_files_equal(first, second):

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -25,6 +25,7 @@ from tests import RecordingOSUtils
 from tests import NonSeekableWriter
 from tests import BaseGeneralInterfaceTest
 from tests import skip_if_windows
+from tests import skip_if_using_serial_implementation
 from s3transfer.compat import six
 from s3transfer.compat import SOCKET_ERROR
 from s3transfer.exceptions import RetriesExceededError
@@ -317,6 +318,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         self.assertEqual(len(osutil.rename_records), 1)
 
     @skip_if_windows('Windows does not support UNIX special files')
+    @skip_if_using_serial_implementation(
+        'A seperate thread is needed to read from the fifo')
     def test_download_for_fifo_file(self):
         self.add_head_object_response()
         self.add_successful_get_object_responses()

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore.awsrequest import create_request_object
+import mock
 
 from tests import skip_if_using_serial_implementation
 from tests import StubbedClientTest
@@ -141,10 +142,8 @@ class TestTransferManager(StubbedClientTest):
             'once')
 
     def test_use_custom_executor_implementation(self):
+        mocked_executor_cls = mock.Mock(BaseExecutor)
         transfer_manager = TransferManager(
-            self.client, executor_cls=BaseExecutor)
-        # The BaseExecutor class has no methods implemented so it should
-        # immediately raise a NotImplementedError once something is
-        # submitted to it
-        with self.assertRaises(NotImplementedError):
-            transfer_manager.delete('bucket', 'key')
+            self.client, executor_cls=mocked_executor_cls)
+        transfer_manager.delete('bucket', 'key')
+        self.assertTrue(mocked_executor_cls.return_value.submit.called)

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from botocore.awsrequest import create_request_object
 
+from tests import skip_if_using_serial_implementation
 from tests import StubbedClientTest
 from s3transfer.exceptions import CancelledError
 from s3transfer.exceptions import FatalError
@@ -38,6 +39,12 @@ class CallbackEnablingBody(object):
 
 
 class TestTransferManager(StubbedClientTest):
+    @skip_if_using_serial_implementation(
+        'Exception is thrown once all transfers are submitted. '
+        'However for the serial implementation, transfers are performed '
+        'in main thread meaning all transfers will complete before the '
+        'exception being thrown.'
+    )
     def test_error_in_context_manager_cancels_incomplete_transfers(self):
         # The purpose of this test is to make sure if an error is raised
         # in the body of the context manager, incomplete transfers will
@@ -70,6 +77,12 @@ class TestTransferManager(StubbedClientTest):
                 for future in futures:
                     future.result()
 
+    @skip_if_using_serial_implementation(
+        'Exception is thrown once all transfers are submitted. '
+        'However for the serial implementation, transfers are performed '
+        'in main thread meaning all transfers will complete before the '
+        'exception being thrown.'
+    )
     def test_cntrl_c_in_context_manager_cancels_incomplete_transfers(self):
         # The purpose of this test is to make sure if an error is raised
         # in the body of the context manager, incomplete transfers will

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -15,6 +15,7 @@ from botocore.awsrequest import create_request_object
 from tests import StubbedClientTest
 from s3transfer.exceptions import CancelledError
 from s3transfer.exceptions import FatalError
+from s3transfer.futures import BaseExecutor
 from s3transfer.manager import TransferManager
 from s3transfer.manager import TransferConfig
 
@@ -125,3 +126,12 @@ class TestTransferManager(StubbedClientTest):
             body.disable_callback_call_count, 1,
             'The disable_callback() should have only ever been registered '
             'once')
+
+    def test_use_custom_executor_implementation(self):
+        transfer_manager = TransferManager(
+            self.client, executor_cls=BaseExecutor)
+        # The BaseExecutor class has no methods implemented so it should
+        # immediately raise a NotImplementedError once something is
+        # submitted to it
+        with self.assertRaises(NotImplementedError):
+            transfer_manager.delete('bucket', 'key')

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -18,6 +18,7 @@ from concurrent.futures import CancelledError
 
 from tests import assert_files_equal
 from tests import skip_if_windows
+from tests import skip_if_using_serial_implementation
 from tests import RecordingSubscriber
 from tests import NonSeekableWriter
 from tests.integration import BaseTransferManagerIntegTest
@@ -58,6 +59,12 @@ class TestDownload(BaseTransferManagerIntegTest):
         future.result()
         assert_files_equal(filename, download_path)
 
+    @skip_if_using_serial_implementation(
+        'Exception is thrown once the transfer is submitted. '
+        'However for the serial implementation, transfers are performed '
+        'in main thread meaning the transfer will complete before the '
+        'KeyboardInterrupt being thrown.'
+    )
     def test_large_download_exits_quicky_on_exception(self):
         transfer_manager = self.create_transfer_manager(self.config)
 
@@ -99,6 +106,12 @@ class TestDownload(BaseTransferManagerIntegTest):
         possible_matches = glob.glob('%s*' % download_path)
         self.assertEqual(possible_matches, [])
 
+    @skip_if_using_serial_implementation(
+        'Exception is thrown once the transfer is submitted. '
+        'However for the serial implementation, transfers are performed '
+        'in main thread meaning the transfer will complete before the '
+        'KeyboardInterrupt being thrown.'
+    )
     def test_many_files_exits_quicky_on_exception(self):
         # Set the max request queue size and number of submission threads
         # to something small to simulate having a large queue

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -15,6 +15,7 @@ import time
 from concurrent.futures import CancelledError
 
 from botocore.compat import six
+from tests import skip_if_using_serial_implementation
 from tests import RecordingSubscriber, NonSeekableReader
 from tests.integration import BaseTransferManagerIntegTest
 from s3transfer.manager import TransferConfig
@@ -49,6 +50,12 @@ class TestUpload(BaseTransferManagerIntegTest):
         future.result()
         self.assertTrue(self.object_exists('20mb.txt'))
 
+    @skip_if_using_serial_implementation(
+        'Exception is thrown once the transfer is submitted. '
+        'However for the serial implementation, transfers are performed '
+        'in main thread meaning the transfer will complete before the '
+        'KeyboardInterrupt being thrown.'
+    )
     def test_large_upload_exits_quicky_on_exception(self):
         transfer_manager = self.create_transfer_manager(self.config)
 
@@ -90,6 +97,13 @@ class TestUpload(BaseTransferManagerIntegTest):
             # make sure the object does not exist.
             self.assertFalse(self.object_exists('20mb.txt'))
 
+
+    @skip_if_using_serial_implementation(
+        'Exception is thrown once the transfers are submitted. '
+        'However for the serial implementation, transfers are performed '
+        'in main thread meaning the transfers will complete before the '
+        'KeyboardInterrupt being thrown.'
+    )
     def test_many_files_exits_quicky_on_exception(self):
         # Set the max request queue size and number of submission threads
         # to something small to simulate having a large queue

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -13,6 +13,8 @@
 import sys
 import time
 import traceback
+
+import mock
 from concurrent.futures import ThreadPoolExecutor
 
 from tests import unittest
@@ -547,12 +549,10 @@ class TestBoundedExecutor(unittest.TestCase):
         self.assertFalse(future.done())
 
     def test_replace_underlying_executor(self):
-        executor = BoundedExecutor(10, 1, {}, BaseExecutor)
-        # The BaseExecutor class has no methods implemented so it should
-        # immediately raise a NotImplementedError once something is
-        # submitted to it
-        with self.assertRaises(NotImplementedError):
-            executor.submit(self.get_task(ReturnFooTask))
+        mocked_executor_cls = mock.Mock(BaseExecutor)
+        executor = BoundedExecutor(10, 1, {}, mocked_executor_cls)
+        executor.submit(self.get_task(ReturnFooTask))
+        self.assertTrue(mocked_executor_cls.return_value.submit.called)
 
 
 class TestExecutorFuture(unittest.TestCase):

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -26,6 +26,7 @@ from s3transfer.futures import TransferMeta
 from s3transfer.futures import TransferCoordinator
 from s3transfer.futures import BoundedExecutor
 from s3transfer.futures import ExecutorFuture
+from s3transfer.futures import BaseExecutor
 from s3transfer.futures import NonThreadedExecutor
 from s3transfer.futures import NonThreadedExecutorFuture
 from s3transfer.tasks import Task
@@ -544,6 +545,14 @@ class TestBoundedExecutor(unittest.TestCase):
         # Ensure that the shutdown returns immediately even if the task is
         # not done, which it should not be because it it slow.
         self.assertFalse(future.done())
+
+    def test_replace_underlying_executor(self):
+        executor = BoundedExecutor(10, 1, {}, BaseExecutor)
+        # The BaseExecutor class has no methods implemented so it should
+        # immediately raise a NotImplementedError once something is
+        # submitted to it
+        with self.assertRaises(NotImplementedError):
+            executor.submit(self.get_task(ReturnFooTask))
 
 
 class TestExecutorFuture(unittest.TestCase):


### PR DESCRIPTION
This pull request adds support for supplying a custom executor implementation. Specifically it allows you to use a non-threaded version where all of the logic lives in the main thread. To do this I exposed an `executor_cls` parameter on `TransferManager.__init__()`.

I also needed to update our testing scripts to test the functionality of this implementation by reusing the functional and integration tests. Here are some important decisions I made in doing this where feedback would be good:
- The non-threaded version of the tests can be ran by setting the environment variable `USE_SERIAL_IMPLEMENTATION`.
- In `ci/` scripts I decided not to run any of the plugins like xunit or coverage because I do not want that run to clobber any of the xml files that we get back when running the normal implementation.
- I skipped tests where it is was relying on the main thread not being blocked by the transfer happening in the main thread such as FIFO tests and the Cntrl-C tests. In the end, I was really trying to avoid modifying any of these existing tests, but for the Cntrl-C tests there is not really a great way to inject the Cntrl-C into the process without spinning up an entirely new process. So I was not really sure what to do about that. Suggestions would be great. I also tried signalling an alarm with a KeyboardInterrupt, but that is a bit dangerous as if it got raised at an inappropriate location it would exit out of the tests completely. For what it is worth, I did manual testing and I was able to Cntrl-C very quickly.

In the end, the hope is to use this executor implementation to fix: https://github.com/boto/boto3/issues/814. I did a quick test with the script provided in the issue and it now successfully downloads the object (i.e. no more hanging) so that is good.

cc @jamesls @JordonPhillips 
