### PR TITLE
Add support for optional AWS Common Runtime (CRT) bindings

### DIFF
--- a/.changes/next-release/feature-crt-30324.json
+++ b/.changes/next-release/feature-crt-30324.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``crt``",
+  "description": "Add optional AWS Common Runtime (CRT) support. The AWS CRT provides a C-based S3 transfer client that can improve transfer throughput."
+}

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -1,0 +1,28 @@
+
+name: Run CRT tests
+
+on:
+  push:
+  pull_request:
+    branches-ignore: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies and CRT
+      run: |
+        python scripts/ci/install --extras crt
+    - name: Run tests
+      run: |
+        python scripts/ci/run-crt-tests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,4 @@
 nose==1.3.3
 mock==1.3.0
 coverage==5.0.3
-wheel==0.24.0
+wheel==0.36.2

--- a/s3transfer/constants.py
+++ b/s3transfer/constants.py
@@ -15,6 +15,7 @@ import s3transfer
 
 KB = 1024
 MB = KB * KB
+GB = MB * KB
 
 ALLOWED_DOWNLOAD_ARGS = [
     'VersionId',

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -1,3 +1,15 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 import logging
 from io import BytesIO
 import threading

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -1,0 +1,359 @@
+import logging
+import os
+from io import BytesIO
+
+import botocore.awsrequest
+import botocore.session
+from botocore import UNSIGNED
+from botocore.config import Config
+from botocore.compat import urlsplit
+import awscrt.http
+from awscrt.s3 import S3Client, S3RequestType
+from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
+from awscrt.auth import AwsCredentialsProvider, AwsCredentials
+
+from s3transfer.futures import BaseTransferFuture, BaseTransferMeta
+from s3transfer.utils import CallArgs, OSUtils, get_callbacks
+
+logger = logging.getLogger(__name__)
+
+
+class CRTTransferConfig(object):
+    def __init__(self,
+                 max_bandwidth=None,
+                 multipart_chunksize=None,
+                 max_request_processes=None):
+        # TODO rename max_bandwidth and max_request_processes for more
+        # appropriate description
+        self.max_bandwidth = max_bandwidth
+        self.multipart_chunksize = multipart_chunksize
+        self.max_request_processes = max_request_processes
+
+
+class CRTTransferManager(object):
+    """
+    Transfer manager based on CRT s3 client.
+    """
+
+    def __init__(self, session, config=None, crt_s3_client=None):
+        self._crt_credential_provider = \
+            self._botocore_credential_provider_adaptor(session)
+        if config is None:
+            config = CRTTransferConfig()
+        if crt_s3_client is None:
+            crt_s3_client = self._create_crt_s3_client(session, config)
+        self._crt_s3_client = crt_s3_client
+        self._s3_args_creator = S3ClientArgsCreator(session)
+        self._futures = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, *args):
+        # Wait until all the transfer done, even if some fails and clean up all
+        # the underlying resource
+        try:
+            for future in self._futures:
+                future.result()
+        except Exception:
+            pass
+        shutdown_event = self._crt_s3_client.shutdown_event
+        self._crt_s3_client = None
+        shutdown_event.wait()
+
+    def download(self, bucket, key, fileobj, extra_args=None,
+                 subscribers=None):
+        if extra_args is None:
+            extra_args = {}
+        callargs = CallArgs(
+            bucket=bucket, key=key, fileobj=fileobj,
+            extra_args=extra_args, subscribers=subscribers)
+        return self._submit_transfer("get_object", callargs)
+
+    def upload(self, bucket, key, fileobj, extra_args=None,
+               subscribers=None):
+        if extra_args is None:
+            extra_args = {}
+        callargs = CallArgs(
+            bucket=bucket, key=key, fileobj=fileobj,
+            extra_args=extra_args, subscribers=subscribers)
+        return self._submit_transfer("put_object", callargs)
+
+    def delete(self, bucket, key, extra_args=None,
+               subscribers=None):
+        if extra_args is None:
+            extra_args = {}
+        callargs = CallArgs(
+            bucket=bucket, key=key, extra_args=extra_args,
+            subscribers=subscribers)
+        return self._submit_transfer("delete_object", callargs)
+
+    def _botocore_credential_provider_adaptor(self, session):
+
+        def provider():
+            credentials = session.get_credentials().get_frozen_credentials()
+            return AwsCredentials(credentials.access_key,
+                                  credentials.secret_key, credentials.token)
+
+        return provider
+
+    def _create_crt_s3_client(self, session, transfer_config):
+        client_factory = CRTS3ClientFactory()
+        return client_factory.create_client(
+            region=session.get_config_variable("region"),
+            client_config=session.get_default_client_config(),
+            transfer_config=transfer_config,
+            credential_provider=self._crt_credential_provider
+        )
+
+    def _submit_transfer(self, request_type, call_args):
+        # TODO unique id may be needed for the future.
+        future = CRTTransferFuture(None, CRTTransferMeta(call_args=call_args))
+
+        # TODO Catch any exception happens during serialization and set the
+        # expection for
+        on_queued = self._s3_args_creator.get_crt_callback(future, 'queued')
+        on_queued()
+        crt_callargs = self._s3_args_creator.get_make_request_args(
+            request_type, call_args, future)
+        crt_s3_request = self._crt_s3_client.make_request(**crt_callargs)
+
+        future.set_s3_request(crt_s3_request)
+        self._futures.append(future)
+        return future
+
+
+class CRTUtil(object):
+    '''
+    Utilities related to CRT.
+    '''
+    def crt_request_from_aws_request(aws_request):
+        url_parts = urlsplit(aws_request.url)
+        crt_path = url_parts.path
+        if url_parts.query:
+            crt_path = '%s?%s' % (crt_path, url_parts.query)
+        headers_list = []
+        for name, value in aws_request.headers.items():
+            if isinstance(value, str):
+                headers_list.append((name, value))
+            else:
+                headers_list.append((name, str(value, 'utf-8')))
+
+        crt_headers = awscrt.http.HttpHeaders(headers_list)
+        # CRT requires body (if it exists) to be an I/O stream.
+        crt_body_stream = None
+        if aws_request.body:
+            if hasattr(aws_request.body, 'seek'):
+                crt_body_stream = aws_request.body
+            else:
+                crt_body_stream = BytesIO(aws_request.body)
+
+        crt_request = awscrt.http.HttpRequest(
+            method=aws_request.method,
+            path=crt_path,
+            headers=crt_headers,
+            body_stream=crt_body_stream)
+        return crt_request
+
+
+class CRTTransferMeta(BaseTransferMeta):
+    """Holds metadata about the CRTTransferFuture"""
+
+    def __init__(self, transfer_id=None, call_args=None):
+        self._transfer_id = transfer_id
+        self._call_args = call_args
+        self._user_context = {}
+        self._size = 0
+
+    @property
+    def call_args(self):
+        return self._call_args
+
+    @property
+    def transfer_id(self):
+        return self._transfer_id
+
+    @property
+    def user_context(self):
+        return self._user_context
+
+    @property
+    def size(self):
+        return self._size
+
+    def provide_transfer_size(self, size):
+        # TODO the size is not related to CRT, move this to CLI
+        self._size = size
+
+
+class CRTTransferFuture(BaseTransferFuture):
+    def __init__(self, s3_request=None, meta=None):
+        """The future associated to a submitted transfer request via CRT S3 client
+
+        :type s3_request: S3Request
+        :param s3_request: The s3_request, the CRT s3 request handles cancel
+            and the finish future.
+
+        :type meta: CRTTransferMeta
+        :param meta: The metadata associated to the request. This object
+            is visible to the requester.
+        """
+        self._s3_request = s3_request
+        self._crt_future = None
+        if s3_request:
+            self._crt_future = self._s3_request.finished_future
+        self._meta = meta
+        if meta is None:
+            self._meta = CRTTransferMeta()
+
+    @property
+    def meta(self):
+        return self._meta
+
+    # TODO remove this later, since it's not something we want user to have
+    # access to
+    def set_s3_request(self, s3_request):
+        self._s3_request = s3_request
+        self._crt_future = self._s3_request.finished_future
+
+    def done(self):
+        return self._crt_future.done()
+
+    def result(self):
+        try:
+            if self._s3_request:
+                result = self._crt_future.result()
+                self._s3_request = None
+                return result
+            return
+        except KeyboardInterrupt as e:
+            self.cancel()
+            raise e
+
+    def cancel(self):
+        # TODO support cancel correctly for error handling
+        raise NotImplementedError('cancel')
+
+
+class CRTS3ClientFactory:
+    def create_client(self, region, transfer_config=None,
+                      client_config=None,
+                      credential_provider=None):
+        # TODO client config is not resolved correctly.
+        event_loop_group = EventLoopGroup(
+            transfer_config.max_request_processes)
+        host_resolver = DefaultHostResolver(event_loop_group)
+        bootstrap = ClientBootstrap(
+            event_loop_group, host_resolver)
+        provider = AwsCredentialsProvider.new_delegate(
+            credential_provider)
+        target_gbps = 0
+        if transfer_config.max_bandwidth:
+            # Translate bytes to gigabits
+            target_gbps = transfer_config.max_bandwidth * \
+                8 / (1000 * 1000 * 1000)
+
+        return S3Client(
+            bootstrap=bootstrap,
+            region=region,
+            credential_provider=provider,
+            part_size=transfer_config.multipart_chunksize,
+            throughput_target_gbps=target_gbps)
+
+
+class FakeRawResponse(BytesIO):
+    def stream(self, amt=1024, decode_content=None):
+        while True:
+            chunk = self.read(amt)
+            if not chunk:
+                break
+            yield chunk
+
+
+class S3ClientArgsCreator:
+    def __init__(self, session):
+        # Turn off the signing process and depends on the crt client to sign
+        # the request
+        client_config = Config(signature_version=UNSIGNED)
+        self._client = session.create_client(
+            's3', config=client_config)
+        self._os_utils = OSUtils()
+        self._client.meta.events.register(
+            'request-created.s3.*', self._capture_http_request)
+        self._client.meta.events.register(
+            'after-call.s3.*',
+            self._change_response_to_serialized_http_request)
+        self._client.meta.events.register(
+            'before-send.s3.*', self._make_fake_http_response)
+
+    def get_make_request_args(self, request_type, call_args, future):
+        recv_filepath = None
+        send_filepath = None
+        s3_meta_request_type = getattr(
+            S3RequestType,
+            request_type.upper(),
+            S3RequestType.DEFAULT)
+        if s3_meta_request_type == S3RequestType.GET_OBJECT:
+            recv_filepath = call_args.fileobj
+        elif s3_meta_request_type == S3RequestType.PUT_OBJECT:
+            send_filepath = call_args.fileobj
+            data_len = self._os_utils.get_file_size(send_filepath)
+            call_args.extra_args["ContentLength"] = data_len
+
+        botocore_http_request = self._get_botocore_http_request(
+            request_type, call_args)
+        crt_request = self._convert_to_crt_http_request(botocore_http_request)
+
+        return {
+            'request': crt_request,
+            'type': s3_meta_request_type,
+            'recv_filepath': recv_filepath,
+            'send_filepath': send_filepath,
+            'on_done': self.get_crt_callback(future, 'done'),
+            'on_progress': self.get_crt_callback(future, 'progress')
+        }
+
+    def get_crt_callback(self, future, callback_type):
+
+        def invoke_subscriber_callbacks(*args, **kwargs):
+            # TODO The get_callbacks helper will set the first augment
+            # by keyword, the other augments need to be set by keyword
+            # as well. Consider removing the restriction later
+            if callback_type == "progress":
+                callback(bytes_transferred=args[0])
+            else:
+                callback(*args, **kwargs)
+
+        return invoke_subscriber_callbacks
+
+    def _convert_to_crt_http_request(self, botocore_http_request):
+        # Logic that does CRTUtils.crt_request_from_aws_request
+        crt_request = CRTUtil.crt_request_from_aws_request(
+            botocore_http_request)
+        if crt_request.headers.get("host") is None:
+            # If host is not set, set it for the request before using CRT s3
+            url_parts = urlsplit(botocore_http_request.url)
+            crt_request.headers.set("host", url_parts.netloc)
+        return crt_request
+
+    def _capture_http_request(self, request, **kwargs):
+        request.context['http_request'] = request
+
+    def _change_response_to_serialized_http_request(
+            self, context, parsed, **kwargs):
+        request = context['http_request']
+        parsed['HTTPRequest'] = request.prepare()
+
+    def _make_fake_http_response(self, request, **kwargs):
+        return botocore.awsrequest.AWSResponse(
+            None,
+            200,
+            {},
+            FakeRawResponse(b""),
+        )
+
+    def _get_botocore_http_request(self, client_method, call_args):
+        return getattr(self._client, client_method)(
+            Bucket=call_args.bucket, Key=call_args.key,
+            **call_args.extra_args
+        )['HTTPRequest']

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -331,10 +331,9 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
         if 'config' in client_kwargs:
             user_provided_config = client_kwargs['config']
 
-        client_config = Config()
+        client_config = Config(signature_version=UNSIGNED)
         if user_provided_config:
-            client_config.merge(user_provided_config)
-        client_config.signature_version = UNSIGNED
+            client_config = user_provided_config.merge(client_config)
         client_kwargs['config'] = client_config
         client_kwargs["service_name"] = "s3"
 
@@ -445,7 +444,7 @@ class CRTTransferCoordinator:
         if self._s3_request:
             self._s3_request.cancel()
 
-    def result(self, timeout):
+    def result(self, timeout=None):
         if self._exception:
             raise self._exception
         try:

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import argparse
 import os
 import sys
 from subprocess import check_call
@@ -20,10 +21,20 @@ try:
 except KeyError:
     python_version = '.'.join([str(i) for i in sys.version_info[:2]])
 
-run('pip install -r requirements-test.txt')
-run('pip install coverage')
-if os.path.isdir('dist') and os.listdir('dist'):
-    shutil.rmtree('dist')
-run('python setup.py bdist_wheel')
-wheel_dist = os.listdir('dist')[0]
-run('pip install %s' % (os.path.join('dist', wheel_dist)))
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        '-e', '--extras', help='Install extras_require along with normal install'
+    )
+    args = parser.parse_args()
+    run('pip install -r requirements-test.txt')
+    run('pip install coverage')
+    if os.path.isdir('dist') and os.listdir('dist'):
+        shutil.rmtree('dist')
+    run('python setup.py bdist_wheel')
+    wheel_dist = os.listdir('dist')[0]
+    package = os.path.join('dist', wheel_dist)
+    if args.extras:
+        package = "'%s[%s]'" % (package, args.extras)
+    run('pip install %s' % package)

--- a/scripts/ci/run-crt-tests
+++ b/scripts/ci/run-crt-tests
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Don't run tests from the root repo dir.
+# We want to ensure we're importing from the installed
+# binary package not from the CWD.
+
+import os
+import sys
+from subprocess import check_call
+
+_dname = os.path.dirname
+
+REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
+os.chdir(os.path.join(REPO_ROOT, 'tests'))
+
+
+def run(command, env=None):
+    return check_call(command, shell=True, env=env)
+
+try:
+    import awscrt
+except ImportError:
+    print("MISSING DEPENDENCY: awscrt must be installed to run the crt tests.")
+    sys.exit(1)
+
+run('nosetests s3transfer --with-xunit unit/ functional/')
+
+# Run the serial implementation of s3transfer
+os.environ['USE_SERIAL_EXECUTOR'] = 'True'
+run('nosetests -v functional/', env=os.environ)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ universal = 1
 requires_dist =
     botocore>=1.12.36,<2.0a.0
     futures>=2.2.0,<4.0.0; python_version=="2.7"
+
+[options.extras_require]
+crt = botocore[crt]>=1.20.19<2.0a0

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ requires_dist =
     futures>=2.2.0,<4.0.0; python_version=="2.7"
 
 [options.extras_require]
-crt = botocore[crt]>=1.20.19<2.0a0
+crt = botocore[crt]>=1.20.29,<2.0a0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     install_requires=requires,
     extras_require={
         ':python_version=="2.7"': [
-            'futures>=2.2.0,<4.0.0']
+            'futures>=2.2.0,<4.0.0'],
+        'crt': 'botocore[crt]>=1.20.29,<2.0a.0',
     },
     license="Apache License 2.0",
     classifiers=[

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -43,6 +43,12 @@ from s3transfer.utils import SlidingWindowSemaphore
 
 
 ORIGINAL_EXECUTOR_CLS = BoundedExecutor.EXECUTOR_CLS
+# Detect if CRT is available for use
+try:
+    import awscrt.s3
+    HAS_CRT = True
+except ImportError:
+    HAS_CRT = False
 
 
 def setup_package():
@@ -107,6 +113,12 @@ def skip_if_using_serial_implementation(reason):
     return decorator
 
 
+def requires_crt(cls, reason=None):
+    if reason is None:
+        reason = "Test requires awscrt to be installed."
+    return unittest.skipIf(not HAS_CRT, reason)(cls)
+
+
 class StreamWithError(object):
     """A wrapper to simulate errors while reading from a stream
 
@@ -116,6 +128,7 @@ class StreamWithError(object):
         the exception. A value of zero indicates to raise the error on the
         first read.
     """
+
     def __init__(self, stream, exception_type, num_reads=0):
         self._stream = stream
         self._exception_type = exception_type
@@ -189,6 +202,7 @@ class FileCreator(object):
 
 class RecordingOSUtils(OSUtils):
     """An OSUtil abstraction that records openings and renamings"""
+
     def __init__(self):
         super(RecordingOSUtils, self).__init__()
         self.open_records = []
@@ -228,6 +242,7 @@ class RecordingSubscriber(BaseSubscriber):
 
 class TransferCoordinatorWithInterrupt(TransferCoordinator):
     """Used to inject keyboard interrupts"""
+
     def result(self):
         raise KeyboardInterrupt()
 
@@ -244,6 +259,7 @@ class RecordingExecutor(object):
             'kwargs': keyword args (as dict)
         }
     """
+
     def __init__(self, executor):
         self._executor = executor
         self.submissions = []

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -1,0 +1,76 @@
+import mock
+import unittest
+import tempfile
+import os
+
+from awscrt.s3 import S3Client, S3RequestType
+from botocore.session import Session
+
+from s3transfer.crt import CRTTransferManager
+
+from tests import FileCreator
+
+
+class TestCRTTransferManager(unittest.TestCase):
+    def setUp(self):
+        self.s3_crt_client = mock.Mock(S3Client)
+        self.session = Session()
+        self.transfer_manager = CRTTransferManager(
+            crt_s3_client=self.s3_crt_client, session=self.session)
+        self.region = 'us-west-2'
+        self.session = Session()
+        self.session.set_config_variable('region', self.region)
+        self.bucket = "test_bucket"
+        self.key = "test_key"
+        self.files = FileCreator()
+        self.filename = self.files.create_file('myfile', 'my content')
+        self.expected_path = "/" + self.bucket + "/" + self.key
+        self.expected_host = "s3.%s.amazonaws.com" % (self.region)
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    def test_upload(self):
+        future = self.transfer_manager.upload(
+            self.bucket, self.key, self.filename, {}, [])
+        future.result()
+
+        callargs = self.s3_crt_client.make_request.call_args
+        callargs_kwargs = callargs[1]
+        self.assertEqual(callargs_kwargs["send_filepath"], self.filename)
+        self.assertIsNone(callargs_kwargs["recv_filepath"])
+        self.assertEqual(callargs_kwargs["type"], S3RequestType.PUT_OBJECT)
+        crt_request = callargs_kwargs["request"]
+        self.assertEqual("PUT", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+
+    def test_download(self):
+        future = self.transfer_manager.download(
+            self.bucket, self.key, self.filename, {}, [])
+        future.result()
+
+        callargs = self.s3_crt_client.make_request.call_args
+        callargs_kwargs = callargs[1]
+        self.assertEqual(callargs_kwargs["recv_filepath"], self.filename)
+        self.assertIsNone(callargs_kwargs["send_filepath"])
+        self.assertEqual(callargs_kwargs["type"], S3RequestType.GET_OBJECT)
+        crt_request = callargs_kwargs["request"]
+        self.assertEqual("GET", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+
+    def test_delete(self):
+        future = self.transfer_manager.delete(
+            self.bucket, self.key, {}, [])
+        future.result()
+
+        callargs = self.s3_crt_client.make_request.call_args
+        callargs_kwargs = callargs[1]
+        self.assertIsNone(callargs_kwargs["send_filepath"])
+        self.assertIsNone(callargs_kwargs["recv_filepath"])
+        self.assertEqual(callargs_kwargs["type"], S3RequestType.DEFAULT)
+        crt_request = callargs_kwargs["request"]
+        self.assertEqual("DELETE", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -2,6 +2,7 @@ import mock
 import unittest
 import threading
 import re
+import os
 from concurrent.futures import Future
 
 from awscrt.s3 import S3Client, S3RequestType, S3Request
@@ -10,6 +11,7 @@ from botocore.session import Session
 
 from s3transfer.crt import CRTTransferManager, BotocoreCRTRequestSerializer
 from s3transfer.crt import BaseCRTRequestSerializer
+from s3transfer.subscribers import BaseSubscriber
 
 from tests import FileCreator
 
@@ -23,6 +25,32 @@ class submitThread(threading.Thread):
 
     def run(self):
         self._futures.append(self._transfer_manager.download(*self._callargs))
+
+
+class SerializationException(Exception):
+    pass
+
+
+class ExceptionRaisingSerializer(BaseCRTRequestSerializer):
+    def serialize_http_request(self, transfer_type, future):
+        raise SerializationException()
+
+
+class RecordingSubscriber(BaseSubscriber):
+    def __init__(self):
+        self.on_queued_called = False
+        self.on_done_called = False
+        self.bytes_transferred = 0
+        self.on_queued_future = None
+        self.on_done_future = None
+
+    def on_queued(self, future, **kwargs):
+        self.on_queued_called = True
+        self.on_queued_future = future
+
+    def on_done(self, future, **kwargs):
+        self.on_done_called = True
+        self.on_done_future = future
 
 
 class TestCRTTransferManager(unittest.TestCase):
@@ -43,13 +71,41 @@ class TestCRTTransferManager(unittest.TestCase):
         self.transfer_manager = CRTTransferManager(
             crt_s3_client=self.s3_crt_client,
             crt_request_serializer=self.request_serializer)
+        self.record_subscriber = RecordingSubscriber()
 
     def tearDown(self):
         self.files.remove_all()
 
+    def _assert_subscribers_called(self, expected_future=None):
+        self.assertTrue(self.record_subscriber.on_queued_called)
+        self.assertTrue(self.record_subscriber.on_done_called)
+        if expected_future:
+            self.assertIs(
+                self.record_subscriber.on_queued_future,
+                expected_future)
+            self.assertIs(
+                self.record_subscriber.on_done_future,
+                expected_future)
+
+    def _invoke_done_callbacks(self, **kwargs):
+        callargs = self.s3_crt_client.make_request.call_args
+        callargs_kwargs = callargs[1]
+        on_done = callargs_kwargs["on_done"]
+        on_done(error=None)
+
+    def _simulate_file_download(self, recv_filepath):
+        self.files.create_file(recv_filepath, "fake resopnse")
+
+    def _simulate_make_request_side_effect(self, **kwargs):
+        if kwargs.get('recv_filepath'):
+            self._simulate_file_download(kwargs['recv_filepath'])
+        self._invoke_done_callbacks()
+        return mock.DEFAULT
+
     def test_upload(self):
+        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
         future = self.transfer_manager.upload(
-            self.filename, self.bucket, self.key, {}, [])
+            self.filename, self.bucket, self.key, {}, [self.record_subscriber])
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
@@ -61,10 +117,12 @@ class TestCRTTransferManager(unittest.TestCase):
         self.assertEqual("PUT", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self._assert_subscribers_called(future)
 
     def test_download(self):
+        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
         future = self.transfer_manager.download(
-            self.bucket, self.key, self.filename, {}, [])
+            self.bucket, self.key, self.filename, {}, [self.record_subscriber])
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
@@ -79,10 +137,15 @@ class TestCRTTransferManager(unittest.TestCase):
         self.assertEqual("GET", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self._assert_subscribers_called(future)
+        with open(self.filename, 'rb') as f:
+            # Check the fake response overwrites the file because of download
+            self.assertEqual(f.read(), b'fake resopnse')
 
     def test_delete(self):
+        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
         future = self.transfer_manager.delete(
-            self.bucket, self.key, {}, [])
+            self.bucket, self.key, {}, [self.record_subscriber])
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
@@ -94,6 +157,7 @@ class TestCRTTransferManager(unittest.TestCase):
         self.assertEqual("DELETE", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self._assert_subscribers_called(future)
 
     def test_blocks_when_max_requests_processes_reached(self):
         futures = []
@@ -123,10 +187,7 @@ class TestCRTTransferManager(unittest.TestCase):
         self.cancel_called = True
         self.s3_request.finished_future.set_exception(
             crtException.from_code(0))
-        callargs = self.s3_crt_client.make_request.call_args
-        callargs_kwargs = callargs[1]
-        on_done = callargs_kwargs["on_done"]
-        on_done(error=None)
+        self._invoke_done_callbacks()
 
     def test_cancel(self):
         self.s3_request.finished_future = Future()
@@ -143,3 +204,21 @@ class TestCRTTransferManager(unittest.TestCase):
         with self.assertRaises(crtException.AwsCrtError):
             future.result()
         self.assertTrue(self.cancel_called)
+
+    def test_serializer_error_handling(self):
+        not_impl_serializer = ExceptionRaisingSerializer()
+        transfer_manager = CRTTransferManager(
+            crt_s3_client=self.s3_crt_client,
+            crt_request_serializer=not_impl_serializer)
+        future = transfer_manager.upload(
+            self.filename, self.bucket, self.key, {}, [])
+
+        with self.assertRaises(SerializationException):
+            future.result()
+
+    def test_crt_s3_client_error_handling(self):
+        self.s3_crt_client.make_request.side_effect = crtException.from_code(0)
+        future = self.transfer_manager.upload(
+            self.filename, self.bucket, self.key, {}, [])
+        with self.assertRaises(crtException.AwsCrtError):
+            future.result()

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -1,3 +1,15 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 import mock
 import unittest
 import threading

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -162,8 +162,8 @@ class TestCRTTransferManager(unittest.TestCase):
     def test_blocks_when_max_requests_processes_reached(self):
         futures = []
         callargs = (self.bucket, self.key, self.filename, {}, [])
-        all_concurrent = 33
-        max_request_processes = 32  # the hard coded max processes
+        max_request_processes = 128  # the hard coded max processes
+        all_concurrent = max_request_processes + 1
         threads = []
         for i in range(0, all_concurrent):
             thread = submitThread(self.transfer_manager, futures, callargs)

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -18,11 +18,11 @@ from tests.integration import BaseTransferManagerIntegTest
 from tests import assert_files_equal
 
 from s3transfer.subscribers import BaseSubscriber
-from awscrt.exceptions import AwsCrtError
 from tests import requires_crt, HAS_CRT
 
 if HAS_CRT:
     import s3transfer.crt
+    from awscrt.exceptions import AwsCrtError
 
 
 class RecordingSubscriber(BaseSubscriber):

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -1,0 +1,226 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+
+from tests.integration import BaseTransferManagerIntegTest
+from tests import assert_files_equal
+
+import s3transfer.crt as crt
+
+
+class TestCRTS3Transfers(BaseTransferManagerIntegTest):
+    """Tests for the high level s3transfer based on CRT implementation."""
+
+    def create_s3_transfer(self, config=None):
+        return crt.CRTTransferManager(
+            self.session, config=config
+        )
+
+    def assert_has_public_read_acl(self, response):
+        grants = response['Grants']
+        public_read = [g['Grantee'].get('URI', '') for g in grants
+                       if g['Permission'] == 'READ']
+        self.assertIn('groups/global/AllUsers', public_read[0])
+
+    def test_upload_below_multipart_chunksize(self):
+        config = crt.CRTTransferConfig(
+            multipart_chunksize=5 * 1024 * 1024)
+        transfer = self.create_s3_transfer(config)
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        self.addCleanup(self.delete_object, 'foo.txt')
+
+        with transfer:
+            future = transfer.upload(self.bucket_name,
+                                     'foo.txt', filename)
+            future.result()
+
+        self.assertTrue(self.object_exists('foo.txt'))
+
+    def test_upload_above_multipart_chunksize(self):
+        config = crt.CRTTransferConfig(
+            multipart_chunksize=5 * 1024 * 1024)
+        transfer = self.create_s3_transfer(config)
+        filename = self.files.create_file_with_size(
+            '20mb.txt', filesize=20 * 1024 * 1024)
+        self.addCleanup(self.delete_object, '20mb.txt')
+
+        with transfer:
+            future = transfer.upload(self.bucket_name,
+                                     '20mb.txt', filename)
+            future.result()
+        self.assertTrue(self.object_exists('20mb.txt'))
+
+    def test_upload_file_above_threshold_with_acl(self):
+        config = crt.CRTTransferConfig(
+            multipart_chunksize=5 * 1024 * 1024)
+        transfer = self.create_s3_transfer(config)
+        filename = self.files.create_file_with_size(
+            '6mb.txt', filesize=6 * 1024 * 1024)
+        extra_args = {'ACL': 'public-read'}
+        self.addCleanup(self.delete_object, '6mb.txt')
+
+        with transfer:
+            future = transfer.upload(self.bucket_name,
+                                     '6mb.txt', filename, extra_args=extra_args)
+            future.result()
+
+        self.assertTrue(self.object_exists('6mb.txt'))
+        response = self.client.get_object_acl(
+            Bucket=self.bucket_name, Key='6mb.txt')
+        self.assert_has_public_read_acl(response)
+
+    def test_upload_file_above_threshold_with_ssec(self):
+        key_bytes = os.urandom(32)
+        extra_args = {
+            'SSECustomerKey': key_bytes,
+            'SSECustomerAlgorithm': 'AES256',
+        }
+        config = crt.CRTTransferConfig(
+            multipart_chunksize=5 * 1024 * 1024)
+        transfer = self.create_s3_transfer(config)
+        filename = self.files.create_file_with_size(
+            '6mb.txt', filesize=6 * 1024 * 1024)
+        self.addCleanup(self.delete_object, '6mb.txt')
+        with transfer:
+            future = transfer.upload(self.bucket_name,
+                                     '6mb.txt', filename, extra_args=extra_args)
+            future.result()
+        # A head object will fail if it has a customer key
+        # associated with it and it's not provided in the HeadObject
+        # request so we can use this to verify our functionality.
+        oringal_extra_args = {
+            'SSECustomerKey': key_bytes,
+            'SSECustomerAlgorithm': 'AES256',
+        }
+        self.wait_object_exists('6mb.txt', oringal_extra_args)
+        response = self.client.head_object(
+            Bucket=self.bucket_name,
+            Key='6mb.txt', **oringal_extra_args)
+        self.assertEqual(response['SSECustomerAlgorithm'], 'AES256')
+
+    def test_can_send_extra_params_on_download(self):
+        # We're picking the customer provided sse feature
+        # of S3 to test the extra_args functionality of
+        # S3.
+        key_bytes = os.urandom(32)
+        extra_args = {
+            'SSECustomerKey': key_bytes,
+            'SSECustomerAlgorithm': 'AES256',
+        }
+        filename = self.files.create_file('foo.txt', 'hello world')
+        self.upload_file(filename, 'foo.txt', extra_args)
+        transfer = self.create_s3_transfer()
+
+        download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
+        with transfer:
+            future = transfer.download(self.bucket_name, 'foo.txt',
+                                       download_path, extra_args=extra_args)
+            future.result()
+        with open(download_path, 'rb') as f:
+            self.assertEqual(f.read(), b'hello world')
+
+    def test_download_below_threshold(self):
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        self.upload_file(filename, 'foo.txt')
+
+        download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
+        with transfer:
+            future = transfer.download(self.bucket_name, 'foo.txt',
+                                       download_path)
+            future.result()
+        assert_files_equal(filename, download_path)
+
+    def test_download_above_threshold(self):
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=20 * 1024 * 1024)
+        self.upload_file(filename, 'foo.txt')
+
+        download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
+        with transfer:
+            future = transfer.download(self.bucket_name, 'foo.txt',
+                                       download_path)
+            future.result()
+        assert_files_equal(filename, download_path)
+
+    def test_delete(self):
+        transfer = self.create_s3_transfer()
+        filename = self.files.create_file_with_size(
+            'foo.txt', filesize=1024 * 1024)
+        self.upload_file(filename, 'foo.txt')
+
+        with transfer:
+            future = transfer.delete(self.bucket_name, 'foo.txt')
+            future.result()
+        self.assertTrue(self.object_not_exists('foo.txt'))
+
+    def test_many_files_download(self):
+        transfer = self.create_s3_transfer()
+
+        filename = self.files.create_file_with_size(
+            '1mb.txt', filesize=1024 * 1024)
+        self.upload_file(filename, '1mb.txt')
+
+        filenames = []
+        base_filename = os.path.join(self.files.rootdir, 'file')
+        for i in range(10):
+            filenames.append(base_filename + str(i))
+
+        with transfer:
+            for filename in filenames:
+                transfer.download(
+                    self.bucket_name, '1mb.txt', filename)
+        for download_path in filenames:
+            assert_files_equal(filename, download_path)
+
+    def test_many_files_upload(self):
+        transfer = self.create_s3_transfer()
+        keys = []
+        filenames = []
+        base_key = 'foo'
+        sufix = '.txt'
+        for i in range(10):
+            key = base_key + str(i) + sufix
+            keys.append(key)
+            filename = self.files.create_file_with_size(
+                key, filesize=1024 * 1024)
+            filenames.append(filename)
+            self.addCleanup(self.delete_object, key)
+        with transfer:
+            for filename, key in zip(filenames, keys):
+                transfer.upload(
+                    self.bucket_name, key, filename)
+
+        for key in keys:
+            self.assertTrue(self.object_exists(key))
+
+    def test_many_files_delete(self):
+        transfer = self.create_s3_transfer()
+        keys = []
+        base_key = 'foo'
+        sufix = '.txt'
+        filename = self.files.create_file_with_size(
+            '1mb.txt', filesize=1024 * 1024)
+        for i in range(10):
+            key = base_key + str(i) + sufix
+            keys.append(key)
+            self.upload_file(filename, key)
+
+        with transfer:
+            for key in keys:
+                transfer.delete(self.bucket_name, key)
+        for key in keys:
+            self.assertTrue(self.object_not_exists(key))

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -1,0 +1,67 @@
+
+import unittest
+import mock
+
+from botocore.session import Session
+
+from s3transfer.crt import BotocoreCRTRequestSerializer
+from s3transfer.crt import CRTTransferCoordinator, CRTTransferFuture, CRTTransferMeta
+from s3transfer.utils import CallArgs
+
+from tests import FileCreator
+
+
+class TestBotocoreCRTRequestSerializer(unittest.TestCase):
+    def setUp(self):
+        self.region = 'us-west-2'
+        self.session = Session()
+        self.session.set_config_variable('region', self.region)
+        self.request_serializer = BotocoreCRTRequestSerializer(self.session)
+        self.bucket = "test_bucket"
+        self.key = "test_key"
+        self.files = FileCreator()
+        self.filename = self.files.create_file('myfile', 'my content')
+        self.expected_path = "/" + self.bucket + "/" + self.key
+        self.expected_host = "s3.%s.amazonaws.com" % (self.region)
+
+    def test_upload_request(self):
+        callargs = CallArgs(
+            bucket=self.bucket, key=self.key, fileobj=self.filename,
+            extra_args={}, subscribers=[])
+        coordinator = CRTTransferCoordinator()
+        future = CRTTransferFuture(
+            CRTTransferMeta(call_args=callargs),
+            coordinator)
+        crt_request = self.request_serializer.serialize_http_request(
+            "put_object", future)
+        self.assertEqual("PUT", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+
+    def test_download_request(self):
+        callargs = CallArgs(
+            bucket=self.bucket, key=self.key, fileobj=self.filename,
+            extra_args={}, subscribers=[])
+        coordinator = CRTTransferCoordinator()
+        future = CRTTransferFuture(
+            CRTTransferMeta(call_args=callargs),
+            coordinator)
+        crt_request = self.request_serializer.serialize_http_request(
+            "get_object", future)
+        self.assertEqual("GET", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+
+    def test_delete_request(self):
+        callargs = CallArgs(
+            bucket=self.bucket, key=self.key,
+            extra_args={}, subscribers=[])
+        coordinator = CRTTransferCoordinator()
+        future = CRTTransferFuture(
+            CRTTransferMeta(call_args=callargs),
+            coordinator)
+        crt_request = self.request_serializer.serialize_http_request(
+            "delete_object", future)
+        self.assertEqual("DELETE", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -1,4 +1,15 @@
-
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 import unittest
 import mock
 

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -1,22 +1,24 @@
 
 import unittest
-import mock
 
 from botocore.session import Session
-from awscrt.s3 import S3Client
-from s3transfer.crt import BotocoreCRTRequestSerializer, create_s3_crt_client
-from s3transfer.crt import CRTTransferCoordinator, CRTTransferFuture, CRTTransferMeta
-from s3transfer.utils import CallArgs, OSUtils
+from s3transfer.utils import CallArgs
 
 from tests import FileCreator
+from tests import requires_crt, HAS_CRT
+
+if HAS_CRT:
+    import s3transfer.crt
 
 
+@requires_crt
 class TestBotocoreCRTRequestSerializer(unittest.TestCase):
     def setUp(self):
         self.region = 'us-west-2'
         self.session = Session()
         self.session.set_config_variable('region', self.region)
-        self.request_serializer = BotocoreCRTRequestSerializer(self.session)
+        self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
+            self.session)
         self.bucket = "test_bucket"
         self.key = "test_key"
         self.files = FileCreator()
@@ -31,9 +33,9 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         callargs = CallArgs(
             bucket=self.bucket, key=self.key, fileobj=self.filename,
             extra_args={}, subscribers=[])
-        coordinator = CRTTransferCoordinator()
-        future = CRTTransferFuture(
-            CRTTransferMeta(call_args=callargs),
+        coordinator = s3transfer.crt.CRTTransferCoordinator()
+        future = s3transfer.crt.CRTTransferFuture(
+            s3transfer.crt.CRTTransferMeta(call_args=callargs),
             coordinator)
         crt_request = self.request_serializer.serialize_http_request(
             "put_object", future)
@@ -46,9 +48,9 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         callargs = CallArgs(
             bucket=self.bucket, key=self.key, fileobj=self.filename,
             extra_args={}, subscribers=[])
-        coordinator = CRTTransferCoordinator()
-        future = CRTTransferFuture(
-            CRTTransferMeta(call_args=callargs),
+        coordinator = s3transfer.crt.CRTTransferCoordinator()
+        future = s3transfer.crt.CRTTransferFuture(
+            s3transfer.crt.CRTTransferMeta(call_args=callargs),
             coordinator)
         crt_request = self.request_serializer.serialize_http_request(
             "get_object", future)
@@ -61,9 +63,9 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         callargs = CallArgs(
             bucket=self.bucket, key=self.key,
             extra_args={}, subscribers=[])
-        coordinator = CRTTransferCoordinator()
-        future = CRTTransferFuture(
-            CRTTransferMeta(call_args=callargs),
+        coordinator = s3transfer.crt.CRTTransferCoordinator()
+        future = s3transfer.crt.CRTTransferFuture(
+            s3transfer.crt.CRTTransferMeta(call_args=callargs),
             coordinator)
         crt_request = self.request_serializer.serialize_http_request(
             "delete_object", future)

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -3,10 +3,10 @@ import unittest
 import mock
 
 from botocore.session import Session
-
-from s3transfer.crt import BotocoreCRTRequestSerializer
+from awscrt.s3 import S3Client
+from s3transfer.crt import BotocoreCRTRequestSerializer, create_s3_crt_client
 from s3transfer.crt import CRTTransferCoordinator, CRTTransferFuture, CRTTransferMeta
-from s3transfer.utils import CallArgs
+from s3transfer.utils import CallArgs, OSUtils
 
 from tests import FileCreator
 
@@ -23,6 +23,79 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         self.filename = self.files.create_file('myfile', 'my content')
         self.expected_path = "/" + self.bucket + "/" + self.key
         self.expected_host = "s3.%s.amazonaws.com" % (self.region)
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    def test_upload_request(self):
+        callargs = CallArgs(
+            bucket=self.bucket, key=self.key, fileobj=self.filename,
+            extra_args={}, subscribers=[])
+        coordinator = CRTTransferCoordinator()
+        future = CRTTransferFuture(
+            CRTTransferMeta(call_args=callargs),
+            coordinator)
+        crt_request = self.request_serializer.serialize_http_request(
+            "put_object", future)
+        self.assertEqual("PUT", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+
+    def test_download_request(self):
+        callargs = CallArgs(
+            bucket=self.bucket, key=self.key, fileobj=self.filename,
+            extra_args={}, subscribers=[])
+        coordinator = CRTTransferCoordinator()
+        future = CRTTransferFuture(
+            CRTTransferMeta(call_args=callargs),
+            coordinator)
+        crt_request = self.request_serializer.serialize_http_request(
+            "get_object", future)
+        self.assertEqual("GET", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+
+    def test_delete_request(self):
+        callargs = CallArgs(
+            bucket=self.bucket, key=self.key,
+            extra_args={}, subscribers=[])
+        coordinator = CRTTransferCoordinator()
+        future = CRTTransferFuture(
+            CRTTransferMeta(call_args=callargs),
+            coordinator)
+        crt_request = self.request_serializer.serialize_http_request(
+            "delete_object", future)
+        self.assertEqual("DELETE", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+
+
+class TestBotocoreCRTRequestSerializer(unittest.TestCase):
+    def setUp(self):
+        self.region = 'us-west-2'
+        self.session = Session()
+        self.session.set_config_variable('region', self.region)
+        self.request_serializer = BotocoreCRTRequestSerializer(self.session)
+        self.bucket = "test_bucket"
+        self.key = "test_key"
+        self.files = FileCreator()
+        self.filename = self.files.create_file('myfile', 'my content')
+        self.expected_path = "/" + self.bucket + "/" + self.key
+        self.expected_host = "s3.%s.amazonaws.com" % (self.region)
+
+    def test_upload_request(self):
+        callargs = CallArgs(
+            bucket=self.bucket, key=self.key, fileobj=self.filename,
+            extra_args={}, subscribers=[])
+        coordinator = CRTTransferCoordinator()
+        future = CRTTransferFuture(
+            CRTTransferMeta(call_args=callargs),
+            coordinator)
+        crt_request = self.request_serializer.serialize_http_request(
+            "put_object", future)
+        self.assertEqual("PUT", crt_request.method)
+        self.assertEqual(self.expected_path, crt_request.path)
+        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
 
     def test_upload_request(self):
         callargs = CallArgs(

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -40,6 +40,7 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         self.assertEqual("PUT", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self.assertIsNone(crt_request.headers.get("Authorization"))
 
     def test_download_request(self):
         callargs = CallArgs(
@@ -54,6 +55,7 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         self.assertEqual("GET", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self.assertIsNone(crt_request.headers.get("Authorization"))
 
     def test_delete_request(self):
         callargs = CallArgs(
@@ -68,73 +70,4 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         self.assertEqual("DELETE", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
-
-
-class TestBotocoreCRTRequestSerializer(unittest.TestCase):
-    def setUp(self):
-        self.region = 'us-west-2'
-        self.session = Session()
-        self.session.set_config_variable('region', self.region)
-        self.request_serializer = BotocoreCRTRequestSerializer(self.session)
-        self.bucket = "test_bucket"
-        self.key = "test_key"
-        self.files = FileCreator()
-        self.filename = self.files.create_file('myfile', 'my content')
-        self.expected_path = "/" + self.bucket + "/" + self.key
-        self.expected_host = "s3.%s.amazonaws.com" % (self.region)
-
-    def test_upload_request(self):
-        callargs = CallArgs(
-            bucket=self.bucket, key=self.key, fileobj=self.filename,
-            extra_args={}, subscribers=[])
-        coordinator = CRTTransferCoordinator()
-        future = CRTTransferFuture(
-            CRTTransferMeta(call_args=callargs),
-            coordinator)
-        crt_request = self.request_serializer.serialize_http_request(
-            "put_object", future)
-        self.assertEqual("PUT", crt_request.method)
-        self.assertEqual(self.expected_path, crt_request.path)
-        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
-
-    def test_upload_request(self):
-        callargs = CallArgs(
-            bucket=self.bucket, key=self.key, fileobj=self.filename,
-            extra_args={}, subscribers=[])
-        coordinator = CRTTransferCoordinator()
-        future = CRTTransferFuture(
-            CRTTransferMeta(call_args=callargs),
-            coordinator)
-        crt_request = self.request_serializer.serialize_http_request(
-            "put_object", future)
-        self.assertEqual("PUT", crt_request.method)
-        self.assertEqual(self.expected_path, crt_request.path)
-        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
-
-    def test_download_request(self):
-        callargs = CallArgs(
-            bucket=self.bucket, key=self.key, fileobj=self.filename,
-            extra_args={}, subscribers=[])
-        coordinator = CRTTransferCoordinator()
-        future = CRTTransferFuture(
-            CRTTransferMeta(call_args=callargs),
-            coordinator)
-        crt_request = self.request_serializer.serialize_http_request(
-            "get_object", future)
-        self.assertEqual("GET", crt_request.method)
-        self.assertEqual(self.expected_path, crt_request.path)
-        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
-
-    def test_delete_request(self):
-        callargs = CallArgs(
-            bucket=self.bucket, key=self.key,
-            extra_args={}, subscribers=[])
-        coordinator = CRTTransferCoordinator()
-        future = CRTTransferFuture(
-            CRTTransferMeta(call_args=callargs),
-            coordinator)
-        crt_request = self.request_serializer.serialize_http_request(
-            "delete_object", future)
-        self.assertEqual("DELETE", crt_request.method)
-        self.assertEqual(self.expected_path, crt_request.path)
-        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self.assertIsNone(crt_request.headers.get("Authorization"))


### PR DESCRIPTION
AWS CRT provides a C-based S3 transfer client that can improve transfer throughput for uploads and downloads. You will now be able to install `s3transfer` with `crt` as an optional dependency:
```
pip install s3transfer[crt]
```
And then use transfer manager abstractions from the `s3transfer.crt` module in order to leverage the performance from the CRT S3 transfer client while using a similar interface as the `s3transfer.manager.TransferManager` class.