### PR TITLE
Drop support for Python 2.7

### DIFF
--- a/.changes/next-release/feature-Python-9693.json
+++ b/.changes/next-release/feature-Python-9693.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Python",
+  "description": "Dropped support for Python 2.7"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,9 @@
 [bdist_wheel]
-universal = 1
+universal = 0
 
 [metadata]
 requires_dist =
     botocore>=1.12.36,<2.0a.0
-    futures>=2.2.0,<4.0.0; python_version=="2.7"
 
 [options.extras_require]
 crt = botocore[crt]>=1.20.29,<2.0a0

--- a/setup.py
+++ b/setup.py
@@ -31,18 +31,16 @@ setup(
     include_package_data=True,
     install_requires=requires,
     extras_require={
-        ':python_version=="2.7"': [
-            'futures>=2.2.0,<4.0.0'],
         'crt': 'botocore[crt]>=1.20.29,<2.0a.0',
     },
     license="Apache License 2.0",
+    python_requires=">= 3.6",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38
+envlist = py36,py37,py38
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
As announced in our [blog post](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/) in January, we will be formally dropping support for Python 2.7 on July 15, 2021. This PR will make final changes required to remove references to Python 2.7, update testing infrastructure, and wheel generation settings.

For those looking to continue receiving updates after the deprecation date, we recommend following the instructions in our [blog post](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/) to upgrade to Python 3.6 or later.