### PR TITLE
Update to last released version of nose

### DIFF
--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -82,8 +82,10 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
-nose==1.3.3 \
-    --hash=sha256:b40c2ff268beb85356ada25f626ca0dabc89705f31051649772cf00fc9510326
+nose==1.3.7 \
+    --hash=sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac \
+    --hash=sha256:dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a \
+    --hash=sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98
     # via -r requirements-dev.txt
 packaging==21.0 \
     --hash=sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7 \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 psutil>=4.1.0,<5.0.0
 tabulate==0.7.5
-nose==1.3.3
+nose==1.3.7
 coverage==5.5
 wheel==0.37.0
 


### PR DESCRIPTION
s3transfer was relying on an older version of nose in its requirement file that isn't fully compatible with Python 3+. Upgrading to last available release.