### PR TITLE
Allow using ExpectedBucketOwner

### DIFF
--- a/.changes/next-release/enhancement-s3-1285.json
+++ b/.changes/next-release/enhancement-s3-1285.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3", 
+  "type": "enhancement", 
+  "description": "Adds `ExpectedBucketOwner` to the allowed `ExtraArgs` for uploads to protect against bucket sniping when uploading files. Fixes `#181 <https://github.com/boto/boto3/issues/181>`__."
+}

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -164,6 +164,7 @@ class TransferManager(object):
         'ContentEncoding',
         'ContentLanguage',
         'ContentType',
+        'ExpectedBucketOwner',
         'Expires',
         'GrantFullControl',
         'GrantRead',


### PR DESCRIPTION
Adds ExpectedBucketOwner to the allowed ExtraArgs for uploads to protect against bucket sniping when uploading files.

The underlying APIs already complain if you give them args that don't match, so I'm a little curious why this extra layer/check helps, but regardless adding this allows me to use ExpectedBucketOwner without issue.