### PR TITLE
Adjusting test wait time

### DIFF
--- a/tests/integration/test_processpool.py
+++ b/tests/integration/test_processpool.py
@@ -69,7 +69,7 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         self.upload_file(filename, '60mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '60mb.txt')
-        sleep_time = 0.5
+        sleep_time = 0.2
         try:
             with downloader:
                 downloader.download_file(


### PR DESCRIPTION
When we ran this test on a gigabit connection, it's possible to finish in less than 0.5s causing the test to fail. This should still supply enough delay to start the download but would require a 5gbps connection to fail consistently.