### PR TITLE
Fix setup.cfg botocore[crt] specifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ requires_dist =
     futures>=2.2.0,<4.0.0; python_version=="2.7"
 
 [options.extras_require]
-crt = botocore[crt]>=1.20.19<2.0a0
+crt = botocore[crt]>=1.20.29,<2.0a0


### PR DESCRIPTION
Quick update to fix a typo in the original test branch. Botocore 1.20.29 was the first version to release support for the CRT extra.