### PR TITLE
Fix wrong parameter description on comment

### DIFF
--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -575,7 +575,7 @@ class IOWriteTask(Task):
     def _main(self, fileobj, data, offset):
         """Pulls off an io queue to write contents to a file
 
-        :param f: The file handle to write content to
+        :param fileobj: The file handle to write content to
         :param data: The data to write
         :param offset: The offset to write the data to.
         """
@@ -602,7 +602,7 @@ class IOStreamingWriteTask(Task):
 class IORenameFileTask(Task):
     """A task to rename a temporary file to its final filename
 
-    :param f: The file handle that content was written to.
+    :param fileobj: The file handle that content was written to.
     :param final_filename: The final name of the file to rename to
         upon completion of writing the contents.
     :param osutil: OS utility

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -49,7 +49,7 @@ class TransferFuture(object):
 
     @property
     def meta(self):
-        """The metadata associated tio the TransferFuture"""
+        """The metadata associated to the TransferFuture"""
         return self._meta
 
     def done(self):

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -317,8 +317,10 @@ class TransferManager(object):
         :type key: str
         :param key: The name of the key to download from
 
-        :type fileobj: str
-        :param fileobj: The name of a file to download to.
+        :type fileobj: str or seekable file-like object
+        :param fileobj: The name of a file to download or a seekable file-like
+            object to download. It is recommended to use a filename because
+            file-like objects may result in higher memory usage.
 
         :type extra_args: dict
         :param extra_args: Extra arguments that may be passed to the


### PR DESCRIPTION
fileobj is str or seekable file-like object, not just str.