### PR TITLE
Test Python 3.10 final

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.10 final was released last Monday:

https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Quotes are needed for "3.10" in YAML so it's not interpreted as 3.1:

https://dev.to/hugovk/the-python-3-1-problem-85g