### PR TITLE
Rework test runners to centralized workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,3 @@
-
 name: Run tests
 
 on:
@@ -27,7 +26,7 @@ jobs:
         python scripts/ci/install
     - name: Run tests
       run: |
-        python scripts/ci/run-tests
+        python scripts/ci/run-tests --with-cov
     - name: codecov
       run: |
         rm tests/coverage.xml

--- a/scripts/ci/run-crt-tests
+++ b/scripts/ci/run-crt-tests
@@ -10,11 +10,12 @@ from subprocess import check_call
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+os.chdir(os.path.join(REPO_ROOT, "tests"))
 
 
 def run(command, env=None):
     return check_call(command, shell=True, env=env)
+
 
 try:
     import awscrt
@@ -22,8 +23,4 @@ except ImportError:
     print("MISSING DEPENDENCY: awscrt must be installed to run the crt tests.")
     sys.exit(1)
 
-run('nosetests s3transfer --with-xunit unit/ functional/')
-
-# Run the serial implementation of s3transfer
-os.environ['USE_SERIAL_EXECUTOR'] = 'True'
-run('nosetests -v functional/', env=os.environ)
+run(f"{REPO_ROOT}/scripts/ci/run-tests unit/ functional/")

--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -9,16 +9,11 @@ from subprocess import check_call
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+os.chdir(os.path.join(REPO_ROOT, "tests"))
 
 
 def run(command, env=None):
     return check_call(command, shell=True, env=env)
 
 
-run('nosetests --with-xunit --cover-erase --with-coverage '
-    '--cover-package s3transfer --cover-xml -v integration')
-
-# Run the serial implementation of s3transfer
-os.environ['USE_SERIAL_EXECUTOR'] = 'True'
-run('nosetests -v integration', env=os.environ)
+run(f"{REPO_ROOT}/scripts/ci/run-tests --with-cov integration")

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -3,22 +3,69 @@
 # We want to ensure we're importing from the installed
 # binary package not from the CWD.
 
+import argparse
 import os
 from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+PACKAGE = "s3transfer"
+os.chdir(os.path.join(REPO_ROOT, "tests"))
 
 
 def run(command, env=None):
     return check_call(command, shell=True, env=env)
 
 
-run('nosetests --with-coverage --cover-erase --cover-package s3transfer '
-    '--with-xunit --cover-xml -v unit/ functional/')
+def process_args(args):
+    runner = args.test_runner
+    test_args = ""
+    if args.with_cov:
+        test_args += (
+            f"--with-xunit --cover-erase --with-coverage "
+            f"--cover-package {PACKAGE} --cover-xml -v "
+        )
+    dirs = " ".join(args.test_dirs)
 
-# Run the serial implementation of s3transfer
-os.environ['USE_SERIAL_EXECUTOR'] = 'True'
-run('nosetests -v functional/', env=os.environ)
+    # Unit tests cannot be run with Serial Executor
+    # TODO: We should add appropriate skips with pytest and remove this
+    serial_dir_list = [d for d in args.test_dirs if d.lower() not in ("unit", "unit/")]
+    serial_dirs = " ".join(serial_dir_list)
+
+    return runner, test_args, dirs, serial_dirs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "test_dirs",
+        default=["unit/", "functional/"],
+        nargs="*",
+        help="One or more directories containing tests.",
+    )
+    parser.add_argument(
+        "-r",
+        "--test-runner",
+        default="nosetests",
+        help="Test runner to execute tests. Defaults to nose.",
+    )
+    parser.add_argument(
+        "-c",
+        "--with-cov",
+        default=False,
+        action="store_true",
+        help="Run default test-runner with code coverage enabled.",
+    )
+    raw_args = parser.parse_args()
+    test_runner, test_args, test_dirs, serial_dirs = process_args(raw_args)
+
+    cmd = f"{test_runner} {test_args}{test_dirs}"
+    print(f"Running {cmd}...")
+    run(cmd)
+
+    # Run the serial implementation of s3transfer
+    os.environ["USE_SERIAL_EXECUTOR"] = "True"
+    cmd = f"{test_runner} {test_args}{serial_dirs}"
+    print(f"Running serial execution for {cmd}...")
+    run(cmd, env=os.environ)


### PR DESCRIPTION
This is part of a series of PRs to standardize our test runner scripts for CI across repos. This will work as a stepping block to getting us migrated to arbitrary test runners such as `pytest` that can be used on a per project basis.