### PR TITLE
Replace deprecated unittest aliases

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -451,7 +451,7 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
         self.assertEqual(future.meta.transfer_id, 1)
 
     def test_invalid_extra_args(self):
-        with self.assertRaisesRegexp(ValueError, 'Invalid extra_args'):
+        with self.assertRaisesRegex(ValueError, 'Invalid extra_args'):
             self.method(
                 extra_args=self.create_invalid_extra_args(),
                 **self.create_call_kwargs()

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -281,13 +281,13 @@ class TestNonMultipartCopy(BaseCopyTest):
             'arn:aws:s3-object-lambda:us-west-2:123456789012:'
             'accesspoint:my-accesspoint'
         )
-        with self.assertRaisesRegexp(ValueError, 'methods do not support'):
+        with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.copy(self.copy_source, s3_object_lambda_arn, self.key)
 
     def test_raise_exception_on_s3_object_lambda_resource_as_source(self):
         source = {'Bucket': 'arn:aws:s3-object-lambda:us-west-2:123456789012:'
                             'accesspoint:my-accesspoint'}
-        with self.assertRaisesRegexp(ValueError, 'methods do not support'):
+        with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.copy(source, self.bucket, self.key)
 
 
@@ -540,7 +540,7 @@ class TestMultipartCopy(BaseCopyTest):
         )
 
         future = self.manager.copy(**self.create_call_kwargs())
-        with self.assertRaisesRegexp(ClientError, 'ArbitraryFailure'):
+        with self.assertRaisesRegex(ClientError, 'ArbitraryFailure'):
             future.result()
         self.stubber.assert_no_pending_responses()
 

--- a/tests/functional/test_delete.py
+++ b/tests/functional/test_delete.py
@@ -69,5 +69,5 @@ class TestDeleteObject(BaseGeneralInterfaceTest):
             'arn:aws:s3-object-lambda:us-west-2:123456789012:'
             'accesspoint:my-accesspoint'
         )
-        with self.assertRaisesRegexp(ValueError, 'methods do not support'):
+        with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.delete(s3_object_lambda_arn, self.key)

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -343,7 +343,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
             'arn:aws:s3-object-lambda:us-west-2:123456789012:'
             'accesspoint:my-accesspoint'
         )
-        with self.assertRaisesRegexp(ValueError, 'methods do not support'):
+        with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.download(
                 s3_object_lambda_arn, self.key, self.filename, self.extra_args)
 

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -85,7 +85,7 @@ class TestTransferManager(StubbedClientTest):
         except ArbitraryException:
             # At least one of the submitted futures should have been
             # cancelled.
-            with self.assertRaisesRegexp(FatalError, ref_exception_msg):
+            with self.assertRaisesRegex(FatalError, ref_exception_msg):
                 for future in futures:
                     future.result()
 
@@ -122,7 +122,7 @@ class TestTransferManager(StubbedClientTest):
         except KeyboardInterrupt:
             # At least one of the submitted futures should have been
             # cancelled.
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                     CancelledError, 'KeyboardInterrupt()'):
                 for future in futures:
                     future.result()

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -271,7 +271,7 @@ class TestNonMultipartUpload(BaseUploadTest):
             'arn:aws:s3-object-lambda:us-west-2:123456789012:'
             'accesspoint:my-accesspoint'
         )
-        with self.assertRaisesRegexp(ValueError, 'methods do not support'):
+        with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.upload(self.filename, s3_object_lambda_arn, self.key)
 
 

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -109,7 +109,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         )
 
         # Make sure the future was cancelled because of the KeyboardInterrupt
-        with self.assertRaisesRegexp(CancelledError, 'KeyboardInterrupt()'):
+        with self.assertRaisesRegex(CancelledError, 'KeyboardInterrupt()'):
             future.result()
 
         # Make sure the actual file and the temporary do not exist
@@ -163,7 +163,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         )
 
         # Make sure at least one of the futures got cancelled
-        with self.assertRaisesRegexp(CancelledError, 'KeyboardInterrupt()'):
+        with self.assertRaisesRegex(CancelledError, 'KeyboardInterrupt()'):
             for future in futures:
                 future.result()
 

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -152,7 +152,7 @@ class TestUpload(BaseTransferManagerIntegTest):
         )
 
         # Make sure at least one of the futures got cancelled
-        with self.assertRaisesRegexp(CancelledError, 'KeyboardInterrupt()'):
+        with self.assertRaisesRegex(CancelledError, 'KeyboardInterrupt()'):
             for future in futures:
                 future.result()
         # For the transfer that did get cancelled, make sure the object

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -260,14 +260,14 @@ class TestTransferCoordinator(unittest.TestCase):
         message = 'my message'
         self.transfer_coordinator.cancel(message)
         self.transfer_coordinator.announce_done()
-        with self.assertRaisesRegexp(CancelledError, message):
+        with self.assertRaisesRegex(CancelledError, message):
             self.transfer_coordinator.result()
 
     def test_cancel_with_provided_exception(self):
         message = 'my message'
         self.transfer_coordinator.cancel(message, exc_type=FatalError)
         self.transfer_coordinator.announce_done()
-        with self.assertRaisesRegexp(FatalError, message):
+        with self.assertRaisesRegex(FatalError, message):
             self.transfer_coordinator.result()
 
     def test_cancel_cannot_override_done_state(self):
@@ -633,7 +633,7 @@ class TestNonThreadedExecutorFuture(unittest.TestCase):
     def test_exception_result(self):
         exception = ValueError('message')
         self.future.set_exception_info(exception, None)
-        with self.assertRaisesRegexp(ValueError, 'message'):
+        with self.assertRaisesRegex(ValueError, 'message'):
             self.future.result()
 
     def test_exception_result_doesnt_modify_last_frame(self):

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -84,7 +84,7 @@ class TestTransferCoordinatorController(unittest.TestCase):
             transfer_coordinator)
         self.coordinator_controller.cancel(message)
         transfer_coordinator.announce_done()
-        with self.assertRaisesRegexp(CancelledError, message):
+        with self.assertRaisesRegex(CancelledError, message):
             transfer_coordinator.result()
 
     def test_cancel_with_provided_exception(self):
@@ -94,7 +94,7 @@ class TestTransferCoordinatorController(unittest.TestCase):
             transfer_coordinator)
         self.coordinator_controller.cancel(message, exc_type=FatalError)
         transfer_coordinator.announce_done()
-        with self.assertRaisesRegexp(FatalError, message):
+        with self.assertRaisesRegex(FatalError, message):
             transfer_coordinator.result()
 
     def test_wait_for_done_transfer_coordinators(self):

--- a/tests/unit/test_s3transfer.py
+++ b/tests/unit/test_s3transfer.py
@@ -455,7 +455,7 @@ class TestMultipartDownloader(unittest.TestCase):
                                          os_layer, SequentialExecutor)
         # We're verifying that the exception raised from the IO future
         # propogates back up via download_file().
-        with self.assertRaisesRegexp(Exception, "fake IO error"):
+        with self.assertRaisesRegex(Exception, "fake IO error"):
             downloader.download_file('bucket', 'key', 'filename',
                                      len(response_body), {})
 
@@ -480,7 +480,7 @@ class TestMultipartDownloader(unittest.TestCase):
         downloader = MultipartDownloader(client, TransferConfig(),
                                          InMemoryOSLayer({}),
                                          FailedDownloadParts)
-        with self.assertRaisesRegexp(Exception, "fake download parts error"):
+        with self.assertRaisesRegex(Exception, "fake download parts error"):
             downloader.download_file('bucket', 'key', 'filename',
                                      len(response_body), {})
 

--- a/tests/unit/test_subscribers.py
+++ b/tests/unit/test_subscribers.py
@@ -78,11 +78,11 @@ class TestSubscribers(unittest.TestCase):
             OverrideConstructorSubscriber()
 
     def test_not_callable_in_subclass_subscriber_method(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 InvalidSubscriberMethodError, 'must be callable'):
             NotCallableSubscriber()
 
     def test_no_kwargs_in_subclass_subscriber_method(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 InvalidSubscriberMethodError, 'must accept keyword'):
             NoKwargsSubscriber()


### PR DESCRIPTION
https://docs.python.org/3/library/unittest.html#deprecated-aliases