### PR TITLE
Add whence to mock readable seek to fix functional test

### DIFF
--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -40,7 +40,7 @@ class SignalTransferringBody(RawIOBase):
     def signal_not_transferring(self):
         self.signal_not_transferring_call_count += 1
 
-    def seek(self, where):
+    def seek(self, where, whence=0):
         pass
 
     def tell(self):


### PR DESCRIPTION
Adds the second parameter to seek on a stub object in a functional test