### PR TITLE
Fix trove classifiers for s3transfer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
Update the Trove classifiers in s3transfer to accurately reflect the versions of Python we currently test and support.