### PR TITLE
Fix tests with Python 3.8.2

### DIFF
--- a/tests/unit/test_s3transfer.py
+++ b/tests/unit/test_s3transfer.py
@@ -465,7 +465,7 @@ class TestMultipartDownloader(unittest.TestCase):
                 self.is_first = True
 
             def submit(self, function):
-                future = super(FailedDownloadParts, self).submit(function)
+                future = futures.Future()
                 if self.is_first:
                     # This is the download_parts_thread.
                     future.set_exception(


### PR DESCRIPTION
The behaviour of set_exception for futures changed in Python 3.8, it'll now
raise concurrent.futures.InvalidStateError if the future is already done [1],
which is the case in this test because set_result has already been called on
the future.

1: https://bugs.python.org/issue33238

Fix the test by not using the future from SequentialExecutor, and instead
creating a future which doesn't have a result.

```
FAIL: test_download_futures_fail_triggers_shutdown (tests.unit.test_s3transfer.TestMultipartDownloader)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/guix-build-python-s3transfer-0.3.3.drv-0/s3transfer-0.3.3/tests/unit/test_s3transfer.py", line 484, in test_download_futures_fail_triggers_shutdown
    downloader.download_file('bucket', 'key', 'filename',
AssertionError: "fake download parts error" does not match "FINISHED: <Future at 0x7ffdc8e730d0 state=finished returned NoneType>"
-------------------- >> begin captured logging << --------------------
s3transfer: DEBUG: Making get_object call.
s3transfer: DEBUG: EXITING _download_range for part: 0
--------------------- >> end captured logging << ---------------------
```

I encountered this when looking at a build failure of the python-s3transfer package in GNU Guix when built with Python 3.8.2.