### PR TITLE
Fix being unable to cancel transfers

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -548,7 +548,7 @@ class TransferManager(object):
         :param cancel_msg: The message to specify if canceling all in-progress
             transfers.
         """
-        self._shutdown(cancel, cancel, cancel_msg)
+        self._shutdown(cancel, cancel_msg)
 
     def _shutdown(self, cancel, cancel_msg, exc_type=CancelledError):
         if cancel:


### PR DESCRIPTION
`cancel` was being passed twice when `upload` calls `_upload`, causing cancelling to fail due to the message being passed as the exception type, causing a TypeError due to 'str' not being callable.