### PR TITLE
Update setup.py futures usage

### DIFF
--- a/.changes/next-release/bugfix-packaging-96520.json
+++ b/.changes/next-release/bugfix-packaging-96520.json
@@ -1,0 +1,5 @@
+{
+  "category": "packaging", 
+  "type": "bugfix", 
+  "description": "Fix setup.py metadata for `futures` on Python 2.7"
+}

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,6 @@ requires = [
     'botocore>=1.12.36,<2.0a.0',
 ]
 
-
-if sys.version_info[0] == 2:
-    # concurrent.futures is only in python3, so for
-    # python2 we need to install the backport.
-    requires.append('futures>=2.2.0,<4.0.0')
-
-
 def get_version():
     init = open(os.path.join(ROOT, 's3transfer', '__init__.py')).read()
     return VERSION_RE.search(init).group(1)


### PR DESCRIPTION
The release of s3transfer 0.3.5 was done with an updated version of Wheel that started using wheels with Metadata 2.1. The way the setup.py has been written accidentally includes the requirement for futures on Python 2.7 twice. Once with the version requirement, and once without.

We discovered in #183 this is now breaking installations of s3transfer on _some_ Python 3 environments. We're releasing this change to fix the wheel metadata from:

```
Metadata-Version: 2.1
Name: s3transfer
Version: 0.3.5
Summary: An Amazon S3 Transfer Manager
Home-page: https://github.com/boto/s3transfer
Author: Amazon Web Services
Author-email: kyknapp1@gmail.com
License: Apache License 2.0
Platform: UNKNOWN
Classifier: Development Status :: 3 - Alpha
Classifier: Intended Audience :: Developers
Classifier: Natural Language :: English
Classifier: License :: OSI Approved :: Apache Software License
Classifier: Programming Language :: Python
Classifier: Programming Language :: Python :: 2.7
Classifier: Programming Language :: Python :: 3
Classifier: Programming Language :: Python :: 3.4
Classifier: Programming Language :: Python :: 3.5
Classifier: Programming Language :: Python :: 3.6
Classifier: Programming Language :: Python :: 3.7
Requires-Dist: botocore (<2.0a.0,>=1.12.36)
Requires-Dist: futures (<4.0.0,>=2.2.0)
Requires-Dist: futures (<4.0.0,>=2.2.0) ; python_version=="2.7"
```

to Expected Metadata:
```
Metadata-Version: 2.1
Name: s3transfer
Version: 0.3.5
Summary: An Amazon S3 Transfer Manager
Home-page: https://github.com/boto/s3transfer
Author: Amazon Web Services
Author-email: kyknapp1@gmail.com
License: Apache License 2.0
Platform: UNKNOWN
Classifier: Development Status :: 3 - Alpha
Classifier: Intended Audience :: Developers
Classifier: Natural Language :: English
Classifier: License :: OSI Approved :: Apache Software License
Classifier: Programming Language :: Python
Classifier: Programming Language :: Python :: 2.7
Classifier: Programming Language :: Python :: 3
Classifier: Programming Language :: Python :: 3.4
Classifier: Programming Language :: Python :: 3.5
Classifier: Programming Language :: Python :: 3.6
Classifier: Programming Language :: Python :: 3.7
Requires-Dist: botocore (<2.0a.0,>=1.12.36)
Requires-Dist: futures (<4.0.0,>=2.2.0) ; python_version=="2.7"
```
