### PR TITLE
Fix transient errors in integ tests

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -17,6 +17,7 @@ from tests import unittest
 from tests import FileCreator
 from tests import random_bucket_name
 from s3transfer.manager import TransferManager
+from s3transfer.subscribers import BaseSubscriber
 
 
 def recursive_delete(client, bucket_name):
@@ -83,3 +84,12 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
             transfer.upload(f, self.bucket_name, key, extra_args)
             self.wait_object_exists(key, extra_args)
             self.addCleanup(self.delete_object, key)
+
+
+class WaitForTransferStart(BaseSubscriber):
+    def __init__(self, bytes_transfer_started_event):
+        self._bytes_transfer_started_event = bytes_transfer_started_event
+
+    def on_progress(self, **kwargs):
+        if not self._bytes_transfer_started_event.is_set():
+            self._bytes_transfer_started_event.set()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -65,6 +65,19 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
         except WaiterError:
             return False
 
+    def object_not_exists(self, key, extra_args=None):
+        if extra_args is None:
+            extra_args = {}
+        try:
+            self.client.get_waiter('object_not_exists').wait(
+                Bucket=self.bucket_name,
+                Key=key,
+                **extra_args
+            )
+            return True
+        except WaiterError:
+            return False
+
     def wait_object_exists(self, key, extra_args=None):
         if extra_args is None:
             extra_args = {}

--- a/tests/integration/test_delete.py
+++ b/tests/integration/test_delete.py
@@ -28,4 +28,4 @@ class TestDeleteObject(BaseTransferManagerIntegTest):
                                          key=key_name)
         future.result()
 
-        self.assertFalse(self.object_exists(key_name))
+        self.assertTrue(self.object_not_exists(key_name))

--- a/tests/integration/test_processpool.py
+++ b/tests/integration/test_processpool.py
@@ -72,13 +72,13 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         sleep_time = 0.5
         try:
             with downloader:
-                start_time = time.time()
                 downloader.download_file(
                     self.bucket_name, '60mb.txt', download_path)
                 # Sleep for a little to get the transfer process going
                 time.sleep(sleep_time)
                 # Raise an exception which should cause the preceding
                 # download to cancel and exit quickly
+                start_time = time.time()
                 raise KeyboardInterrupt()
         except KeyboardInterrupt:
             pass
@@ -86,7 +86,7 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple second after
         # sleeping to exit.
-        max_allowed_exit_time = sleep_time + 4
+        max_allowed_exit_time = 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
             "Failed to exit under %s. Instead exited in %s." % (

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -132,12 +132,12 @@ class TestUpload(BaseTransferManagerIntegTest):
 
         try:
             with transfer_manager:
-                start_time = time.time()
                 for i, fileobj in enumerate(fileobjs):
                     futures.append(transfer_manager.upload(
                         fileobj, self.bucket_name, keynames[i]))
                 # Raise an exception which should cause the preceeding
                 # transfer to cancel and exit quickly
+                start_time = time.time()
                 raise KeyboardInterrupt()
         except KeyboardInterrupt:
             pass
@@ -157,7 +157,7 @@ class TestUpload(BaseTransferManagerIntegTest):
                 future.result()
         # For the transfer that did get cancelled, make sure the object
         # does not exist.
-        self.assertFalse(self.object_exists(future.meta.call_args.key))
+        self.assertTrue(self.object_not_exists(future.meta.call_args.key))
 
     def test_progress_subscribers_on_upload(self):
         subscriber = RecordingSubscriber()

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
+import threading
 
 from concurrent.futures import CancelledError
 
@@ -18,6 +19,7 @@ from botocore.compat import six
 from tests import skip_if_using_serial_implementation
 from tests import RecordingSubscriber, NonSeekableReader
 from tests.integration import BaseTransferManagerIntegTest
+from tests.integration import WaitForTransferStart
 from s3transfer.manager import TransferConfig
 
 
@@ -62,16 +64,23 @@ class TestUpload(BaseTransferManagerIntegTest):
         filename = self.get_input_fileobj(
             name='foo.txt', size=20 * 1024 * 1024)
 
-        sleep_time = 0.25
+        timeout = 10
+        bytes_transferring = threading.Event()
+        subscriber = WaitForTransferStart(bytes_transferring)
         try:
             with transfer_manager:
-                start_time = time.time()
                 future = transfer_manager.upload(
-                    filename, self.bucket_name, '20mb.txt')
-                # Sleep for a little to get the transfer process going
-                time.sleep(sleep_time)
+                    filename, self.bucket_name, '20mb.txt',
+                    subscribers=[subscriber]
+                )
+                if not bytes_transferring.wait(timeout):
+                    future.cancel()
+                    raise RuntimeError(
+                        "Download transfer did not start after waiting for "
+                        "%s seconds." % timeout)
                 # Raise an exception which should cause the preceeding
                 # download to cancel and exit quickly
+                start_time = time.time()
                 raise KeyboardInterrupt()
         except KeyboardInterrupt:
             pass
@@ -79,11 +88,12 @@ class TestUpload(BaseTransferManagerIntegTest):
         # The maximum time allowed for the transfer manager to exit.
         # This means that it should take less than a couple second after
         # sleeping to exit.
-        max_allowed_exit_time = sleep_time + 5
+        max_allowed_exit_time = 5
+        actual_time_to_exit = end_time - start_time
         self.assertLess(
-            end_time - start_time, max_allowed_exit_time,
+            actual_time_to_exit, max_allowed_exit_time,
             "Failed to exit under %s. Instead exited in %s." % (
-                max_allowed_exit_time, end_time - start_time)
+                max_allowed_exit_time, actual_time_to_exit)
         )
 
         try:
@@ -95,8 +105,7 @@ class TestUpload(BaseTransferManagerIntegTest):
             self.assertEqual(str(e), 'KeyboardInterrupt()')
             # If the transfer did get cancelled,
             # make sure the object does not exist.
-            self.assertFalse(self.object_exists('20mb.txt'))
-
+            self.assertTrue(self.object_not_exists('20mb.txt'))
 
     @skip_if_using_serial_implementation(
         'Exception is thrown once the transfers are submitted. '


### PR DESCRIPTION
This adds three commits to make our tests more robust and fixes a regression in test execution time:


* Refactor ctrl-c download test

    * Move event waiter to init module so we can reuse across tests
    * Modify the measured time to be from ctrl-c until exit.  We don't
      really care when the download() call was started, we care that
      once ctrl-c a transfer, it exits in a reasonable amount of time.

* Make ctrl-c upload test more robust

    * This adds a similar fix to the ctrl-c download test where we
    measure the time from when we ctrl-c to when it exits, which is
    what we really want to test.

    * I also updated the tests to run quicker.  An earlier commit
    switched the object_exists call to use a waiter, but did not
    verify the slower runtime of the tests in the negative case.
    Rather than wait for the waiter to timeout, I've added an
    object_not_exists.  This cuts the time to run this test down by
    an order or magnitude.  A subsequent commit will fix the remaining
    cases.

* Fix remaining s3 test to use object_not_exists
