### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 universal = 1
 
 [metadata]
+license-file = LICENSE.txt
 requires-dist =
 	botocore>=1.3.0,<2.0.0
 	futures>=2.2.0,<4.0.0; python_version=="2.6" or python_version=="2.7"


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file