### PR TITLE
Implement seek whence param for zero length files

### DIFF
--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -276,8 +276,8 @@ class ReadFileChunk(object):
     def disable_callback(self):
         self._callback_enabled = False
 
-    def seek(self, where):
-        self._fileobj.seek(self._start_byte + where)
+    def seek(self, where, whence=0):
+        self._fileobj.seek(self._start_byte + where, whence)
         if self._callback is not None and self._callback_enabled:
             # To also rewind the callback() for an accurate progress report
             self._callback(where - self._amount_read)

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -84,8 +84,8 @@ class InterruptReader(object):
             raise self._transfer_coordinator.exception
         return self._fileobj.read(amount)
 
-    def seek(self, where):
-        self._fileobj.seek(where)
+    def seek(self, where, whence=0):
+        self._fileobj.seek(where, whence)
 
     def tell(self):
         return self._fileobj.tell()

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -313,9 +313,9 @@ class DeferredOpenFile(object):
         self._open_if_needed()
         self._fileobj.write(data)
 
-    def seek(self, where):
+    def seek(self, where, whence=0):
         self._open_if_needed()
-        self._fileobj.seek(where)
+        self._fileobj.seek(where, whence)
 
     def tell(self):
         if self._fileobj is None:
@@ -439,8 +439,8 @@ class ReadFileChunk(object):
     def disable_callback(self):
         self._callbacks_enabled = False
 
-    def seek(self, where):
-        self._fileobj.seek(self._start_byte + where)
+    def seek(self, where, whence=0):
+        self._fileobj.seek(self._start_byte + where, whence)
         if self._callbacks is not None and self._callbacks_enabled:
             # To also rewind the callback() for an accurate progress report
             invoke_progress_callbacks(


### PR DESCRIPTION
Bug: https://github.com/aws/aws-cli/issues/2403
Bug-Ubuntu: https://bugs.launchpad.net/bugs/1696800

As described in the bug reports referenced above, trying to copy a
zero-length file to S3 fails (with some version combinations of python3,
awscli, s3transfer, and requests) like this:

    $ aws s3 cp emptyfile s3://somebucket
    upload failed: ./emptyfile to s3://somebucket/emptyfile seek() takes 2 positional arguments but 3 were given

... due to the incomplete implementation of seek() -- missing the optional
'whence' argument -- in s3transfer's ReadFileChunk method.  This patch
adds the whence argument to all of s3transfer's seek implementations.