### PR TITLE
docs: fix typos

### DIFF
--- a/.github/workflows/fail-master-prs.yml
+++ b/.github/workflows/fail-master-prs.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - name: Fail PRs against master
         run: |
-          echo "PRs must be made aginst the develop branch."
+          echo "PRs must be made against the develop branch."
           exit 1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,7 +54,7 @@ CHANGELOG
 0.2.1
 =====
 
-* enhancment:ProcessPool: Adds user agent suffix.
+* enhancement:ProcessPool: Adds user agent suffix.
 
 
 0.2.0

--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -72,7 +72,7 @@ client operation.  Here are a few examples using ``upload_file``::
                          extra_args={'ContentType': "application/json"})
 
 
-The ``S3Transfer`` clas also supports progress callbacks so you can
+The ``S3Transfer`` class also supports progress callbacks so you can
 provide transfer progress to users.  Both the ``upload_file`` and
 ``download_file`` methods take an optional ``callback`` parameter.
 Here's an example of how to print a simple progress percentage

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -492,7 +492,7 @@ class GetObjectTask(Task):
         :param bucket: The bucket to download from
         :param key: The key to download from
         :param fileobj: The file handle to write content to
-        :param exta_args: Any extra arguements to include in GetObject request
+        :param exta_args: Any extra arguments to include in GetObject request
         :param callbacks: List of progress callbacks to invoke on download
         :param max_attempts: The number of retries to do when downloading
         :param download_output_manager: The download output manager associated

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -71,7 +71,7 @@ class TransferConfig(object):
             processing a call to a TransferManager method. Processing a
             call usually entails determining which S3 API requests that need
             to be enqueued, but does **not** entail making any of the
-            S3 API data transfering requests needed to perform the transfer.
+            S3 API data transferring requests needed to perform the transfer.
             The threads controlled by ``max_request_concurrency`` is
             responsible for that.
 
@@ -99,7 +99,7 @@ class TransferConfig(object):
             will be tried upon errors with downloading an object in S3. Note
             that these retries account for errors that occur when streamming
             down the data from s3 (i.e. socket errors and read timeouts that
-            occur after recieving an OK response from s3).
+            occur after receiving an OK response from s3).
             Other retryable exceptions such as throttling errors and 5xx errors
             are already retried by botocore (this default is 5). The
             ``num_download_attempts`` does not take into account the
@@ -640,7 +640,7 @@ class TransferCoordinatorController(object):
             self._tracked_transfer_coordinators.add(transfer_coordinator)
 
     def remove_transfer_coordinator(self, transfer_coordinator):
-        """Remove a transfer coordinator from cancelation consideration
+        """Remove a transfer coordinator from cancellation consideration
 
         Typically, this method is invoked by the transfer coordinator itself
         to remove its self when it completes its transfer.

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -476,7 +476,7 @@ class ProcessPoolTransferFuture(BaseTransferFuture):
         """The future associated to a submitted process pool transfer request
 
         :type monitor: TransferMonitor
-        :param monitor: The monitor associated to the proccess pool downloader
+        :param monitor: The monitor associated to the process pool downloader
 
         :type meta: ProcessPoolTransferMeta
         :param meta: The metadata associated to the request. This object
@@ -566,7 +566,7 @@ class ClientFactory(object):
 
 class TransferMonitor(object):
     def __init__(self):
-        """Monitors transfers for cross-proccess communication
+        """Monitors transfers for cross-process communication
 
         Notifications can be sent to the monitor and information can be
         retrieved from the monitor for a particular transfer. This abstraction

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -186,7 +186,7 @@ class Task(object):
         #
         # concurrent.futures.wait() is not used instead because of this
         # reported issue: https://bugs.python.org/issue20319.
-        # The issue would occassionally cause multipart uploads to hang
+        # The issue would occasionally cause multipart uploads to hang
         # when wait() was called. With this approach, it avoids the
         # concurrency bug by removing any association with concurrent.futures
         # implementation of waiters.
@@ -324,7 +324,7 @@ class CreateMultipartUploadTask(Task):
         :param bucket: The name of the bucket to upload to
         :param key: The name of the key to upload to
         :param extra_args: A dictionary of any extra arguments that may be
-            used in the intialization.
+            used in the initialization.
 
         :returns: The upload id of the multipart upload
         """

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -592,7 +592,7 @@ class TaskSemaphore(object):
             needed for API compatibility with the SlidingWindowSemaphore
             implementation.
         :param block: If True, block until it can be acquired. If False,
-            do not block and raise an exception if cannot be aquired.
+            do not block and raise an exception if cannot be acquired.
 
         :returns: A token (can be None) to use when releasing the semaphore
         """

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -684,7 +684,7 @@ class TestGetObjectTask(BaseTaskTest):
 
         self.stubber.assert_no_pending_responses()
         expected_contents = []
-        # This is the content intially read in before the retry hit on the
+        # This is the content initially read in before the retry hit on the
         # second read()
         expected_contents.append((0, bytes(self.content[0:1])))
 


### PR DESCRIPTION
Hello,

This huge PR will fix : 

- 1 typo in `.github/workflows/fail-master-prs.yml`
- 1 typo in `CHANGELOG.rst`
- 1 typo in `s3transfer/__init__.py`
- 1 typo in `s3transfer/download.py`
- 3 typos in `s3transfer/manager.py`
- 2 typos in `s3transfer/processpool.py`
- 2 typos in `s3transfer/tasks.py`
- 1 typo in `s3transfer/utils.py`
- 1 typo in `tests/unit/test_download.py`



Best! :robot: