### PR TITLE
Increase allowable exit time in tests

### DIFF
--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -90,7 +90,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple second after
         # sleeping to exit.
-        max_allowed_exit_time = sleep_time + 1
+        max_allowed_exit_time = sleep_time + 4
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
             "Failed to exit under %s. Instead exited in %s." % (


### PR DESCRIPTION
We were seeing on and off again failures of the test that hovered
around the current threshold. Increasing it to something slightly
higher but still relatively low to reduce these type of failures.

cc @jamesls @JordonPhillips @stealthycoin 