### PR TITLE
fix a bug where rename would fail for objectname . (dot)

### DIFF
--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -13,7 +13,7 @@
 import logging
 import threading
 import heapq
-
+import sys
 
 from botocore.compat import six
 
@@ -598,6 +598,12 @@ class IORenameFileTask(Task):
     """
     def _main(self, fileobj, final_filename, osutil):
         fileobj.close()
+        # if the platform is linux, and object name is . then we get
+        # an -EBUSY error from performing the rename(2) system call.
+        # Therefore, fix the by replacing the . with a different name.
+        if (sys.platform.startswith("linux") and final_filename.endswith("/.")):
+            sys.stderr.write("\nfound . as the filename, replacing . with filename " + fileobj.name.split('/')[-1] + "\n")
+            final_filename = fileobj.name
         osutil.rename_file(fileobj.name, final_filename)
 
 


### PR DESCRIPTION
o When using s3transfer and we have an object named "." (dot) and the platform is Linux, the s3transfer fails for object with an -EBUSY.

~~~
$ aws s3 sync s3://random-bucket-name/ /tmp/test
download failed: s3://random-bucket-name/. to ../../tmp/test/. [Errno 16] Device or resource busy
~~~

o The rename that is failing in above comes from s3transfer:

~~~
  File "/usr/lib/python2.7/site-packages/s3transfer/download.py", line 601, in _main
    osutil.rename_file(fileobj.name, final_filename)
~~~

o  Note that "." in Linux holds a special resemblance. Every directory contains the special name "." (dot), a shorthand name that is a map to the inode of the directory itself. That counts as a link to the directory. There can exist an object named "." but you can not overwrite this filename in Linux because of which python calls os.rename() which internally calls the rename(2) system call. The systemcall fails with -EBUSY causing this bug as this case is not handled yet.

o This is a corner case scenario if the customer is using s3transfer to copy objects named . to current working directory.

o As a fix to this issue, I propose that we change the object name to fileobj.name  and print the value in stderr.

Any feedback is appreciated.