### PR TITLE
Travis CI: sudo no longer needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,14 @@ matrix:
   include:
     - python: 2.7
       dist: trusty
-      sudo: false
     - python: 3.4
       dist: trusty
-      sudo: false
     - python: 3.5
       dist: trusty
-      sudo: false
     - python: 3.6
       dist: trusty
-      sudo: false
     - python: 3.7
       dist: xenial
-      sudo: true
 
 install:
   - python scripts/ci/install


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration