### PR TITLE
Fix Uplaoad Bug - Allow using ExpectedBucketOwner

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -164,6 +164,7 @@ class TransferManager(object):
         'ContentEncoding',
         'ContentLanguage',
         'ContentType',
+        'ExpectedBucketOwner',
         'Expires',
         'GrantFullControl',
         'GrantRead',
@@ -179,8 +180,7 @@ class TransferManager(object):
         'SSEKMSKeyId',
         'SSEKMSEncryptionContext',
         'Tagging',
-        'WebsiteRedirectLocation',
-		'ExpectedBucketOwner'
+        'WebsiteRedirectLocation'
     ]
 
     ALLOWED_COPY_ARGS = ALLOWED_UPLOAD_ARGS + [

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -179,7 +179,8 @@ class TransferManager(object):
         'SSEKMSKeyId',
         'SSEKMSEncryptionContext',
         'Tagging',
-        'WebsiteRedirectLocation'
+        'WebsiteRedirectLocation',
+		'ExpectedBucketOwner'
     ]
 
     ALLOWED_COPY_ARGS = ALLOWED_UPLOAD_ARGS + [


### PR DESCRIPTION
Currently we are using s3transfer to do s3 upload and would like to make sure we pass "ExpectedBucketOwner" as an argument to protect against bucket sniping when uploading files. However, one bug we found is that s3transfer manager.py is missing "ExpectedBucketOwner" in its ALLOWED_UPLOAD_ARGS list and thus the validation method is throwing the below error, though base api allows "ExpectedBucketOwner" as one of the ExtraArgs #181 