### PR TITLE
Add python_requires to help pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     url='https://github.com/boto/s3transfer',
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=requires,
     extras_require={
         ':python_version=="2.7"': [

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     url='https://github.com/boto/s3transfer',
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     install_requires=requires,
     extras_require={
         ':python_version=="2.6" or python_version=="2.7"': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
When s2transfer drops old Python versions, this will help pip install the right version for people still running those old Python versions.
 
For more info on how this works:
* https://hackernoon.com/phasing-out-python-runtimes-gracefully-956f112f33c4
* https://github.com/pypa/python-packaging-user-guide/issues/450

---

By the way, here's the pip installs for s3transfer from PyPI for July 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  90.08% |     11,483,209 |
| 3.6            |   5.31% |        676,957 |
| 3.5            |   2.64% |        336,926 |
| 3.4            |   1.42% |        181,543 |
| 2.6            |   0.27% |         34,822 |
| 3.7            |   0.27% |         34,614 |
| 3.3            |   0.00% |            357 |
| 3.8            |   0.00% |             13 |
| None           |   0.00% |              2 |
| Total          |         |     12,748,443 |

Source: `pypinfo --start-date 2018-07-01 --end-date 2018-07-31 --percent --markdown s3transfer pyversion`