### PR TITLE
Allow developmental versions of botocore v2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,5 @@ universal = 1
 
 [metadata]
 requires-dist =
-	botocore>=1.12.36,<2.0.0
-	futures>=2.2.0,<4.0.0; python_version=="2.7"
+    botocore>=1.12.36,<2.0a.0
+    futures>=2.2.0,<4.0.0; python_version=="2.7"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 
 
 requires = [
-    'botocore>=1.12.36,<2.0.0',
+    'botocore>=1.12.36,<2.0a.0',
 ]
 
 


### PR DESCRIPTION
This allows for developmental versions of botocore to be used such as `2.0.0devX` or `2.0a.0devX` as they are less than `2.0a.0`. However, this will not allow `2.0a.0` or greater of botocore.

[Version Identification PEP](https://www.python.org/dev/peps/pep-0440/#developmental-releases)