### PR TITLE
Expose client and config properties on manager

### DIFF
--- a/.changes/next-release/enhancement-TransferManager-80541.json
+++ b/.changes/next-release/enhancement-TransferManager-80541.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``TransferManager``",
+  "description": "Expose ``client`` and ``config`` properties"
+}

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -261,6 +261,14 @@ class TransferManager(object):
 
         self._register_handlers()
 
+    @property
+    def client(self):
+        return self._client
+
+    @property
+    def config(self):
+        return self._config
+
     def upload(self, fileobj, bucket, key, extra_args=None, subscribers=None):
         """Uploads a file to S3
 

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -163,3 +163,12 @@ class TestTransferManager(StubbedClientTest):
         with self.assertRaises(ArbitraryException):
             with TransferManager(self.client):
                 raise ArbitraryException(u'\u2713')
+
+    def test_client_property(self):
+        manager = TransferManager(self.client)
+        self.assertIs(manager.client, self.client)
+
+    def test_config_property(self):
+        config = TransferConfig()
+        manager = TransferManager(self.client, config)
+        self.assertIs(manager.config, config)


### PR DESCRIPTION
This allows you to just pass the transfer manager instead of all three of those objects if the client and config is needed as well.

