### PR TITLE
Update classifiers from tuple to list for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
             'futures>=2.2.0,<4.0.0']
     },
     license="Apache License 2.0",
-    classifiers=(
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -54,5 +54,5 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-    ),
+    ],
 )


### PR DESCRIPTION
Part of the Warehouse migration moved expectations for classifiers to be a list instead of a tuple. We missed s3transfer in that update, so we're finishing off the corrections now.

Related ticket: https://bugs.python.org/issue19610