### PR TITLE
Use correct parameter list to _shutdown()

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -543,7 +543,7 @@ class TransferManager(object):
         :param cancel_msg: The message to specify if canceling all in-progress
             transfers.
         """
-        self._shutdown(cancel, cancel, cancel_msg)
+        self._shutdown(cancel, cancel_msg)
 
     def _shutdown(self, cancel, cancel_msg, exc_type=CancelledError):
         if cancel:


### PR DESCRIPTION
This update fixes a param call typo, to a member function 2 lines below it.

Previous to this change, the "cancel_msg" param would get a boolean instead of a prefered string.