### PR TITLE
Update more allowed exit times for tests

### DIFF
--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -144,7 +144,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         end_time = time.time()
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple seconds to exit.
-        max_allowed_exit_time = 2
+        max_allowed_exit_time = 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
             "Failed to exit under %s. Instead exited in %s." % (

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -79,7 +79,7 @@ class TestUpload(BaseTransferManagerIntegTest):
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple second after
         # sleeping to exit.
-        max_allowed_exit_time = sleep_time + 2
+        max_allowed_exit_time = sleep_time + 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
             "Failed to exit under %s. Instead exited in %s." % (
@@ -135,7 +135,7 @@ class TestUpload(BaseTransferManagerIntegTest):
         end_time = time.time()
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple seconds to exit.
-        max_allowed_exit_time = 2
+        max_allowed_exit_time = 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
             "Failed to exit under %s. Instead exited in %s." % (


### PR DESCRIPTION
Five seconds seemed reasonable as it is still a short period of time, but a good ceiling for now as the exit test usually take at most around 4 seconds.

cc @jamesls @JordonPhillips @stealthycoin 