### PR TITLE
Reduce chance of race condition in tests

### DIFF
--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -501,7 +501,7 @@ class TestBoundedExecutor(unittest.TestCase):
         self.assert_submit_would_block(second_task)
 
     def test_executor_clears_capacity_on_done_tasks(self):
-        first_task = self.get_task(ReturnFooTask)
+        first_task = self.get_sleep_task()
         second_task = self.get_task(ReturnFooTask)
 
         # Submit a task.


### PR DESCRIPTION
When adding a done callback to a future, it will execute immediately
*in the current thread* if the future is marked as done. This means
that you can have callbacks occuring simultaneously. We had a test
that was relying on a pair of callbacks being ran one at a time and
in order. When it ran into this race condition, it would fail. This
adds a delay to the completion of the future so that the race condition
is less likely.