### PR TITLE
Fix for Python 4: replace unsafe six.PY3 with PY2

### DIFF
--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -34,7 +34,13 @@ if sys.platform.startswith('win'):
 else:
     rename_file = os.rename
 
-if six.PY3:
+if six.PY2:
+    def accepts_kwargs(func):
+        return inspect.getargspec(func)[2]
+
+    SOCKET_ERROR = socket.error
+    MAXINT = sys.maxint
+else:
     def accepts_kwargs(func):
         # In python3.4.1, there's backwards incompatible
         # changes when using getargspec with functools.partials.
@@ -46,12 +52,7 @@ if six.PY3:
     # ConnectionError
     SOCKET_ERROR = ConnectionError
     MAXINT = None
-else:
-    def accepts_kwargs(func):
-        return inspect.getargspec(func)[2]
 
-    SOCKET_ERROR = socket.error
-    MAXINT = sys.maxint
 
 
 def seekable(fileobj):


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print "Python 2 code"
```

Where:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code!

Instead, use `six.PY2`.

Found using https://github.com/asottile/flake8-2020.

---

See also:

* https://github.com/boto/botocore/pull/1933
* https://github.com/boto/boto3/pull/2256
* https://github.com/boto/boto/pull/3880