### PR TITLE
Add set_exception for CRT Transfer future

### DIFF
--- a/.changes/next-release/enhancement-crt-20073.json
+++ b/.changes/next-release/enhancement-crt-20073.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``crt``",
+  "description": "Add ``set_exception`` to ``CRTTransferFuture`` to allow setting exceptions in subscribers."
+}

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -27,6 +27,7 @@ from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
 from awscrt.io import ClientTlsContext, TlsContextOptions
 from awscrt.auth import AwsCredentialsProvider, AwsCredentials
 
+from s3transfer.exceptions import TransferNotDoneError
 from s3transfer.futures import BaseTransferFuture, BaseTransferMeta
 from s3transfer.utils import CallArgs, OSUtils, get_callbacks
 from s3transfer.constants import GB, MB
@@ -316,6 +317,14 @@ class CRTTransferFuture(BaseTransferFuture):
 
     def cancel(self):
         self._coordinator.cancel()
+
+    def set_exception(self, exception):
+        """Sets the exception on the future."""
+        if not self.done():
+            raise TransferNotDoneError(
+                'set_exception can only be called once the transfer is '
+                'complete.')
+        self._coordinator.set_exception(exception, override=True)
 
 
 class BaseCRTRequestSerializer:


### PR DESCRIPTION
This enables more parity with the threaded, Python transfer manager where a subscriber can set an exception in the on_done
callback such as failing to delete the source file after transferring it.