### PR TITLE
Update requires-dist to new syntax for setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 universal = 1
 
 [metadata]
-requires-dist =
+requires_dist =
     botocore>=1.12.36,<2.0a.0
     futures>=2.2.0,<4.0.0; python_version=="2.7"


### PR DESCRIPTION
Updating setup.cfg metadata key `requires_dist` to expected format of setuptools.