### PR TITLE
Move to pytest

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 -e git://github.com/boto/botocore.git@develop#egg=botocore
-nose==1.3.3
+pytest==6.2.5
+pytest-cov==2.12.1
 mock==1.3.0
-coverage==5.0.3
+coverage==5.5
 wheel==0.36.2

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -22,10 +22,7 @@ def process_args(args):
     runner = args.test_runner
     test_args = ""
     if args.with_cov:
-        test_args += (
-            f"--with-xunit --cover-erase --with-coverage "
-            f"--cover-package {PACKAGE} --cover-xml -v "
-        )
+        test_args += f"--cov={PACKAGE} --cov-report xml "
     dirs = " ".join(args.test_dirs)
 
     return runner, test_args, dirs
@@ -42,8 +39,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-r",
         "--test-runner",
-        default="nosetests",
-        help="Test runner to execute tests. Defaults to nose.",
+        default="pytest",
+        help="Test runner to execute tests. Defaults to pytest.",
     )
     parser.add_argument(
         "-c",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -300,7 +300,7 @@ class TestOSUtils(BaseUtilsTest):
         filename = 'myfile'
         self.assertIsNotNone(
             re.match(
-                '%s\.[0-9A-Fa-f]{8}$' % filename,
+                r'%s\.[0-9A-Fa-f]{8}$' % filename,
                 OSUtils().get_temp_filename(filename)
             )
         )


### PR DESCRIPTION
This PR will migrate s3 transfer off of `nosetests` and start using `pytest` to allow us to continue testing on Python 3.10.

**Nose Unit/Fundamental:**
```
nateprewitt@- s3transfer % ./scripts/ci/run-tests unit functional
Running nosetests unit functional...
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 617 tests in 29.368s
```
**Pytest Unit/Fundamental:**
```
nateprewitt@- s3transfer % ./scripts/ci/run-tests unit functional
Running pytest unit functional...
====================================== test session starts =======================================
platform darwin -- Python 3.8.10, pytest-6.2.5, py-1.9.0, pluggy-0.13.1
rootdir: /Users/nateprewitt/Work/OpenSource/s3transfer, inifile:
plugins: cov-2.9.0, httpbin-1.0.0, mock-2.0.0, xdist-2.1.0, asyncio-0.14.0, forked-1.3.0
collected 617 items                                                                              

unit/test_bandwidth.py ....................................                                [  5%]
unit/test_compat.py ........                                                               [  7%]
unit/test_copies.py ......                                                                 [  8%]
unit/test_crt.py ........                                                                  [  9%]
unit/test_delete.py ..                                                                     [  9%]
unit/test_download.py ..................................................................   [ 20%]
unit/test_futures.py .........................................................             [ 29%]
unit/test_manager.py .........                                                             [ 31%]
unit/test_processpool.py ...................................................               [ 39%]
unit/test_s3transfer.py .........................................................          [ 48%]
unit/test_subscribers.py ........                                                          [ 49%]
unit/test_tasks.py ...............................                                         [ 54%]
unit/test_upload.py ...............................................                        [ 62%]
unit/test_utils.py ....................................................................... [ 74%]
.....................                                                                      [ 77%]
functional/test_copy.py .................................                                  [ 82%]
functional/test_crt.py .......                                                             [ 83%]
functional/test_delete.py .......                                                          [ 85%]
functional/test_download.py .........................................                      [ 91%]
functional/test_manager.py ........                                                        [ 93%]
functional/test_processpool.py ............                                                [ 94%]
functional/test_upload.py ............................                                     [ 99%]
functional/test_utils.py ...                                                               [100%]

================================== 617 passed in 25.21 seconds ===================================
```
**Nose Integ:**
```
nateprewitt@- s3transfer % ./scripts/ci/run-tests integration
Running nosetests integration...
..........................................................
----------------------------------------------------------------------
Ran 58 tests in 637.963s

OK
```
**Pytest Integ:**
```
nateprewitt@- s3transfer % ./scripts/ci/run-tests integration/ 
Running pytest integration/...
====================================== test session starts =======================================
platform darwin -- Python 3.8.10, pytest-6.2.5, py-1.9.0, pluggy-0.13.1
rootdir: /Users/nateprewitt/Work/OpenSource/s3transfer, inifile:
plugins: cov-2.9.0, httpbin-1.0.0, mock-2.0.0, xdist-2.1.0, asyncio-0.14.0, forked-1.3.0
collected 58 items                                                                               

integration/test_copy.py ...                                                               [  5%]
integration/test_crt.py .............                                                      [ 27%]
integration/test_delete.py .                                                               [ 29%]
integration/test_download.py ..........                                                    [ 46%]
integration/test_processpool.py ....                                                       [ 53%]
integration/test_s3transfer.py ............                                                [ 74%]
integration/test_upload.py ...............                                                 [100%]

================================== 58 passed in 581.24 seconds ===================================
```