### PR TITLE
Skip non-passing tests

### DIFF
--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -28,12 +28,7 @@ def process_args(args):
         )
     dirs = " ".join(args.test_dirs)
 
-    # Unit tests cannot be run with Serial Executor
-    # TODO: We should add appropriate skips with pytest and remove this
-    serial_dir_list = [d for d in args.test_dirs if d.lower() not in ("unit", "unit/")]
-    serial_dirs = " ".join(serial_dir_list)
-
-    return runner, test_args, dirs, serial_dirs
+    return runner, test_args, dirs
 
 
 if __name__ == "__main__":
@@ -58,7 +53,7 @@ if __name__ == "__main__":
         help="Run default test-runner with code coverage enabled.",
     )
     raw_args = parser.parse_args()
-    test_runner, test_args, test_dirs, serial_dirs = process_args(raw_args)
+    test_runner, test_args, test_dirs = process_args(raw_args)
 
     cmd = f"{test_runner} {test_args}{test_dirs}"
     print(f"Running {cmd}...")
@@ -66,6 +61,5 @@ if __name__ == "__main__":
 
     # Run the serial implementation of s3transfer
     os.environ["USE_SERIAL_EXECUTOR"] = "True"
-    cmd = f"{test_runner} {test_args}{serial_dirs}"
     print(f"Running serial execution for {cmd}...")
     run(cmd, env=os.environ)

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import sys
 import time
 import traceback
@@ -490,6 +491,10 @@ class TestBoundedExecutor(unittest.TestCase):
         # Ensure the callable got executed.
         self.assertEqual(future.result(), 'foo')
 
+    @unittest.skipIf(
+        os.environ.get('USE_SERIAL_EXECUTOR'),
+        "Not supported with serial executor tests"
+    )
     def test_executor_blocks_on_full_capacity(self):
         first_task = self.get_sleep_task()
         second_task = self.get_sleep_task()
@@ -516,6 +521,10 @@ class TestBoundedExecutor(unittest.TestCase):
         # Wait for it to complete.
         self.executor.shutdown()
 
+    @unittest.skipIf(
+        os.environ.get('USE_SERIAL_EXECUTOR'),
+        "Not supported with serial executor tests"
+    )
     def test_would_not_block_when_full_capacity_in_other_semaphore(self):
         first_task = self.get_sleep_task()
 
@@ -544,6 +553,10 @@ class TestBoundedExecutor(unittest.TestCase):
         # Ensure that the shutdown waits until the task is done
         self.assertTrue(future.done())
 
+    @unittest.skipIf(
+        os.environ.get('USE_SERIAL_EXECUTOR'),
+        "Not supported with serial executor tests"
+    )
     def test_shutdown_no_wait(self):
         slow_task = self.get_sleep_task()
         future = self.executor.submit(slow_task)


### PR DESCRIPTION
There were some unforeseen issues with the directory skipping approach so we're just going to add formal skip declarations when the `USE_SERIAL_EXECUTOR` environment variable is set.