### PR TITLE
Add support for Tagging and TaggingDirective

### DIFF
--- a/.changes/next-release/enhancement-Tags-63524.json
+++ b/.changes/next-release/enhancement-Tags-63524.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Tags",
+  "description": "Add support for ``Tagging`` and ``TaggingDirective``"
+}

--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -609,6 +609,7 @@ class S3Transfer(object):
         'SSECustomerKey',
         'SSECustomerKeyMD5',
         'SSEKMSKeyId',
+        'Tagging',
     ]
 
     def __init__(self, client, config=None, osutil=None):

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -59,7 +59,8 @@ class CopySubmissionTask(SubmissionTask):
         'CopySourceSSECustomerKey',
         'CopySourceSSECustomerAlgorithm',
         'CopySourceSSECustomerKeyMD5',
-        'MetadataDirective'
+        'MetadataDirective',
+        'TaggingDirective',
     ]
 
     COMPLETE_MULTIPART_ARGS = [

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -177,6 +177,7 @@ class TransferManager(object):
         'SSECustomerKey',
         'SSECustomerKeyMD5',
         'SSEKMSKeyId',
+        'Tagging',
         'WebsiteRedirectLocation'
     ]
 
@@ -188,7 +189,8 @@ class TransferManager(object):
         'CopySourceSSECustomerAlgorithm',
         'CopySourceSSECustomerKey',
         'CopySourceSSECustomerKeyMD5',
-        'MetadataDirective'
+        'MetadataDirective',
+        'TaggingDirective',
     ]
 
     ALLOWED_DELETE_ARGS = [

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -257,6 +257,25 @@ class TestNonMultipartCopy(BaseCopyTest):
         for allowed_upload_arg in self._manager.ALLOWED_COPY_ARGS:
             self.assertIn(allowed_upload_arg, op_model.input_shape.members)
 
+    def test_copy_with_tagging(self):
+        extra_args = {
+            'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'
+        }
+        self.add_head_object_response()
+        self.add_successful_copy_responses(
+            expected_copy_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'Tagging': 'tag1=val1',
+                'TaggingDirective': 'REPLACE'
+            }
+        )
+        future = self.manager.copy(
+            self.copy_source, self.bucket, self.key, extra_args)
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
 
 class TestMultipartCopy(BaseCopyTest):
     __test__ = True
@@ -509,4 +528,21 @@ class TestMultipartCopy(BaseCopyTest):
         future = self.manager.copy(**self.create_call_kwargs())
         with self.assertRaisesRegexp(ClientError, 'ArbitraryFailure'):
             future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_mp_copy_with_tagging_directive(self):
+        extra_args = {
+            'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'
+        }
+        self.add_head_object_response()
+        self.add_successful_copy_responses(
+            expected_create_mpu_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'Tagging': 'tag1=val1',
+            }
+        )
+        future = self.manager.copy(
+            self.copy_source, self.bucket, self.key, extra_args)
+        future.result()
         self.stubber.assert_no_pending_responses()


### PR DESCRIPTION
This just allows users to proxy the values through to the `upload` and `copy` methods. Currently, `Tagging` is modeled as a string that you have to urlencode yourself. I did not add any special logic to do the url encoding on the user's behalf. However, in the future we can always allow `Tagging` to accept a dictionary and have either `s3transfer` or `botocore` urlencode it on your behalf.