### PR TITLE
Fixing temp filename length to be less than or equal to 255

### DIFF
--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -349,6 +349,11 @@ class OSUtils(object):
     def rename_file(self, current_filename, new_filename):
         s3transfer.compat.rename_file(current_filename, new_filename)
 
+    def get_temp_filename(self, filename):
+        path,name = os.path.dirname(filename), os.path.basename(filename)
+        temp_filename = name[:255-8-1] + os.extsep + random_file_extension()
+        return temp_filename
+
 
 class MultipartUploader(object):
     # These are the extra_args that need to be forwarded onto
@@ -668,7 +673,7 @@ class S3Transfer(object):
             extra_args = {}
         self._validate_all_known_args(extra_args, self.ALLOWED_DOWNLOAD_ARGS)
         object_size = self._object_size(bucket, key, extra_args)
-        temp_filename = filename + os.extsep + random_file_extension()
+        temp_filename = self._osutil.get_temp_filename(filename)
         try:
             self._download_file(bucket, key, temp_filename, object_size,
                                 extra_args, callback)

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -300,7 +300,9 @@ class OSUtils(object):
         return False
 
     def get_temp_filename(self, filename):
-        return filename + os.extsep + random_file_extension()
+        path,name = os.path.dirname(filename), os.path.basename(filename)
+        temp_filename = name[:255-8-1] + os.extsep + random_file_extension()
+        return temp_filename
 
     def allocate(self, filename, size):
         try:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -297,10 +297,11 @@ class TestOSUtils(BaseUtilsTest):
         self.assertFalse(OSUtils().is_special_file(non_existant_filename))
 
     def test_get_temp_filename(self):
-        filename = 'myfile'
+        filename = ''.join([str(random.randint(0,9)) for i in range(0, 255)])
+        self.assertTrue(len(OSUtils().get_temp_filename(filename))<=255)
         self.assertIsNotNone(
             re.match(
-                '%s\.[0-9A-Fa-f]{8}$' % filename,
+                '%s\.[0-9A-Fa-f]{8}$' % filename[:255-8-1],
                 OSUtils().get_temp_filename(filename)
             )
         )


### PR DESCRIPTION
Fixes issue https://github.com/boto/botocore/issues/1916.

