### PR TITLE
Add python 3.6 to configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 sudo: false
 install:
   - python scripts/ci/install

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py26,py27,py33,py34,py35,py36
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
This adds python 3.6 to the tox configuration, the setup.py
classifiers, and the travis configuration.

Resolves #79

cc @kyleknap @jamesls @stealthycoin @dstufft