### PR TITLE
Remove warning message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             'futures>=2.2.0,<4.0.0']
     },
     license="Apache License 2.0",
-    classifiers=(
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -54,5 +54,5 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-    ),
+    ],
 )


### PR DESCRIPTION
The warning is as follows:
Warning: 'classifiers' should be a list, got type 'tuple'

Reference:	https://www.python.org/dev/peps/pep-0301/#distutils-trove-classification