### PR TITLE
Extend linting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,16 @@
 exclude: ^(.changes/|CHANGELOG.rst)
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/pycqa/flake8
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+  - repo: 'https://github.com/PyCQA/isort'
+    rev: 5.9.3
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
-    -   id: flake8
+      - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
-    -   id: flake8
--   repo: https://github.com/codespell-project/codespell
+      - id: flake8
+  - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
-    -   id: codespell
+      - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: ^(.changes/|CHANGELOG.rst)
+exclude: ^(.changes/|CHANGELOG.rst|s3transfer/compat.py)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
@@ -6,6 +6,12 @@ repos:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
+  - repo: 'https://github.com/asottile/pyupgrade'
+    rev: v2.29.0
+    hooks:
+      - id: pyupgrade
+        args:
+          - '--py36-plus'
   - repo: 'https://github.com/PyCQA/isort'
     rev: 5.9.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
     rev: 5.9.3
     hooks:
       - id: isort
+  - repo: 'https://github.com/psf/black'
+    rev: 21.7b0
+    hooks:
+      - id: black
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 79
+honor_noqa = true
+src_paths = ["s3transfer", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@ profile = "black"
 line_length = 79
 honor_noqa = true
 src_paths = ["s3transfer", "tests"]
+
+[tool.black]
+line-length = 79
+skip_string_normalization = true

--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -123,24 +123,24 @@ transfer.  For example:
 
 
 """
-import os
-import math
+import concurrent.futures
 import functools
 import logging
-import socket
-import threading
+import math
+import os
 import random
+import socket
 import string
-import concurrent.futures
+import threading
 
 from botocore.compat import six
-from botocore.vendored.requests.packages.urllib3.exceptions import \
-    ReadTimeoutError
 from botocore.exceptions import IncompleteReadError
+from botocore.vendored.requests.packages.urllib3.exceptions import (
+    ReadTimeoutError,
+)
 
 import s3transfer.compat
 from s3transfer.exceptions import RetriesExceededError, S3UploadFailedError
-
 
 __author__ = 'Amazon Web Services'
 __version__ = '0.5.0'

--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -164,14 +164,16 @@ def random_file_extension(num_digits=8):
 
 
 def disable_upload_callbacks(request, operation_name, **kwargs):
-    if operation_name in ['PutObject', 'UploadPart'] and \
-            hasattr(request.body, 'disable_callback'):
+    if operation_name in ['PutObject', 'UploadPart'] and hasattr(
+        request.body, 'disable_callback'
+    ):
         request.body.disable_callback()
 
 
 def enable_upload_callbacks(request, operation_name, **kwargs):
-    if operation_name in ['PutObject', 'UploadPart'] and \
-            hasattr(request.body, 'enable_callback'):
+    if operation_name in ['PutObject', 'UploadPart'] and hasattr(
+        request.body, 'enable_callback'
+    ):
         request.body.enable_callback()
 
 
@@ -180,8 +182,15 @@ class QueueShutdownError(Exception):
 
 
 class ReadFileChunk:
-    def __init__(self, fileobj, start_byte, chunk_size, full_file_size,
-                 callback=None, enable_callback=True):
+    def __init__(
+        self,
+        fileobj,
+        start_byte,
+        chunk_size,
+        full_file_size,
+        callback=None,
+        enable_callback=True,
+    ):
         """
 
         Given a file object shown below:
@@ -213,16 +222,25 @@ class ReadFileChunk:
         self._fileobj = fileobj
         self._start_byte = start_byte
         self._size = self._calculate_file_size(
-            self._fileobj, requested_size=chunk_size,
-            start_byte=start_byte, actual_file_size=full_file_size)
+            self._fileobj,
+            requested_size=chunk_size,
+            start_byte=start_byte,
+            actual_file_size=full_file_size,
+        )
         self._fileobj.seek(self._start_byte)
         self._amount_read = 0
         self._callback = callback
         self._callback_enabled = enable_callback
 
     @classmethod
-    def from_filename(cls, filename, start_byte, chunk_size, callback=None,
-                      enable_callback=True):
+    def from_filename(
+        cls,
+        filename,
+        start_byte,
+        chunk_size,
+        callback=None,
+        enable_callback=True,
+    ):
         """Convenience factory function to create from a filename.
 
         :type start_byte: int
@@ -250,11 +268,13 @@ class ReadFileChunk:
         """
         f = open(filename, 'rb')
         file_size = os.fstat(f.fileno()).st_size
-        return cls(f, start_byte, chunk_size, file_size, callback,
-                   enable_callback)
+        return cls(
+            f, start_byte, chunk_size, file_size, callback, enable_callback
+        )
 
-    def _calculate_file_size(self, fileobj, requested_size, start_byte,
-                             actual_file_size):
+    def _calculate_file_size(
+        self, fileobj, requested_size, start_byte, actual_file_size
+    ):
         max_chunk_size = actual_file_size - start_byte
         return min(max_chunk_size, requested_size)
 
@@ -313,6 +333,7 @@ class ReadFileChunk:
 
 class StreamReaderProgress:
     """Wrapper for a read only stream that adds progress callbacks."""
+
     def __init__(self, stream, callback=None):
         self._stream = stream
         self._callback = callback
@@ -329,9 +350,9 @@ class OSUtils:
         return os.path.getsize(filename)
 
     def open_file_chunk_reader(self, filename, start_byte, size, callback):
-        return ReadFileChunk.from_filename(filename, start_byte,
-                                           size, callback,
-                                           enable_callback=False)
+        return ReadFileChunk.from_filename(
+            filename, start_byte, size, callback, enable_callback=False
+        )
 
     def open(self, filename, mode):
         return open(filename, mode)
@@ -359,8 +380,13 @@ class MultipartUploader:
         'RequestPayer',
     ]
 
-    def __init__(self, client, config, osutil,
-                 executor_cls=concurrent.futures.ThreadPoolExecutor):
+    def __init__(
+        self,
+        client,
+        config,
+        osutil,
+        executor_cls=concurrent.futures.ThreadPoolExecutor,
+    ):
         self._client = client
         self._config = config
         self._os = osutil
@@ -376,50 +402,83 @@ class MultipartUploader:
         return upload_parts_args
 
     def upload_file(self, filename, bucket, key, callback, extra_args):
-        response = self._client.create_multipart_upload(Bucket=bucket,
-                                                        Key=key, **extra_args)
+        response = self._client.create_multipart_upload(
+            Bucket=bucket, Key=key, **extra_args
+        )
         upload_id = response['UploadId']
         try:
-            parts = self._upload_parts(upload_id, filename, bucket, key,
-                                       callback, extra_args)
+            parts = self._upload_parts(
+                upload_id, filename, bucket, key, callback, extra_args
+            )
         except Exception as e:
-            logger.debug("Exception raised while uploading parts, "
-                         "aborting multipart upload.", exc_info=True)
+            logger.debug(
+                "Exception raised while uploading parts, "
+                "aborting multipart upload.",
+                exc_info=True,
+            )
             self._client.abort_multipart_upload(
-                Bucket=bucket, Key=key, UploadId=upload_id)
+                Bucket=bucket, Key=key, UploadId=upload_id
+            )
             raise S3UploadFailedError(
                 "Failed to upload {} to {}: {}".format(
-                    filename, '/'.join([bucket, key]), e))
+                    filename, '/'.join([bucket, key]), e
+                )
+            )
         self._client.complete_multipart_upload(
-            Bucket=bucket, Key=key, UploadId=upload_id,
-            MultipartUpload={'Parts': parts})
+            Bucket=bucket,
+            Key=key,
+            UploadId=upload_id,
+            MultipartUpload={'Parts': parts},
+        )
 
-    def _upload_parts(self, upload_id, filename, bucket, key, callback,
-                      extra_args):
+    def _upload_parts(
+        self, upload_id, filename, bucket, key, callback, extra_args
+    ):
         upload_parts_extra_args = self._extra_upload_part_args(extra_args)
         parts = []
         part_size = self._config.multipart_chunksize
         num_parts = int(
-            math.ceil(self._os.get_file_size(filename) / float(part_size)))
+            math.ceil(self._os.get_file_size(filename) / float(part_size))
+        )
         max_workers = self._config.max_concurrency
         with self._executor_cls(max_workers=max_workers) as executor:
             upload_partial = functools.partial(
-                self._upload_one_part, filename, bucket, key, upload_id,
-                part_size, upload_parts_extra_args, callback)
+                self._upload_one_part,
+                filename,
+                bucket,
+                key,
+                upload_id,
+                part_size,
+                upload_parts_extra_args,
+                callback,
+            )
             for part in executor.map(upload_partial, range(1, num_parts + 1)):
                 parts.append(part)
         return parts
 
-    def _upload_one_part(self, filename, bucket, key,
-                         upload_id, part_size, extra_args,
-                         callback, part_number):
+    def _upload_one_part(
+        self,
+        filename,
+        bucket,
+        key,
+        upload_id,
+        part_size,
+        extra_args,
+        callback,
+        part_number,
+    ):
         open_chunk_reader = self._os.open_file_chunk_reader
-        with open_chunk_reader(filename, part_size * (part_number - 1),
-                               part_size, callback) as body:
+        with open_chunk_reader(
+            filename, part_size * (part_number - 1), part_size, callback
+        ) as body:
             response = self._client.upload_part(
-                Bucket=bucket, Key=key,
-                UploadId=upload_id, PartNumber=part_number, Body=body,
-                **extra_args)
+                Bucket=bucket,
+                Key=key,
+                UploadId=upload_id,
+                PartNumber=part_number,
+                Body=body,
+                **extra_args,
+            )
             etag = response['ETag']
             return {'ETag': etag, 'PartNumber': part_number}
 
@@ -435,6 +494,7 @@ class ShutdownQueue(queue.Queue):
     to be a drop in replacement for ``queue.Queue``.
 
     """
+
     def _init(self, maxsize):
         self._shutdown = False
         self._shutdown_lock = threading.Lock()
@@ -451,36 +511,50 @@ class ShutdownQueue(queue.Queue):
         # Need to hook into the condition vars used by this class.
         with self._shutdown_lock:
             if self._shutdown:
-                raise QueueShutdownError("Cannot put item to queue when "
-                                         "queue has been shutdown.")
+                raise QueueShutdownError(
+                    "Cannot put item to queue when " "queue has been shutdown."
+                )
         return queue.Queue.put(self, item)
 
 
 class MultipartDownloader:
-    def __init__(self, client, config, osutil,
-                 executor_cls=concurrent.futures.ThreadPoolExecutor):
+    def __init__(
+        self,
+        client,
+        config,
+        osutil,
+        executor_cls=concurrent.futures.ThreadPoolExecutor,
+    ):
         self._client = client
         self._config = config
         self._os = osutil
         self._executor_cls = executor_cls
         self._ioqueue = ShutdownQueue(self._config.max_io_queue)
 
-    def download_file(self, bucket, key, filename, object_size,
-                      extra_args, callback=None):
+    def download_file(
+        self, bucket, key, filename, object_size, extra_args, callback=None
+    ):
         with self._executor_cls(max_workers=2) as controller:
             # 1 thread for the future that manages the uploading of files
             # 1 thread for the future that manages IO writes.
             download_parts_handler = functools.partial(
                 self._download_file_as_future,
-                bucket, key, filename, object_size, callback)
+                bucket,
+                key,
+                filename,
+                object_size,
+                callback,
+            )
             parts_future = controller.submit(download_parts_handler)
 
             io_writes_handler = functools.partial(
-                self._perform_io_writes, filename)
+                self._perform_io_writes, filename
+            )
             io_future = controller.submit(io_writes_handler)
             results = concurrent.futures.wait(
                 [parts_future, io_future],
-                return_when=concurrent.futures.FIRST_EXCEPTION)
+                return_when=concurrent.futures.FIRST_EXCEPTION,
+            )
             self._process_future_results(results)
 
     def _process_future_results(self, futures):
@@ -488,14 +562,21 @@ class MultipartDownloader:
         for future in finished:
             future.result()
 
-    def _download_file_as_future(self, bucket, key, filename, object_size,
-                                 callback):
+    def _download_file_as_future(
+        self, bucket, key, filename, object_size, callback
+    ):
         part_size = self._config.multipart_chunksize
         num_parts = int(math.ceil(object_size / float(part_size)))
         max_workers = self._config.max_concurrency
         download_partial = functools.partial(
-            self._download_range, bucket, key, filename,
-            part_size, num_parts, callback)
+            self._download_range,
+            bucket,
+            key,
+            filename,
+            part_size,
+            num_parts,
+            callback,
+        )
         try:
             with self._executor_cls(max_workers=max_workers) as executor:
                 list(executor.map(download_partial, range(num_parts)))
@@ -511,11 +592,13 @@ class MultipartDownloader:
         range_param = f'bytes={start_range}-{end_range}'
         return range_param
 
-    def _download_range(self, bucket, key, filename,
-                        part_size, num_parts, callback, part_index):
+    def _download_range(
+        self, bucket, key, filename, part_size, num_parts, callback, part_index
+    ):
         try:
             range_param = self._calculate_range_param(
-                part_size, part_index, num_parts)
+                part_size, part_index, num_parts
+            )
 
             max_attempts = self._config.num_download_attempts
             last_exception = None
@@ -523,20 +606,33 @@ class MultipartDownloader:
                 try:
                     logger.debug("Making get_object call.")
                     response = self._client.get_object(
-                        Bucket=bucket, Key=key, Range=range_param)
+                        Bucket=bucket, Key=key, Range=range_param
+                    )
                     streaming_body = StreamReaderProgress(
-                        response['Body'], callback)
+                        response['Body'], callback
+                    )
                     buffer_size = 1024 * 16
                     current_index = part_size * part_index
-                    for chunk in iter(lambda: streaming_body.read(buffer_size),
-                                      b''):
+                    for chunk in iter(
+                        lambda: streaming_body.read(buffer_size), b''
+                    ):
                         self._ioqueue.put((current_index, chunk))
                         current_index += len(chunk)
                     return
-                except (socket.timeout, OSError, ReadTimeoutError, IncompleteReadError) as e:
-                    logger.debug("Retrying exception caught (%s), "
-                                 "retrying request, (attempt %s / %s)", e, i,
-                                 max_attempts, exc_info=True)
+                except (
+                    socket.timeout,
+                    OSError,
+                    ReadTimeoutError,
+                    IncompleteReadError,
+                ) as e:
+                    logger.debug(
+                        "Retrying exception caught (%s), "
+                        "retrying request, (attempt %s / %s)",
+                        e,
+                        i,
+                        max_attempts,
+                        exc_info=True,
+                    )
                     last_exception = e
                     continue
             raise RetriesExceededError(last_exception)
@@ -548,8 +644,10 @@ class MultipartDownloader:
             while True:
                 task = self._ioqueue.get()
                 if task is SHUTDOWN_SENTINEL:
-                    logger.debug("Shutdown sentinel received in IO handler, "
-                                 "shutting down IO handler.")
+                    logger.debug(
+                        "Shutdown sentinel received in IO handler, "
+                        "shutting down IO handler."
+                    )
                     return
                 else:
                     try:
@@ -557,19 +655,24 @@ class MultipartDownloader:
                         f.seek(offset)
                         f.write(data)
                     except Exception as e:
-                        logger.debug("Caught exception in IO thread: %s",
-                                     e, exc_info=True)
+                        logger.debug(
+                            "Caught exception in IO thread: %s",
+                            e,
+                            exc_info=True,
+                        )
                         self._ioqueue.trigger_shutdown()
                         raise
 
 
 class TransferConfig:
-    def __init__(self,
-                 multipart_threshold=8 * MB,
-                 max_concurrency=10,
-                 multipart_chunksize=8 * MB,
-                 num_download_attempts=5,
-                 max_io_queue=100):
+    def __init__(
+        self,
+        multipart_threshold=8 * MB,
+        max_concurrency=10,
+        multipart_chunksize=8 * MB,
+        num_download_attempts=5,
+        max_io_queue=100,
+    ):
         self.multipart_threshold = multipart_threshold
         self.max_concurrency = max_concurrency
         self.multipart_chunksize = multipart_chunksize
@@ -620,8 +723,9 @@ class S3Transfer:
             osutil = OSUtils()
         self._osutil = osutil
 
-    def upload_file(self, filename, bucket, key,
-                    callback=None, extra_args=None):
+    def upload_file(
+        self, filename, bucket, key, callback=None, extra_args=None
+    ):
         """Upload a file to an S3 object.
 
         Variants have also been injected into S3 client, Bucket and Object.
@@ -631,14 +735,20 @@ class S3Transfer:
             extra_args = {}
         self._validate_all_known_args(extra_args, self.ALLOWED_UPLOAD_ARGS)
         events = self._client.meta.events
-        events.register_first('request-created.s3',
-                              disable_upload_callbacks,
-                              unique_id='s3upload-callback-disable')
-        events.register_last('request-created.s3',
-                             enable_upload_callbacks,
-                             unique_id='s3upload-callback-enable')
-        if self._osutil.get_file_size(filename) >= \
-                self._config.multipart_threshold:
+        events.register_first(
+            'request-created.s3',
+            disable_upload_callbacks,
+            unique_id='s3upload-callback-disable',
+        )
+        events.register_last(
+            'request-created.s3',
+            enable_upload_callbacks,
+            unique_id='s3upload-callback-enable',
+        )
+        if (
+            self._osutil.get_file_size(filename)
+            >= self._config.multipart_threshold
+        ):
             self._multipart_upload(filename, bucket, key, callback, extra_args)
         else:
             self._put_object(filename, bucket, key, callback, extra_args)
@@ -647,14 +757,19 @@ class S3Transfer:
         # We're using open_file_chunk_reader so we can take advantage of the
         # progress callback functionality.
         open_chunk_reader = self._osutil.open_file_chunk_reader
-        with open_chunk_reader(filename, 0,
-                               self._osutil.get_file_size(filename),
-                               callback=callback) as body:
-            self._client.put_object(Bucket=bucket, Key=key, Body=body,
-                                    **extra_args)
+        with open_chunk_reader(
+            filename,
+            0,
+            self._osutil.get_file_size(filename),
+            callback=callback,
+        ) as body:
+            self._client.put_object(
+                Bucket=bucket, Key=key, Body=body, **extra_args
+            )
 
-    def download_file(self, bucket, key, filename, extra_args=None,
-                      callback=None):
+    def download_file(
+        self, bucket, key, filename, extra_args=None, callback=None
+    ):
         """Download an S3 object to a file.
 
         Variants have also been injected into S3 client, Bucket and Object.
@@ -669,21 +784,28 @@ class S3Transfer:
         object_size = self._object_size(bucket, key, extra_args)
         temp_filename = filename + os.extsep + random_file_extension()
         try:
-            self._download_file(bucket, key, temp_filename, object_size,
-                                extra_args, callback)
+            self._download_file(
+                bucket, key, temp_filename, object_size, extra_args, callback
+            )
         except Exception:
-            logger.debug("Exception caught in download_file, removing partial "
-                         "file: %s", temp_filename, exc_info=True)
+            logger.debug(
+                "Exception caught in download_file, removing partial "
+                "file: %s",
+                temp_filename,
+                exc_info=True,
+            )
             self._osutil.remove_file(temp_filename)
             raise
         else:
             self._osutil.rename_file(temp_filename, filename)
 
-    def _download_file(self, bucket, key, filename, object_size,
-                       extra_args, callback):
+    def _download_file(
+        self, bucket, key, filename, object_size, extra_args, callback
+    ):
         if object_size >= self._config.multipart_threshold:
-            self._ranged_download(bucket, key, filename, object_size,
-                                  extra_args, callback)
+            self._ranged_download(
+                bucket, key, filename, object_size, extra_args, callback
+            )
         else:
             self._get_object(bucket, key, filename, extra_args, callback)
 
@@ -692,15 +814,18 @@ class S3Transfer:
             if kwarg not in allowed:
                 raise ValueError(
                     "Invalid extra_args key '%s', "
-                    "must be one of: %s" % (
-                        kwarg, ', '.join(allowed)))
+                    "must be one of: %s" % (kwarg, ', '.join(allowed))
+                )
 
-    def _ranged_download(self, bucket, key, filename, object_size,
-                         extra_args, callback):
-        downloader = MultipartDownloader(self._client, self._config,
-                                         self._osutil)
-        downloader.download_file(bucket, key, filename, object_size,
-                                 extra_args, callback)
+    def _ranged_download(
+        self, bucket, key, filename, object_size, extra_args, callback
+    ):
+        downloader = MultipartDownloader(
+            self._client, self._config, self._osutil
+        )
+        downloader.download_file(
+            bucket, key, filename, object_size, extra_args, callback
+        )
 
     def _get_object(self, bucket, key, filename, extra_args, callback):
         # precondition: num_download_attempts > 0
@@ -708,30 +833,42 @@ class S3Transfer:
         last_exception = None
         for i in range(max_attempts):
             try:
-                return self._do_get_object(bucket, key, filename,
-                                           extra_args, callback)
-            except (socket.timeout, OSError, ReadTimeoutError, IncompleteReadError) as e:
+                return self._do_get_object(
+                    bucket, key, filename, extra_args, callback
+                )
+            except (
+                socket.timeout,
+                OSError,
+                ReadTimeoutError,
+                IncompleteReadError,
+            ) as e:
                 # TODO: we need a way to reset the callback if the
                 # download failed.
-                logger.debug("Retrying exception caught (%s), "
-                             "retrying request, (attempt %s / %s)", e, i,
-                             max_attempts, exc_info=True)
+                logger.debug(
+                    "Retrying exception caught (%s), "
+                    "retrying request, (attempt %s / %s)",
+                    e,
+                    i,
+                    max_attempts,
+                    exc_info=True,
+                )
                 last_exception = e
                 continue
         raise RetriesExceededError(last_exception)
 
     def _do_get_object(self, bucket, key, filename, extra_args, callback):
-        response = self._client.get_object(Bucket=bucket, Key=key,
-                                           **extra_args)
-        streaming_body = StreamReaderProgress(
-            response['Body'], callback)
+        response = self._client.get_object(
+            Bucket=bucket, Key=key, **extra_args
+        )
+        streaming_body = StreamReaderProgress(response['Body'], callback)
         with self._osutil.open(filename, 'wb') as f:
             for chunk in iter(lambda: streaming_body.read(8192), b''):
                 f.write(chunk)
 
     def _object_size(self, bucket, key, extra_args):
-        return self._client.head_object(
-            Bucket=bucket, Key=key, **extra_args)['ContentLength']
+        return self._client.head_object(Bucket=bucket, Key=key, **extra_args)[
+            'ContentLength'
+        ]
 
     def _multipart_upload(self, filename, bucket, key, callback, extra_args):
         uploader = MultipartUploader(self._client, self._config, self._osutil)

--- a/s3transfer/bandwidth.py
+++ b/s3transfer/bandwidth.py
@@ -31,18 +31,18 @@ class RequestExceededException(Exception):
         self.requested_amt = requested_amt
         self.retry_time = retry_time
         msg = (
-            'Request amount %s exceeded the amount available. Retry in %s' % (
+            'Request amount {} exceeded the amount available. Retry in {}'.format(
                 requested_amt, retry_time)
         )
-        super(RequestExceededException, self).__init__(msg)
+        super().__init__(msg)
 
 
-class RequestToken(object):
+class RequestToken:
     """A token to pass as an identifier when consuming from the LeakyBucket"""
     pass
 
 
-class TimeUtils(object):
+class TimeUtils:
     def time(self):
         """Get the current time back
 
@@ -60,7 +60,7 @@ class TimeUtils(object):
         return time.sleep(value)
 
 
-class BandwidthLimiter(object):
+class BandwidthLimiter:
     def __init__(self, leaky_bucket, time_utils=None):
         """Limits bandwidth for shared S3 transfers
 
@@ -97,7 +97,7 @@ class BandwidthLimiter(object):
         return stream
 
 
-class BandwidthLimitedStream(object):
+class BandwidthLimitedStream:
     def __init__(self, fileobj, leaky_bucket, transfer_coordinator,
                  time_utils=None, bytes_threshold=256 * 1024):
         """Limits bandwidth for reads on a wrapped stream
@@ -203,7 +203,7 @@ class BandwidthLimitedStream(object):
         self.close()
 
 
-class LeakyBucket(object):
+class LeakyBucket:
     def __init__(self, max_rate, time_utils=None, rate_tracker=None,
                  consumption_scheduler=None):
         """A leaky bucket abstraction to limit bandwidth consumption
@@ -285,7 +285,7 @@ class LeakyBucket(object):
         return amt
 
 
-class ConsumptionScheduler(object):
+class ConsumptionScheduler:
     def __init__(self):
         """Schedules when to consume a desired amount"""
         self._tokens_to_scheduled_consumption = {}
@@ -338,7 +338,7 @@ class ConsumptionScheduler(object):
             self._total_wait - scheduled_retry['time_to_consume'], 0)
 
 
-class BandwidthRateTracker(object):
+class BandwidthRateTracker:
     def __init__(self, alpha=0.8):
         """Tracks the rate of bandwidth consumption
 

--- a/s3transfer/bandwidth.py
+++ b/s3transfer/bandwidth.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import time
 import threading
+import time
 
 
 class RequestExceededException(Exception):

--- a/s3transfer/bandwidth.py
+++ b/s3transfer/bandwidth.py
@@ -30,15 +30,15 @@ class RequestExceededException(Exception):
         """
         self.requested_amt = requested_amt
         self.retry_time = retry_time
-        msg = (
-            'Request amount {} exceeded the amount available. Retry in {}'.format(
-                requested_amt, retry_time)
+        msg = 'Request amount {} exceeded the amount available. Retry in {}'.format(
+            requested_amt, retry_time
         )
         super().__init__(msg)
 
 
 class RequestToken:
     """A token to pass as an identifier when consuming from the LeakyBucket"""
+
     pass
 
 
@@ -75,8 +75,9 @@ class BandwidthLimiter:
         if time_utils is None:
             self._time_utils = TimeUtils()
 
-    def get_bandwith_limited_stream(self, fileobj, transfer_coordinator,
-                                    enabled=True):
+    def get_bandwith_limited_stream(
+        self, fileobj, transfer_coordinator, enabled=True
+    ):
         """Wraps a fileobj in a bandwidth limited stream wrapper
 
         :type fileobj: file-like obj
@@ -90,16 +91,22 @@ class BandwidthLimiter:
         :param enabled: Whether bandwidth limiting should be enabled to start
         """
         stream = BandwidthLimitedStream(
-            fileobj, self._leaky_bucket, transfer_coordinator,
-            self._time_utils)
+            fileobj, self._leaky_bucket, transfer_coordinator, self._time_utils
+        )
         if not enabled:
             stream.disable_bandwidth_limiting()
         return stream
 
 
 class BandwidthLimitedStream:
-    def __init__(self, fileobj, leaky_bucket, transfer_coordinator,
-                 time_utils=None, bytes_threshold=256 * 1024):
+    def __init__(
+        self,
+        fileobj,
+        leaky_bucket,
+        transfer_coordinator,
+        time_utils=None,
+        bytes_threshold=256 * 1024,
+    ):
         """Limits bandwidth for reads on a wrapped stream
 
         :type fileobj: file-like object
@@ -164,7 +171,8 @@ class BandwidthLimitedStream:
         while not self._transfer_coordinator.exception:
             try:
                 self._leaky_bucket.consume(
-                    self._bytes_seen, self._request_token)
+                    self._bytes_seen, self._request_token
+                )
                 self._bytes_seen = 0
                 return
             except RequestExceededException as e:
@@ -204,8 +212,13 @@ class BandwidthLimitedStream:
 
 
 class LeakyBucket:
-    def __init__(self, max_rate, time_utils=None, rate_tracker=None,
-                 consumption_scheduler=None):
+    def __init__(
+        self,
+        max_rate,
+        time_utils=None,
+        rate_tracker=None,
+        consumption_scheduler=None,
+    ):
         """A leaky bucket abstraction to limit bandwidth consumption
 
         :type rate: int
@@ -256,10 +269,12 @@ class LeakyBucket:
             time_now = self._time_utils.time()
             if self._consumption_scheduler.is_scheduled(request_token):
                 return self._release_requested_amt_for_scheduled_request(
-                    amt, request_token, time_now)
+                    amt, request_token, time_now
+                )
             elif self._projected_to_exceed_max_rate(amt, time_now):
                 self._raise_request_exceeded_exception(
-                    amt, request_token, time_now)
+                    amt, request_token, time_now
+                )
             else:
                 return self._release_requested_amt(amt, time_now)
 
@@ -267,18 +282,22 @@ class LeakyBucket:
         projected_rate = self._rate_tracker.get_projected_rate(amt, time_now)
         return projected_rate > self._max_rate
 
-    def _release_requested_amt_for_scheduled_request(self, amt, request_token,
-                                                     time_now):
+    def _release_requested_amt_for_scheduled_request(
+        self, amt, request_token, time_now
+    ):
         self._consumption_scheduler.process_scheduled_consumption(
-            request_token)
+            request_token
+        )
         return self._release_requested_amt(amt, time_now)
 
     def _raise_request_exceeded_exception(self, amt, request_token, time_now):
         allocated_time = amt / float(self._max_rate)
         retry_time = self._consumption_scheduler.schedule_consumption(
-            amt, request_token, allocated_time)
+            amt, request_token, allocated_time
+        )
         raise RequestExceededException(
-            requested_amt=amt, retry_time=retry_time)
+            requested_amt=amt, retry_time=retry_time
+        )
 
     def _release_requested_amt(self, amt, time_now):
         self._rate_tracker.record_consumption_rate(amt, time_now)
@@ -335,7 +354,8 @@ class ConsumptionScheduler:
         """
         scheduled_retry = self._tokens_to_scheduled_consumption.pop(token)
         self._total_wait = max(
-            self._total_wait - scheduled_retry['time_to_consume'], 0)
+            self._total_wait - scheduled_retry['time_to_consume'], 0
+        )
 
 
 class BandwidthRateTracker:
@@ -381,7 +401,8 @@ class BandwidthRateTracker:
         if self._last_time is None:
             return 0.0
         return self._calculate_exponential_moving_average_rate(
-            amt, time_at_consumption)
+            amt, time_at_consumption
+        )
 
     def record_consumption_rate(self, amt, time_at_consumption):
         """Record the consumption rate based off amount and time point
@@ -397,7 +418,8 @@ class BandwidthRateTracker:
             self._current_rate = 0.0
             return
         self._current_rate = self._calculate_exponential_moving_average_rate(
-            amt, time_at_consumption)
+            amt, time_at_consumption
+        )
         self._last_time = time_at_consumption
 
     def _calculate_rate(self, amt, time_at_consumption):
@@ -410,7 +432,8 @@ class BandwidthRateTracker:
             return float('inf')
         return amt / (time_delta)
 
-    def _calculate_exponential_moving_average_rate(self, amt,
-                                                   time_at_consumption):
+    def _calculate_exponential_moving_average_rate(
+        self, amt, time_at_consumption
+    ):
         new_rate = self._calculate_rate(amt, time_at_consumption)
         return self._alpha * new_rate + (1 - self._alpha) * self._current_rate

--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -33,24 +33,17 @@ if sys.platform.startswith('win'):
 else:
     rename_file = os.rename
 
-if six.PY3:
-    def accepts_kwargs(func):
-        # In python3.4.1, there's backwards incompatible
-        # changes when using getargspec with functools.partials.
-        return inspect.getfullargspec(func)[2]
 
-    # In python3, socket.error is OSError, which is too general
-    # for what we want (i.e FileNotFoundError is a subclass of OSError).
-    # In py3 all the socket related errors are in a newly created
-    # ConnectionError
-    SOCKET_ERROR = ConnectionError
-    MAXINT = None
-else:
-    def accepts_kwargs(func):
-        return inspect.getargspec(func)[2]
+def accepts_kwargs(func):
+    return inspect.getfullargspec(func)[2]
 
-    SOCKET_ERROR = socket.error
-    MAXINT = sys.maxint
+
+# In python 3, socket.error is OSError, which is too general
+# for what we want (i.e FileNotFoundError is a subclass of OSError).
+# In python 3, all the socket related errors are in a newly created
+# ConnectionError.
+SOCKET_ERROR = ConnectionError
+MAXINT = None
 
 
 def seekable(fileobj):
@@ -70,7 +63,7 @@ def seekable(fileobj):
         try:
             fileobj.seek(0, 1)
             return True
-        except (OSError, IOError):
+        except OSError:
             # If an io related error was thrown then it is not seekable.
             return False
     # Else, the fileobj is not seekable

--- a/s3transfer/compat.py
+++ b/s3transfer/compat.py
@@ -10,14 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import inspect
-import sys
-import os
 import errno
+import inspect
+import os
 import socket
+import sys
 
 from botocore.compat import six
-
 
 if sys.platform.startswith('win'):
     def rename_file(current_filename, new_filename):

--- a/s3transfer/constants.py
+++ b/s3transfer/constants.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import s3transfer
 
-
 KB = 1024
 MB = KB * KB
 GB = MB * KB

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -13,14 +13,18 @@
 import copy
 import math
 
-from s3transfer.tasks import Task
-from s3transfer.tasks import SubmissionTask
-from s3transfer.tasks import CreateMultipartUploadTask
-from s3transfer.tasks import CompleteMultipartUploadTask
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import calculate_range_parameter
-from s3transfer.utils import get_filtered_dict
-from s3transfer.utils import ChunksizeAdjuster
+from s3transfer.tasks import (
+    CompleteMultipartUploadTask,
+    CreateMultipartUploadTask,
+    SubmissionTask,
+    Task,
+)
+from s3transfer.utils import (
+    ChunksizeAdjuster,
+    calculate_range_parameter,
+    get_callbacks,
+    get_filtered_dict,
+)
 
 
 class CopySubmissionTask(SubmissionTask):

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -39,7 +39,7 @@ class CopySubmissionTask(SubmissionTask):
         'CopySourceSSECustomerAlgorithm': 'SSECustomerAlgorithm',
         'CopySourceSSECustomerKeyMD5': 'SSECustomerKeyMD5',
         'RequestPayer': 'RequestPayer',
-        'ExpectedBucketOwner': 'ExpectedBucketOwner'
+        'ExpectedBucketOwner': 'ExpectedBucketOwner',
     }
 
     UPLOAD_PART_COPY_ARGS = [
@@ -54,7 +54,7 @@ class CopySubmissionTask(SubmissionTask):
         'SSECustomerAlgorithm',
         'SSECustomerKeyMD5',
         'RequestPayer',
-        'ExpectedBucketOwner'
+        'ExpectedBucketOwner',
     ]
 
     CREATE_MULTIPART_ARGS_BLACKLIST = [
@@ -69,13 +69,11 @@ class CopySubmissionTask(SubmissionTask):
         'TaggingDirective',
     ]
 
-    COMPLETE_MULTIPART_ARGS = [
-        'RequestPayer',
-        'ExpectedBucketOwner'
-    ]
+    COMPLETE_MULTIPART_ARGS = ['RequestPayer', 'ExpectedBucketOwner']
 
-    def _submit(self, client, config, osutil, request_executor,
-                transfer_future):
+    def _submit(
+        self, client, config, osutil, request_executor, transfer_future
+    ):
         """
         :param client: The client associated with the transfer manager
 
@@ -102,9 +100,11 @@ class CopySubmissionTask(SubmissionTask):
             # of the client, they may have to provide the file size themselves
             # with a completely new client.
             call_args = transfer_future.meta.call_args
-            head_object_request = \
+            head_object_request = (
                 self._get_head_object_request_from_copy_source(
-                    call_args.copy_source)
+                    call_args.copy_source
+                )
+            )
             extra_args = call_args.extra_args
 
             # Map any values that may be used in the head object that is
@@ -112,24 +112,30 @@ class CopySubmissionTask(SubmissionTask):
             for param, value in extra_args.items():
                 if param in self.EXTRA_ARGS_TO_HEAD_ARGS_MAPPING:
                     head_object_request[
-                        self.EXTRA_ARGS_TO_HEAD_ARGS_MAPPING[param]] = value
+                        self.EXTRA_ARGS_TO_HEAD_ARGS_MAPPING[param]
+                    ] = value
 
             response = call_args.source_client.head_object(
-                **head_object_request)
+                **head_object_request
+            )
             transfer_future.meta.provide_transfer_size(
-                response['ContentLength'])
+                response['ContentLength']
+            )
 
         # If it is greater than threshold do a multipart copy, otherwise
         # do a regular copy object.
         if transfer_future.meta.size < config.multipart_threshold:
             self._submit_copy_request(
-                client, config, osutil, request_executor, transfer_future)
+                client, config, osutil, request_executor, transfer_future
+            )
         else:
             self._submit_multipart_request(
-                client, config, osutil, request_executor, transfer_future)
+                client, config, osutil, request_executor, transfer_future
+            )
 
-    def _submit_copy_request(self, client, config, osutil, request_executor,
-                             transfer_future):
+    def _submit_copy_request(
+        self, client, config, osutil, request_executor, transfer_future
+    ):
         call_args = transfer_future.meta.call_args
 
         # Get the needed progress callbacks for the task
@@ -147,14 +153,15 @@ class CopySubmissionTask(SubmissionTask):
                     'key': call_args.key,
                     'extra_args': call_args.extra_args,
                     'callbacks': progress_callbacks,
-                    'size': transfer_future.meta.size
+                    'size': transfer_future.meta.size,
                 },
-                is_final=True
-            )
+                is_final=True,
+            ),
         )
 
-    def _submit_multipart_request(self, client, config, osutil,
-                                  request_executor, transfer_future):
+    def _submit_multipart_request(
+        self, client, config, osutil, request_executor, transfer_future
+    ):
         call_args = transfer_future.meta.call_args
 
         # Submit the request to create a multipart upload and make sure it
@@ -173,8 +180,8 @@ class CopySubmissionTask(SubmissionTask):
                     'bucket': call_args.bucket,
                     'key': call_args.key,
                     'extra_args': create_multipart_extra_args,
-                }
-            )
+                },
+            ),
         )
 
         # Determine how many parts are needed based on filesize and
@@ -182,9 +189,11 @@ class CopySubmissionTask(SubmissionTask):
         part_size = config.multipart_chunksize
         adjuster = ChunksizeAdjuster()
         part_size = adjuster.adjust_chunksize(
-            part_size, transfer_future.meta.size)
+            part_size, transfer_future.meta.size
+        )
         num_parts = int(
-            math.ceil(transfer_future.meta.size / float(part_size)))
+            math.ceil(transfer_future.meta.size / float(part_size))
+        )
 
         # Submit requests to upload the parts of the file.
         part_futures = []
@@ -192,17 +201,24 @@ class CopySubmissionTask(SubmissionTask):
 
         for part_number in range(1, num_parts + 1):
             extra_part_args = self._extra_upload_part_args(
-                call_args.extra_args)
+                call_args.extra_args
+            )
             # The part number for upload part starts at 1 while the
             # range parameter starts at zero, so just subtract 1 off of
             # the part number
             extra_part_args['CopySourceRange'] = calculate_range_parameter(
-                part_size, part_number-1, num_parts, transfer_future.meta.size
+                part_size,
+                part_number - 1,
+                num_parts,
+                transfer_future.meta.size,
             )
             # Get the size of the part copy as well for the progress
             # callbacks.
             size = self._get_transfer_size(
-                part_size, part_number-1, num_parts, transfer_future.meta.size
+                part_size,
+                part_number - 1,
+                num_parts,
+                transfer_future.meta.size,
             )
             part_futures.append(
                 self._transfer_coordinator.submit(
@@ -217,17 +233,18 @@ class CopySubmissionTask(SubmissionTask):
                             'part_number': part_number,
                             'extra_args': extra_part_args,
                             'callbacks': progress_callbacks,
-                            'size': size
+                            'size': size,
                         },
                         pending_main_kwargs={
                             'upload_id': create_multipart_future
-                        }
-                    )
+                        },
+                    ),
                 )
             )
 
         complete_multipart_extra_args = self._extra_complete_multipart_args(
-            call_args.extra_args)
+            call_args.extra_args
+        )
         # Submit the request to complete the multipart upload.
         self._transfer_coordinator.submit(
             request_executor,
@@ -241,10 +258,10 @@ class CopySubmissionTask(SubmissionTask):
                 },
                 pending_main_kwargs={
                     'upload_id': create_multipart_future,
-                    'parts': part_futures
+                    'parts': part_futures,
                 },
-                is_final=True
-            )
+                is_final=True,
+            ),
         )
 
     def _get_head_object_request_from_copy_source(self, copy_source):
@@ -254,8 +271,7 @@ class CopySubmissionTask(SubmissionTask):
             raise TypeError(
                 'Expecting dictionary formatted: '
                 '{"Bucket": bucket_name, "Key": key} '
-                'but got %s or type %s.'
-                % (copy_source, type(copy_source))
+                'but got %s or type %s.' % (copy_source, type(copy_source))
             )
 
     def _extra_upload_part_args(self, extra_args):
@@ -266,8 +282,9 @@ class CopySubmissionTask(SubmissionTask):
     def _extra_complete_multipart_args(self, extra_args):
         return get_filtered_dict(extra_args, self.COMPLETE_MULTIPART_ARGS)
 
-    def _get_transfer_size(self, part_size, part_index, num_parts,
-                           total_transfer_size):
+    def _get_transfer_size(
+        self, part_size, part_index, num_parts, total_transfer_size
+    ):
         if part_index == num_parts - 1:
             # The last part may be different in size then the rest of the
             # parts.
@@ -277,8 +294,10 @@ class CopySubmissionTask(SubmissionTask):
 
 class CopyObjectTask(Task):
     """Task to do a nonmultipart copy"""
-    def _main(self, client, copy_source, bucket, key, extra_args, callbacks,
-              size):
+
+    def _main(
+        self, client, copy_source, bucket, key, extra_args, callbacks, size
+    ):
         """
         :param client: The client to use when calling PutObject
         :param copy_source: The CopySource parameter to use
@@ -292,15 +311,27 @@ class CopyObjectTask(Task):
 
         """
         client.copy_object(
-            CopySource=copy_source, Bucket=bucket, Key=key, **extra_args)
+            CopySource=copy_source, Bucket=bucket, Key=key, **extra_args
+        )
         for callback in callbacks:
             callback(bytes_transferred=size)
 
 
 class CopyPartTask(Task):
     """Task to upload a part in a multipart copy"""
-    def _main(self, client, copy_source, bucket, key, upload_id, part_number,
-              extra_args, callbacks, size):
+
+    def _main(
+        self,
+        client,
+        copy_source,
+        bucket,
+        key,
+        upload_id,
+        part_number,
+        extra_args,
+        callbacks,
+        size,
+    ):
         """
         :param client: The client to use when calling PutObject
         :param copy_source: The CopySource parameter to use
@@ -324,8 +355,13 @@ class CopyPartTask(Task):
             the multipart upload.
         """
         response = client.upload_part_copy(
-            CopySource=copy_source, Bucket=bucket, Key=key,
-            UploadId=upload_id, PartNumber=part_number, **extra_args)
+            CopySource=copy_source,
+            Bucket=bucket,
+            Key=key,
+            UploadId=upload_id,
+            PartNumber=part_number,
+            **extra_args
+        )
         for callback in callbacks:
             callback(bytes_transferred=size)
         etag = response['CopyPartResult']['ETag']

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -11,26 +11,30 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
-from io import BytesIO
 import threading
-
-import botocore.awsrequest
-import botocore.session
-from botocore import UNSIGNED
-from botocore.config import Config
-from botocore.compat import urlsplit
-from botocore.exceptions import NoCredentialsError
+from io import BytesIO
 
 import awscrt.http
-from awscrt.s3 import S3Client, S3RequestType, S3RequestTlsMode
-from awscrt.io import ClientBootstrap, DefaultHostResolver, EventLoopGroup
-from awscrt.io import ClientTlsContext, TlsContextOptions
-from awscrt.auth import AwsCredentialsProvider, AwsCredentials
+import botocore.awsrequest
+import botocore.session
+from awscrt.auth import AwsCredentials, AwsCredentialsProvider
+from awscrt.io import (
+    ClientBootstrap,
+    ClientTlsContext,
+    DefaultHostResolver,
+    EventLoopGroup,
+    TlsContextOptions,
+)
+from awscrt.s3 import S3Client, S3RequestTlsMode, S3RequestType
+from botocore import UNSIGNED
+from botocore.compat import urlsplit
+from botocore.config import Config
+from botocore.exceptions import NoCredentialsError
 
+from s3transfer.constants import GB, MB
 from s3transfer.exceptions import TransferNotDoneError
 from s3transfer.futures import BaseTransferFuture, BaseTransferMeta
 from s3transfer.utils import CallArgs, OSUtils, get_callbacks
-from s3transfer.constants import GB, MB
 
 logger = logging.getLogger(__name__)
 

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -47,27 +47,31 @@ class CRTCredentialProviderAdapter:
 
     def __call__(self):
         credentials = self._get_credentials().get_frozen_credentials()
-        return AwsCredentials(credentials.access_key,
-                              credentials.secret_key, credentials.token)
+        return AwsCredentials(
+            credentials.access_key, credentials.secret_key, credentials.token
+        )
 
     def _get_credentials(self):
         with self._lock:
             if self._loaded_credentials is None:
-                loaded_creds = self._botocore_credential_provider\
-                    .load_credentials()
+                loaded_creds = (
+                    self._botocore_credential_provider.load_credentials()
+                )
                 if loaded_creds is None:
                     raise NoCredentialsError()
                 self._loaded_credentials = loaded_creds
             return self._loaded_credentials
 
 
-def create_s3_crt_client(region,
-                         botocore_credential_provider=None,
-                         num_threads=None,
-                         target_throughput=5 * GB / 8,
-                         part_size=8 * MB,
-                         use_ssl=True,
-                         verify=None):
+def create_s3_crt_client(
+    region,
+    botocore_credential_provider=None,
+    num_threads=None,
+    target_throughput=5 * GB / 8,
+    part_size=8 * MB,
+    use_ssl=True,
+    verify=None,
+):
     """
     :type region: str
     :param region: The region used for signing
@@ -112,22 +116,26 @@ def create_s3_crt_client(region,
     provider = None
     tls_connection_options = None
 
-    tls_mode = S3RequestTlsMode.ENABLED if use_ssl \
-        else S3RequestTlsMode.DISABLED
+    tls_mode = (
+        S3RequestTlsMode.ENABLED if use_ssl else S3RequestTlsMode.DISABLED
+    )
     if verify is not None:
         tls_ctx_options = TlsContextOptions()
         if verify:
             tls_ctx_options.override_default_trust_store_from_path(
-                ca_filepath=verify)
+                ca_filepath=verify
+            )
         else:
             tls_ctx_options.verify_peer = False
         client_tls_option = ClientTlsContext(tls_ctx_options)
         tls_connection_options = client_tls_option.new_connection_options()
     if botocore_credential_provider:
         credentails_provider_adapter = CRTCredentialProviderAdapter(
-            botocore_credential_provider)
+            botocore_credential_provider
+        )
         provider = AwsCredentialsProvider.new_delegate(
-            credentails_provider_adapter)
+            credentails_provider_adapter
+        )
 
     target_gbps = target_throughput * 8 / GB
     return S3Client(
@@ -137,11 +145,11 @@ def create_s3_crt_client(region,
         part_size=part_size,
         tls_mode=tls_mode,
         tls_connection_options=tls_connection_options,
-        throughput_target_gbps=target_gbps)
+        throughput_target_gbps=target_gbps,
+    )
 
 
 class CRTTransferManager:
-
     def __init__(self, crt_s3_client, crt_request_serializer, osutil=None):
         """A transfer manager interface for Amazon S3 on CRT s3 client.
 
@@ -161,7 +169,8 @@ class CRTTransferManager:
             self._osutil = OSUtils()
         self._crt_s3_client = crt_s3_client
         self._s3_args_creator = S3ClientArgsCreator(
-            crt_request_serializer, self._osutil)
+            crt_request_serializer, self._osutil
+        )
         self._future_coordinators = []
         self._semaphore = threading.Semaphore(128)  # not configurable
         # A counter to create unique id's for each transfer submitted.
@@ -176,36 +185,47 @@ class CRTTransferManager:
             cancel = True
         self._shutdown(cancel)
 
-    def download(self, bucket, key, fileobj, extra_args=None,
-                 subscribers=None):
+    def download(
+        self, bucket, key, fileobj, extra_args=None, subscribers=None
+    ):
         if extra_args is None:
             extra_args = {}
         if subscribers is None:
             subscribers = {}
-        callargs = CallArgs(bucket=bucket, key=key, fileobj=fileobj,
-                            extra_args=extra_args, subscribers=subscribers)
+        callargs = CallArgs(
+            bucket=bucket,
+            key=key,
+            fileobj=fileobj,
+            extra_args=extra_args,
+            subscribers=subscribers,
+        )
         return self._submit_transfer("get_object", callargs)
 
-    def upload(self, fileobj, bucket, key, extra_args=None,
-               subscribers=None):
+    def upload(self, fileobj, bucket, key, extra_args=None, subscribers=None):
         if extra_args is None:
             extra_args = {}
         if subscribers is None:
             subscribers = {}
         callargs = CallArgs(
-            bucket=bucket, key=key, fileobj=fileobj,
-            extra_args=extra_args, subscribers=subscribers)
+            bucket=bucket,
+            key=key,
+            fileobj=fileobj,
+            extra_args=extra_args,
+            subscribers=subscribers,
+        )
         return self._submit_transfer("put_object", callargs)
 
-    def delete(self, bucket, key, extra_args=None,
-               subscribers=None):
+    def delete(self, bucket, key, extra_args=None, subscribers=None):
         if extra_args is None:
             extra_args = {}
         if subscribers is None:
             subscribers = {}
         callargs = CallArgs(
-            bucket=bucket, key=key, extra_args=extra_args,
-            subscribers=subscribers)
+            bucket=bucket,
+            key=key,
+            extra_args=extra_args,
+            subscribers=subscribers,
+        )
         return self._submit_transfer("delete_object", callargs)
 
     def shutdown(self, cancel=False):
@@ -245,7 +265,7 @@ class CRTTransferManager:
         coordinator = CRTTransferCoordinator(transfer_id=self._id_counter)
         components = {
             'meta': CRTTransferMeta(self._id_counter, call_args),
-            'coordinator': coordinator
+            'coordinator': coordinator,
         }
         future = CRTTransferFuture(**components)
         afterdone = AfterDoneHandler(coordinator)
@@ -254,16 +274,22 @@ class CRTTransferManager:
         try:
             self._semaphore.acquire()
             on_queued = self._s3_args_creator.get_crt_callback(
-                future, 'queued')
+                future, 'queued'
+            )
             on_queued()
             crt_callargs = self._s3_args_creator.get_make_request_args(
-                request_type, call_args, coordinator,
-                future, on_done_after_calls)
+                request_type,
+                call_args,
+                coordinator,
+                future,
+                on_done_after_calls,
+            )
             crt_s3_request = self._crt_s3_client.make_request(**crt_callargs)
         except Exception as e:
             coordinator.set_exception(e, True)
             on_done = self._s3_args_creator.get_crt_callback(
-                future, 'done', after_subscribers=on_done_after_calls)
+                future, 'done', after_subscribers=on_done_after_calls
+            )
             on_done(error=e)
         else:
             coordinator.set_s3_request(crt_s3_request)
@@ -327,7 +353,8 @@ class CRTTransferFuture(BaseTransferFuture):
         if not self.done():
             raise TransferNotDoneError(
                 'set_exception can only be called once the transfer is '
-                'complete.')
+                'complete.'
+            )
         self._coordinator.set_exception(exception, override=True)
 
 
@@ -366,12 +393,14 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
         self._resolve_client_config(session, client_kwargs)
         self._client = session.create_client(**client_kwargs)
         self._client.meta.events.register(
-            'request-created.s3.*', self._capture_http_request)
+            'request-created.s3.*', self._capture_http_request
+        )
         self._client.meta.events.register(
-            'after-call.s3.*',
-            self._change_response_to_serialized_http_request)
+            'after-call.s3.*', self._change_response_to_serialized_http_request
+        )
         self._client.meta.events.register(
-            'before-send.s3.*', self._make_fake_http_response)
+            'before-send.s3.*', self._make_fake_http_response
+        )
 
     def _resolve_client_config(self, session, client_kwargs):
         user_provided_config = None
@@ -411,13 +440,13 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
             method=aws_request.method,
             path=crt_path,
             headers=crt_headers,
-            body_stream=crt_body_stream)
+            body_stream=crt_body_stream,
+        )
         return crt_request
 
     def _convert_to_crt_http_request(self, botocore_http_request):
         # Logic that does CRTUtils.crt_request_from_aws_request
-        crt_request = self._crt_request_from_aws_request(
-            botocore_http_request)
+        crt_request = self._crt_request_from_aws_request(botocore_http_request)
         if crt_request.headers.get("host") is None:
             # If host is not set, set it for the request before using CRT s3
             url_parts = urlsplit(botocore_http_request.url)
@@ -430,7 +459,8 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
         request.context['http_request'] = request
 
     def _change_response_to_serialized_http_request(
-            self, context, parsed, **kwargs):
+        self, context, parsed, **kwargs
+    ):
         request = context['http_request']
         parsed['HTTPRequest'] = request.prepare()
 
@@ -444,12 +474,13 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
 
     def _get_botocore_http_request(self, client_method, call_args):
         return getattr(self._client, client_method)(
-            Bucket=call_args.bucket, Key=call_args.key,
-            **call_args.extra_args)['HTTPRequest']
+            Bucket=call_args.bucket, Key=call_args.key, **call_args.extra_args
+        )['HTTPRequest']
 
     def serialize_http_request(self, transfer_type, future):
         botocore_http_request = self._get_botocore_http_request(
-            transfer_type, future.meta.call_args)
+            transfer_type, future.meta.call_args
+        )
         crt_request = self._convert_to_crt_http_request(botocore_http_request)
         return crt_request
 
@@ -522,20 +553,20 @@ class S3ClientArgsCreator:
         self._os_utils = os_utils
 
     def get_make_request_args(
-            self, request_type, call_args, coordinator, future,
-            on_done_after_calls):
+        self, request_type, call_args, coordinator, future, on_done_after_calls
+    ):
         recv_filepath = None
         send_filepath = None
         s3_meta_request_type = getattr(
-            S3RequestType,
-            request_type.upper(),
-            S3RequestType.DEFAULT)
+            S3RequestType, request_type.upper(), S3RequestType.DEFAULT
+        )
         on_done_before_calls = []
         if s3_meta_request_type == S3RequestType.GET_OBJECT:
             final_filepath = call_args.fileobj
             recv_filepath = self._os_utils.get_temp_filename(final_filepath)
             file_ondone_call = RenameTempFileHandler(
-                coordinator, final_filepath, recv_filepath, self._os_utils)
+                coordinator, final_filepath, recv_filepath, self._os_utils
+            )
             on_done_before_calls.append(file_ondone_call)
         elif s3_meta_request_type == S3RequestType.PUT_OBJECT:
             send_filepath = call_args.fileobj
@@ -543,22 +574,27 @@ class S3ClientArgsCreator:
             call_args.extra_args["ContentLength"] = data_len
 
         crt_request = self._request_serializer.serialize_http_request(
-            request_type, future)
+            request_type, future
+        )
 
         return {
             'request': crt_request,
             'type': s3_meta_request_type,
             'recv_filepath': recv_filepath,
             'send_filepath': send_filepath,
-            'on_done': self.get_crt_callback(future, 'done',
-                                             on_done_before_calls,
-                                             on_done_after_calls),
-            'on_progress': self.get_crt_callback(future, 'progress')
+            'on_done': self.get_crt_callback(
+                future, 'done', on_done_before_calls, on_done_after_calls
+            ),
+            'on_progress': self.get_crt_callback(future, 'progress'),
         }
 
-    def get_crt_callback(self, future, callback_type,
-                         before_subscribers=None, after_subscribers=None):
-
+    def get_crt_callback(
+        self,
+        future,
+        callback_type,
+        before_subscribers=None,
+        after_subscribers=None,
+    ):
         def invoke_all_callbacks(*args, **kwargs):
             callbacks_list = []
             if before_subscribers is not None:
@@ -592,7 +628,8 @@ class RenameTempFileHandler:
         else:
             try:
                 self._osutil.rename_file(
-                    self._temp_filename, self._final_filename)
+                    self._temp_filename, self._final_filename
+                )
             except Exception as e:
                 self._osutil.remove_file(self._temp_filename)
                 # the CRT future has done already at this point

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -140,7 +140,7 @@ def create_s3_crt_client(region,
         throughput_target_gbps=target_gbps)
 
 
-class CRTTransferManager(object):
+class CRTTransferManager:
 
     def __init__(self, crt_s3_client, crt_request_serializer, osutil=None):
         """A transfer manager interface for Amazon S3 on CRT s3 client.
@@ -390,7 +390,7 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
         url_parts = urlsplit(aws_request.url)
         crt_path = url_parts.path
         if url_parts.query:
-            crt_path = '%s?%s' % (crt_path, url_parts.query)
+            crt_path = f'{crt_path}?{url_parts.query}'
         headers_list = []
         for name, value in aws_request.headers.items():
             if isinstance(value, str):

--- a/s3transfer/delete.py
+++ b/s3transfer/delete.py
@@ -47,8 +47,8 @@ class DeleteSubmissionTask(SubmissionTask):
                     'key': call_args.key,
                     'extra_args': call_args.extra_args,
                 },
-                is_final=True
-            )
+                is_final=True,
+            ),
         )
 
 

--- a/s3transfer/delete.py
+++ b/s3transfer/delete.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from s3transfer.tasks import Task
-from s3transfer.tasks import SubmissionTask
+from s3transfer.tasks import SubmissionTask, Task
 
 
 class DeleteSubmissionTask(SubmissionTask):

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -46,6 +46,7 @@ class DownloadOutputManager:
     that may be accepted. All implementations must subclass and override
     public methods from this class.
     """
+
     def __init__(self, osutil, transfer_coordinator, io_executor):
         self._osutil = osutil
         self._transfer_coordinator = transfer_coordinator
@@ -93,8 +94,7 @@ class DownloadOutputManager:
 
         """
         self._transfer_coordinator.submit(
-            self._io_executor,
-            self.get_io_write_task(fileobj, data, offset)
+            self._io_executor, self.get_io_write_task(fileobj, data, offset)
         )
 
     def get_io_write_task(self, fileobj, data, offset):
@@ -120,7 +120,7 @@ class DownloadOutputManager:
                 'fileobj': fileobj,
                 'data': data,
                 'offset': offset,
-            }
+            },
         )
 
     def get_final_io_task(self):
@@ -134,12 +134,12 @@ class DownloadOutputManager:
         :rtype: s3transfer.tasks.Task
         :returns: A final task to completed in the io executor
         """
-        raise NotImplementedError(
-            'must implement get_final_io_task()')
+        raise NotImplementedError('must implement get_final_io_task()')
 
     def _get_fileobj_from_filename(self, filename):
         f = DeferredOpenFile(
-            filename, mode='wb', open_function=self._osutil.open)
+            filename, mode='wb', open_function=self._osutil.open
+        )
         # Make sure the file gets closed and we remove the temporary file
         # if anything goes wrong during the process.
         self._transfer_coordinator.add_failure_cleanup(f.close)
@@ -148,8 +148,7 @@ class DownloadOutputManager:
 
 class DownloadFilenameOutputManager(DownloadOutputManager):
     def __init__(self, osutil, transfer_coordinator, io_executor):
-        super().__init__(
-            osutil, transfer_coordinator, io_executor)
+        super().__init__(osutil, transfer_coordinator, io_executor)
         self._final_filename = None
         self._temp_filename = None
         self._temp_fileobj = None
@@ -174,15 +173,16 @@ class DownloadFilenameOutputManager(DownloadOutputManager):
             main_kwargs={
                 'fileobj': self._temp_fileobj,
                 'final_filename': self._final_filename,
-                'osutil': self._osutil
+                'osutil': self._osutil,
             },
-            is_final=True
+            is_final=True,
         )
 
     def _get_temp_fileobj(self):
         f = self._get_fileobj_from_filename(self._temp_filename)
         self._transfer_coordinator.add_failure_cleanup(
-            self._osutil.remove_file, self._temp_filename)
+            self._osutil.remove_file, self._temp_filename
+        )
         return f
 
 
@@ -199,14 +199,15 @@ class DownloadSeekableOutputManager(DownloadOutputManager):
         # This task will serve the purpose of signaling when all of the io
         # writes have finished so done callbacks can be called.
         return CompleteDownloadNOOPTask(
-            transfer_coordinator=self._transfer_coordinator)
+            transfer_coordinator=self._transfer_coordinator
+        )
 
 
 class DownloadNonSeekableOutputManager(DownloadOutputManager):
-    def __init__(self, osutil, transfer_coordinator, io_executor,
-                 defer_queue=None):
-        super().__init__(
-            osutil, transfer_coordinator, io_executor)
+    def __init__(
+        self, osutil, transfer_coordinator, io_executor, defer_queue=None
+    ):
+        super().__init__(osutil, transfer_coordinator, io_executor)
         if defer_queue is None:
             defer_queue = DeferQueue()
         self._defer_queue = defer_queue
@@ -224,7 +225,8 @@ class DownloadNonSeekableOutputManager(DownloadOutputManager):
 
     def get_final_io_task(self):
         return CompleteDownloadNOOPTask(
-            transfer_coordinator=self._transfer_coordinator)
+            transfer_coordinator=self._transfer_coordinator
+        )
 
     def queue_file_io_task(self, fileobj, data, offset):
         with self._io_submit_lock:
@@ -234,10 +236,9 @@ class DownloadNonSeekableOutputManager(DownloadOutputManager):
                 logger.debug(
                     "Queueing IO offset %s for fileobj: %s",
                     write['offset'],
-                    fileobj
+                    fileobj,
                 )
-                super().queue_file_io_task(
-                    fileobj, data, offset)
+                super().queue_file_io_task(fileobj, data, offset)
 
     def get_io_write_task(self, fileobj, data, offset):
         return IOStreamingWriteTask(
@@ -245,22 +246,23 @@ class DownloadNonSeekableOutputManager(DownloadOutputManager):
             main_kwargs={
                 'fileobj': fileobj,
                 'data': data,
-            }
+            },
         )
 
 
 class DownloadSpecialFilenameOutputManager(DownloadNonSeekableOutputManager):
-    def __init__(self, osutil, transfer_coordinator, io_executor,
-                 defer_queue=None):
+    def __init__(
+        self, osutil, transfer_coordinator, io_executor, defer_queue=None
+    ):
         super().__init__(
-            osutil, transfer_coordinator, io_executor, defer_queue)
+            osutil, transfer_coordinator, io_executor, defer_queue
+        )
         self._fileobj = None
 
     @classmethod
     def is_compatible(cls, download_target, osutil):
-        return (
-            isinstance(download_target, str)
-            and osutil.is_special_file(download_target)
+        return isinstance(download_target, str) and osutil.is_special_file(
+            download_target
         )
 
     def get_fileobj_for_io_writes(self, transfer_future):
@@ -273,7 +275,8 @@ class DownloadSpecialFilenameOutputManager(DownloadNonSeekableOutputManager):
         return IOCloseTask(
             transfer_coordinator=self._transfer_coordinator,
             is_final=True,
-            main_kwargs={'fileobj': self._fileobj})
+            main_kwargs={'fileobj': self._fileobj},
+        )
 
 
 class DownloadSubmissionTask(SubmissionTask):
@@ -305,10 +308,20 @@ class DownloadSubmissionTask(SubmissionTask):
                 return download_manager_cls
         raise RuntimeError(
             'Output {} of type: {} is not supported.'.format(
-                fileobj, type(fileobj)))
+                fileobj, type(fileobj)
+            )
+        )
 
-    def _submit(self, client, config, osutil, request_executor, io_executor,
-                transfer_future, bandwidth_limiter=None):
+    def _submit(
+        self,
+        client,
+        config,
+        osutil,
+        request_executor,
+        io_executor,
+        transfer_future,
+        bandwidth_limiter=None,
+    ):
         """
         :param client: The client associated with the transfer manager
 
@@ -341,36 +354,59 @@ class DownloadSubmissionTask(SubmissionTask):
             response = client.head_object(
                 Bucket=transfer_future.meta.call_args.bucket,
                 Key=transfer_future.meta.call_args.key,
-                **transfer_future.meta.call_args.extra_args
+                **transfer_future.meta.call_args.extra_args,
             )
             transfer_future.meta.provide_transfer_size(
-                response['ContentLength'])
+                response['ContentLength']
+            )
 
         download_output_manager = self._get_download_output_manager_cls(
-            transfer_future, osutil)(osutil, self._transfer_coordinator,
-                                     io_executor)
+            transfer_future, osutil
+        )(osutil, self._transfer_coordinator, io_executor)
 
         # If it is greater than threshold do a ranged download, otherwise
         # do a regular GetObject download.
         if transfer_future.meta.size < config.multipart_threshold:
             self._submit_download_request(
-                client, config, osutil, request_executor, io_executor,
-                download_output_manager, transfer_future, bandwidth_limiter)
+                client,
+                config,
+                osutil,
+                request_executor,
+                io_executor,
+                download_output_manager,
+                transfer_future,
+                bandwidth_limiter,
+            )
         else:
             self._submit_ranged_download_request(
-                client, config, osutil, request_executor, io_executor,
-                download_output_manager, transfer_future, bandwidth_limiter)
+                client,
+                config,
+                osutil,
+                request_executor,
+                io_executor,
+                download_output_manager,
+                transfer_future,
+                bandwidth_limiter,
+            )
 
-    def _submit_download_request(self, client, config, osutil,
-                                 request_executor, io_executor,
-                                 download_output_manager, transfer_future,
-                                 bandwidth_limiter):
+    def _submit_download_request(
+        self,
+        client,
+        config,
+        osutil,
+        request_executor,
+        io_executor,
+        download_output_manager,
+        transfer_future,
+        bandwidth_limiter,
+    ):
         call_args = transfer_future.meta.call_args
 
         # Get a handle to the file that will be used for writing downloaded
         # contents
         fileobj = download_output_manager.get_fileobj_for_io_writes(
-            transfer_future)
+            transfer_future
+        )
 
         # Get the needed callbacks for the task
         progress_callbacks = get_callbacks(transfer_future, 'progress')
@@ -396,18 +432,24 @@ class DownloadSubmissionTask(SubmissionTask):
                     'max_attempts': config.num_download_attempts,
                     'download_output_manager': download_output_manager,
                     'io_chunksize': config.io_chunksize,
-                    'bandwidth_limiter': bandwidth_limiter
+                    'bandwidth_limiter': bandwidth_limiter,
                 },
-                done_callbacks=[final_task]
+                done_callbacks=[final_task],
             ),
-            tag=get_object_tag
+            tag=get_object_tag,
         )
 
-    def _submit_ranged_download_request(self, client, config, osutil,
-                                        request_executor, io_executor,
-                                        download_output_manager,
-                                        transfer_future,
-                                        bandwidth_limiter):
+    def _submit_ranged_download_request(
+        self,
+        client,
+        config,
+        osutil,
+        request_executor,
+        io_executor,
+        download_output_manager,
+        transfer_future,
+        bandwidth_limiter,
+    ):
         call_args = transfer_future.meta.call_args
 
         # Get the needed progress callbacks for the task
@@ -416,7 +458,8 @@ class DownloadSubmissionTask(SubmissionTask):
         # Get a handle to the file that will be used for writing downloaded
         # contents
         fileobj = download_output_manager.get_fileobj_for_io_writes(
-            transfer_future)
+            transfer_future
+        )
 
         # Determine the number of parts
         part_size = config.multipart_chunksize
@@ -435,7 +478,8 @@ class DownloadSubmissionTask(SubmissionTask):
         for i in range(num_parts):
             # Calculate the range parameter
             range_parameter = calculate_range_parameter(
-                part_size, i, num_parts)
+                part_size, i, num_parts
+            )
 
             # Inject the Range parameter to the parameters to be passed in
             # as extra args
@@ -458,19 +502,21 @@ class DownloadSubmissionTask(SubmissionTask):
                         'start_index': i * part_size,
                         'download_output_manager': download_output_manager,
                         'io_chunksize': config.io_chunksize,
-                        'bandwidth_limiter': bandwidth_limiter
+                        'bandwidth_limiter': bandwidth_limiter,
                     },
-                    done_callbacks=[finalize_download_invoker.decrement]
+                    done_callbacks=[finalize_download_invoker.decrement],
                 ),
-                tag=get_object_tag
+                tag=get_object_tag,
             )
         finalize_download_invoker.finalize()
 
-    def _get_final_io_task_submission_callback(self, download_manager,
-                                               io_executor):
+    def _get_final_io_task_submission_callback(
+        self, download_manager, io_executor
+    ):
         final_task = download_manager.get_final_io_task()
         return FunctionContainer(
-            self._transfer_coordinator.submit, io_executor, final_task)
+            self._transfer_coordinator.submit, io_executor, final_task
+        )
 
     def _calculate_range_param(self, part_size, part_index, num_parts):
         # Used to calculate the Range parameter
@@ -484,9 +530,20 @@ class DownloadSubmissionTask(SubmissionTask):
 
 
 class GetObjectTask(Task):
-    def _main(self, client, bucket, key, fileobj, extra_args, callbacks,
-              max_attempts, download_output_manager, io_chunksize,
-              start_index=0, bandwidth_limiter=None):
+    def _main(
+        self,
+        client,
+        bucket,
+        key,
+        fileobj,
+        extra_args,
+        callbacks,
+        max_attempts,
+        download_output_manager,
+        io_chunksize,
+        start_index=0,
+        bandwidth_limiter=None,
+    ):
         """Downloads an object and places content into io queue
 
         :param client: The client to use when calling GetObject
@@ -510,13 +567,17 @@ class GetObjectTask(Task):
             try:
                 current_index = start_index
                 response = client.get_object(
-                    Bucket=bucket, Key=key, **extra_args)
+                    Bucket=bucket, Key=key, **extra_args
+                )
                 streaming_body = StreamReaderProgress(
-                    response['Body'], callbacks)
+                    response['Body'], callbacks
+                )
                 if bandwidth_limiter:
-                    streaming_body = \
+                    streaming_body = (
                         bandwidth_limiter.get_bandwith_limited_stream(
-                            streaming_body, self._transfer_coordinator)
+                            streaming_body, self._transfer_coordinator
+                        )
+                    )
 
                 chunks = DownloadChunkIterator(streaming_body, io_chunksize)
                 for chunk in chunks:
@@ -525,23 +586,31 @@ class GetObjectTask(Task):
                     # data to be written and break out of the download.
                     if not self._transfer_coordinator.done():
                         self._handle_io(
-                            download_output_manager, fileobj, chunk,
-                            current_index
+                            download_output_manager,
+                            fileobj,
+                            chunk,
+                            current_index,
                         )
                         current_index += len(chunk)
                     else:
                         return
                 return
             except S3_RETRYABLE_DOWNLOAD_ERRORS as e:
-                logger.debug("Retrying exception caught (%s), "
-                             "retrying request, (attempt %s / %s)", e, i,
-                             max_attempts, exc_info=True)
+                logger.debug(
+                    "Retrying exception caught (%s), "
+                    "retrying request, (attempt %s / %s)",
+                    e,
+                    i,
+                    max_attempts,
+                    exc_info=True,
+                )
                 last_exception = e
                 # Also invoke the progress callbacks to indicate that we
                 # are trying to download the stream again and all progress
                 # for this GetObject has been lost.
                 invoke_progress_callbacks(
-                    callbacks, start_index - current_index)
+                    callbacks, start_index - current_index
+                )
                 continue
         raise RetriesExceededError(last_exception)
 
@@ -556,6 +625,7 @@ class ImmediatelyWriteIOGetObjectTask(GetObjectTask):
     downloading the object so there is no reason to go through the
     overhead of using an IO queue and executor.
     """
+
     def _handle_io(self, download_output_manager, fileobj, chunk, index):
         task = download_output_manager.get_io_write_task(fileobj, chunk, index)
         task()
@@ -597,6 +667,7 @@ class IORenameFileTask(Task):
         upon completion of writing the contents.
     :param osutil: OS utility
     """
+
     def _main(self, fileobj, final_filename, osutil):
         fileobj.close()
         osutil.rename_file(fileobj.name, final_filename)
@@ -607,6 +678,7 @@ class IOCloseTask(Task):
 
     :param fileobj: The fileobj to close.
     """
+
     def _main(self, fileobj):
         fileobj.close()
 
@@ -617,15 +689,21 @@ class CompleteDownloadNOOPTask(Task):
     Note that the default for is_final is set to True because this should
     always be the last task.
     """
-    def __init__(self, transfer_coordinator, main_kwargs=None,
-                 pending_main_kwargs=None, done_callbacks=None,
-                 is_final=True):
+
+    def __init__(
+        self,
+        transfer_coordinator,
+        main_kwargs=None,
+        pending_main_kwargs=None,
+        done_callbacks=None,
+        is_final=True,
+    ):
         super().__init__(
             transfer_coordinator=transfer_coordinator,
             main_kwargs=main_kwargs,
             pending_main_kwargs=pending_main_kwargs,
             done_callbacks=done_callbacks,
-            is_final=is_final
+            is_final=is_final,
         )
 
     def _main(self):
@@ -671,6 +749,7 @@ class DeferQueue:
     until it has the next contiguous block available (starting at 0).
 
     """
+
     def __init__(self):
         self._writes = []
         self._pending_offsets = set()

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -10,28 +10,27 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import heapq
 import logging
 import threading
-import heapq
-
 
 from botocore.compat import six
 
 from s3transfer.compat import seekable
 from s3transfer.exceptions import RetriesExceededError
 from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
-from s3transfer.utils import S3_RETRYABLE_DOWNLOAD_ERRORS
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import invoke_progress_callbacks
-from s3transfer.utils import calculate_num_parts
-from s3transfer.utils import calculate_range_parameter
-from s3transfer.utils import FunctionContainer
-from s3transfer.utils import CountCallbackInvoker
-from s3transfer.utils import StreamReaderProgress
-from s3transfer.utils import DeferredOpenFile
-from s3transfer.tasks import Task
-from s3transfer.tasks import SubmissionTask
-
+from s3transfer.tasks import SubmissionTask, Task
+from s3transfer.utils import (
+    S3_RETRYABLE_DOWNLOAD_ERRORS,
+    CountCallbackInvoker,
+    DeferredOpenFile,
+    FunctionContainer,
+    StreamReaderProgress,
+    calculate_num_parts,
+    calculate_range_parameter,
+    get_callbacks,
+    invoke_progress_callbacks,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -15,7 +15,7 @@ from concurrent.futures import CancelledError
 
 class RetriesExceededError(Exception):
     def __init__(self, last_exception, msg='Max Retries Exceeded'):
-        super(RetriesExceededError, self).__init__(msg)
+        super().__init__(msg)
         self.last_exception = last_exception
 
 

--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -33,4 +33,5 @@ class TransferNotDoneError(Exception):
 
 class FatalError(CancelledError):
     """A CancelledError raised from an error in the TransferManager"""
+
     pass

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -10,19 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from concurrent import futures
-from collections import namedtuple
 import copy
 import logging
 import sys
 import threading
+from collections import namedtuple
+from concurrent import futures
 
-from s3transfer.compat import MAXINT
-from s3transfer.compat import six
+from s3transfer.compat import MAXINT, six
 from s3transfer.exceptions import CancelledError, TransferNotDoneError
-from s3transfer.utils import FunctionContainer
-from s3transfer.utils import TaskSemaphore
-
+from s3transfer.utils import FunctionContainer, TaskSemaphore
 
 logger = logging.getLogger(__name__)
 

--- a/s3transfer/futures.py
+++ b/s3transfer/futures.py
@@ -17,14 +17,14 @@ import threading
 from collections import namedtuple
 from concurrent import futures
 
-from s3transfer.compat import MAXINT, six
+from s3transfer.compat import MAXINT
 from s3transfer.exceptions import CancelledError, TransferNotDoneError
 from s3transfer.utils import FunctionContainer, TaskSemaphore
 
 logger = logging.getLogger(__name__)
 
 
-class BaseTransferFuture(object):
+class BaseTransferFuture:
     @property
     def meta(self):
         """The metadata associated to the TransferFuture"""
@@ -51,7 +51,7 @@ class BaseTransferFuture(object):
         raise NotImplementedError('cancel()')
 
 
-class BaseTransferMeta(object):
+class BaseTransferMeta:
     @property
     def call_args(self):
         """The call args used in the transfer request"""
@@ -155,7 +155,7 @@ class TransferMeta(BaseTransferMeta):
         self._size = size
 
 
-class TransferCoordinator(object):
+class TransferCoordinator:
     """A helper class for managing TransferFuture"""
     def __init__(self, transfer_id=None):
         self.transfer_id = transfer_id
@@ -172,7 +172,7 @@ class TransferCoordinator(object):
         self._failure_cleanups_lock = threading.Lock()
 
     def __repr__(self):
-        return '%s(transfer_id=%s)' % (
+        return '{}(transfer_id={})'.format(
             self.__class__.__name__, self.transfer_id)
 
     @property
@@ -311,7 +311,7 @@ class TransferCoordinator(object):
         :returns: A future representing the submitted task
         """
         logger.debug(
-            "Submitting task %s to executor %s for transfer request: %s." % (
+            "Submitting task {} to executor {} for transfer request: {}.".format(
                 task, executor, self.transfer_id)
         )
         future = executor.submit(task, tag=tag)
@@ -395,7 +395,7 @@ class TransferCoordinator(object):
             logger.debug("Exception raised in %s." % callback, exc_info=True)
 
 
-class BoundedExecutor(object):
+class BoundedExecutor:
     EXECUTOR_CLS = futures.ThreadPoolExecutor
 
     def __init__(self, max_size, max_num_threads, tag_semaphores=None,
@@ -471,7 +471,7 @@ class BoundedExecutor(object):
         self._executor.shutdown(wait)
 
 
-class ExecutorFuture(object):
+class ExecutorFuture:
     def __init__(self, future):
         """A future returned from the executor
 
@@ -506,7 +506,7 @@ class ExecutorFuture(object):
         return self._future.done()
 
 
-class BaseExecutor(object):
+class BaseExecutor:
     """Base Executor class implementation needed to work with s3transfer"""
     def __init__(self, max_workers=None):
         pass
@@ -538,7 +538,7 @@ class NonThreadedExecutor(BaseExecutor):
         pass
 
 
-class NonThreadedExecutorFuture(object):
+class NonThreadedExecutorFuture:
     """The Future returned from NonThreadedExecutor
 
     Note that this future is **not** thread-safe as it is being used
@@ -562,8 +562,7 @@ class NonThreadedExecutorFuture(object):
 
     def result(self, timeout=None):
         if self._exception:
-            six.reraise(
-                type(self._exception), self._exception, self._traceback)
+            raise self._exception.with_traceback(self._traceback)
         return self._result
 
     def _set_done(self):

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -17,30 +17,30 @@ import threading
 
 from botocore.compat import six
 
-from s3transfer.constants import KB, MB
-from s3transfer.constants import ALLOWED_DOWNLOAD_ARGS
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import signal_transferring
-from s3transfer.utils import signal_not_transferring
-from s3transfer.utils import CallArgs
-from s3transfer.utils import OSUtils
-from s3transfer.utils import TaskSemaphore
-from s3transfer.utils import SlidingWindowSemaphore
-from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import FatalError
-from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
-from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
-from s3transfer.futures import BoundedExecutor
-from s3transfer.futures import TransferFuture
-from s3transfer.futures import TransferMeta
-from s3transfer.futures import TransferCoordinator
-from s3transfer.download import DownloadSubmissionTask
-from s3transfer.upload import UploadSubmissionTask
+from s3transfer.bandwidth import BandwidthLimiter, LeakyBucket
+from s3transfer.constants import ALLOWED_DOWNLOAD_ARGS, KB, MB
 from s3transfer.copies import CopySubmissionTask
 from s3transfer.delete import DeleteSubmissionTask
-from s3transfer.bandwidth import LeakyBucket
-from s3transfer.bandwidth import BandwidthLimiter
-
+from s3transfer.download import DownloadSubmissionTask
+from s3transfer.exceptions import CancelledError, FatalError
+from s3transfer.futures import (
+    IN_MEMORY_DOWNLOAD_TAG,
+    IN_MEMORY_UPLOAD_TAG,
+    BoundedExecutor,
+    TransferCoordinator,
+    TransferFuture,
+    TransferMeta,
+)
+from s3transfer.upload import UploadSubmissionTask
+from s3transfer.utils import (
+    CallArgs,
+    OSUtils,
+    SlidingWindowSemaphore,
+    TaskSemaphore,
+    get_callbacks,
+    signal_not_transferring,
+    signal_transferring,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -145,10 +145,7 @@ class TransferConfig:
         self._validate_attrs_are_nonzero()
 
     def _validate_attrs_are_nonzero(self):
-        for (
-            attr,
-            attr_val,
-        ) in self.__dict__.items():
+        for attr, attr_val in self.__dict__.items():
             if attr_val is not None and attr_val <= 0:
                 raise ValueError(
                     'Provided parameter %s of value %s must be greater than '

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -15,8 +15,6 @@ import logging
 import re
 import threading
 
-from botocore.compat import six
-
 from s3transfer.bandwidth import BandwidthLimiter, LeakyBucket
 from s3transfer.constants import ALLOWED_DOWNLOAD_ARGS, KB, MB
 from s3transfer.copies import CopySubmissionTask
@@ -45,7 +43,7 @@ from s3transfer.utils import (
 logger = logging.getLogger(__name__)
 
 
-class TransferConfig(object):
+class TransferConfig:
     def __init__(self,
                  multipart_threshold=8 * MB,
                  multipart_chunksize=8 * MB,
@@ -152,7 +150,7 @@ class TransferConfig(object):
                     '0.' % (attr, attr_val))
 
 
-class TransferManager(object):
+class TransferManager:
     ALLOWED_DOWNLOAD_ARGS = ALLOWED_DOWNLOAD_ARGS
 
     ALLOWED_UPLOAD_ARGS = [
@@ -558,7 +556,7 @@ class TransferManager(object):
         # all of the inprogress futures in the shutdown.
         if exc_type:
             cancel = True
-            cancel_msg = six.text_type(exc_value)
+            cancel_msg = str(exc_value)
             if not cancel_msg:
                 cancel_msg = repr(exc_value)
             # If it was a KeyboardInterrupt, the cancellation was initiated
@@ -609,7 +607,7 @@ class TransferManager(object):
             self._io_executor.shutdown()
 
 
-class TransferCoordinatorController(object):
+class TransferCoordinatorController:
     def __init__(self):
         """Abstraction to control all transfer coordinators
 

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -196,27 +196,24 @@ import collections
 import contextlib
 import logging
 import multiprocessing
-import threading
 import signal
+import threading
 from copy import deepcopy
 
 import botocore.session
 from botocore.config import Config
 
-from s3transfer.constants import MB
-from s3transfer.constants import ALLOWED_DOWNLOAD_ARGS
-from s3transfer.constants import PROCESS_USER_AGENT
-from s3transfer.compat import MAXINT
-from s3transfer.compat import BaseManager
-from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import RetriesExceededError
-from s3transfer.futures import BaseTransferFuture
-from s3transfer.futures import BaseTransferMeta
-from s3transfer.utils import S3_RETRYABLE_DOWNLOAD_ERRORS
-from s3transfer.utils import calculate_num_parts
-from s3transfer.utils import calculate_range_parameter
-from s3transfer.utils import OSUtils
-from s3transfer.utils import CallArgs
+from s3transfer.compat import MAXINT, BaseManager
+from s3transfer.constants import ALLOWED_DOWNLOAD_ARGS, MB, PROCESS_USER_AGENT
+from s3transfer.exceptions import CancelledError, RetriesExceededError
+from s3transfer.futures import BaseTransferFuture, BaseTransferMeta
+from s3transfer.utils import (
+    S3_RETRYABLE_DOWNLOAD_ERRORS,
+    CallArgs,
+    OSUtils,
+    calculate_num_parts,
+    calculate_range_parameter,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -406,10 +406,10 @@ class ProcessPoolDownloader:
     def _validate_all_known_args(self, provided):
         for kwarg in provided:
             if kwarg not in ALLOWED_DOWNLOAD_ARGS:
+                download_args = ', '.join(ALLOWED_DOWNLOAD_ARGS)
                 raise ValueError(
-                    "Invalid extra_args key '%s', "
-                    "must be one of: %s"
-                    % (kwarg, ', '.join(ALLOWED_DOWNLOAD_ARGS))
+                    f"Invalid extra_args key '{kwarg}', "
+                    f"must be one of: {download_args}"
                 )
 
     def _get_transfer_future(self, transfer_id, call_args):
@@ -830,7 +830,7 @@ class GetObjectSubmitter(BaseS3TransferProcess):
             expected_size = self._client.head_object(
                 Bucket=download_file_request.bucket,
                 Key=download_file_request.key,
-                **download_file_request.extra_args
+                **download_file_request.extra_args,
             )['ContentLength']
         return expected_size
 

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -223,31 +223,33 @@ SHUTDOWN_SIGNAL = 'SHUTDOWN'
 # to the GetObjectSubmitter in order for the submitter to begin submitting
 # GetObjectJobs to the GetObjectWorkers.
 DownloadFileRequest = collections.namedtuple(
-    'DownloadFileRequest', [
-        'transfer_id',    # The unique id for the transfer
-        'bucket',         # The bucket to download the object from
-        'key',            # The key to download the object from
-        'filename',       # The user-requested download location
-        'extra_args',     # Extra arguments to provide to client calls
+    'DownloadFileRequest',
+    [
+        'transfer_id',  # The unique id for the transfer
+        'bucket',  # The bucket to download the object from
+        'key',  # The key to download the object from
+        'filename',  # The user-requested download location
+        'extra_args',  # Extra arguments to provide to client calls
         'expected_size',  # The user-provided expected size of the download
-    ]
+    ],
 )
 
 # The GetObjectJob tuple is submitted from the GetObjectSubmitter
 # to the GetObjectWorkers to download the file or parts of the file.
 GetObjectJob = collections.namedtuple(
-    'GetObjectJob', [
-        'transfer_id',    # The unique id for the transfer
-        'bucket',         # The bucket to download the object from
-        'key',            # The key to download the object from
+    'GetObjectJob',
+    [
+        'transfer_id',  # The unique id for the transfer
+        'bucket',  # The bucket to download the object from
+        'key',  # The key to download the object from
         'temp_filename',  # The temporary file to write the content to via
-                          # completed GetObject calls.
-        'extra_args',     # Extra arguments to provide to the GetObject call
-        'offset',         # The offset to write the content for the temp file.
-        'filename',       # The user-requested download location. The worker
-                          # of final GetObjectJob will move the file located at
-                          # temp_filename to the location of filename.
-    ]
+        # completed GetObject calls.
+        'extra_args',  # Extra arguments to provide to the GetObject call
+        'offset',  # The offset to write the content for the temp file.
+        'filename',  # The user-requested download location. The worker
+        # of final GetObjectJob will move the file located at
+        # temp_filename to the location of filename.
+    ],
 )
 
 
@@ -265,10 +267,12 @@ def _add_ignore_handler_for_interrupts():
 
 
 class ProcessTransferConfig:
-    def __init__(self,
-                 multipart_threshold=8 * MB,
-                 multipart_chunksize=8 * MB,
-                 max_request_processes=10):
+    def __init__(
+        self,
+        multipart_threshold=8 * MB,
+        multipart_chunksize=8 * MB,
+        max_request_processes=10,
+    ):
         """Configuration for the ProcessPoolDownloader
 
         :param multipart_threshold: The threshold for which ranged downloads
@@ -318,8 +322,9 @@ class ProcessPoolDownloader:
         self._submitter = None
         self._workers = []
 
-    def download_file(self, bucket, key, filename, extra_args=None,
-                      expected_size=None):
+    def download_file(
+        self, bucket, key, filename, extra_args=None, expected_size=None
+    ):
         """Downloads the object's contents to a file
 
         :type bucket: str
@@ -350,16 +355,24 @@ class ProcessPoolDownloader:
         self._validate_all_known_args(extra_args)
         transfer_id = self._transfer_monitor.notify_new_transfer()
         download_file_request = DownloadFileRequest(
-            transfer_id=transfer_id, bucket=bucket, key=key,
-            filename=filename, extra_args=extra_args,
+            transfer_id=transfer_id,
+            bucket=bucket,
+            key=key,
+            filename=filename,
+            extra_args=extra_args,
             expected_size=expected_size,
         )
         logger.debug(
-            'Submitting download file request: %s.', download_file_request)
+            'Submitting download file request: %s.', download_file_request
+        )
         self._download_request_queue.put(download_file_request)
         call_args = CallArgs(
-            bucket=bucket, key=key, filename=filename, extra_args=extra_args,
-            expected_size=expected_size)
+            bucket=bucket,
+            key=key,
+            filename=filename,
+            extra_args=extra_args,
+            expected_size=expected_size,
+        )
         future = self._get_transfer_future(transfer_id, call_args)
         return future
 
@@ -395,14 +408,17 @@ class ProcessPoolDownloader:
             if kwarg not in ALLOWED_DOWNLOAD_ARGS:
                 raise ValueError(
                     "Invalid extra_args key '%s', "
-                    "must be one of: %s" % (
-                        kwarg, ', '.join(ALLOWED_DOWNLOAD_ARGS)))
+                    "must be one of: %s"
+                    % (kwarg, ', '.join(ALLOWED_DOWNLOAD_ARGS))
+                )
 
     def _get_transfer_future(self, transfer_id, call_args):
         meta = ProcessPoolTransferMeta(
-            call_args=call_args, transfer_id=transfer_id)
+            call_args=call_args, transfer_id=transfer_id
+        )
         future = ProcessPoolTransferFuture(
-            monitor=self._transfer_monitor, meta=meta)
+            monitor=self._transfer_monitor, meta=meta
+        )
         return future
 
     def _start_transfer_monitor_manager(self):
@@ -423,13 +439,15 @@ class ProcessPoolDownloader:
             transfer_monitor=self._transfer_monitor,
             osutil=self._osutil,
             download_request_queue=self._download_request_queue,
-            worker_queue=self._worker_queue
+            worker_queue=self._worker_queue,
         )
         self._submitter.start()
 
     def _start_get_object_workers(self):
-        logger.debug('Starting %s GetObjectWorkers.',
-                     self._transfer_config.max_request_processes)
+        logger.debug(
+            'Starting %s GetObjectWorkers.',
+            self._transfer_config.max_request_processes,
+        )
         for _ in range(self._transfer_config.max_request_processes):
             worker = GetObjectWorker(
                 queue=self._worker_queue,
@@ -518,6 +536,7 @@ class ProcessPoolTransferFuture(BaseTransferFuture):
 
 class ProcessPoolTransferMeta(BaseTransferMeta):
     """Holds metadata about the ProcessPoolTransferFuture"""
+
     def __init__(self, transfer_id, call_args):
         self._transfer_id = transfer_id
         self._call_args = call_args
@@ -558,7 +577,8 @@ class ClientFactory:
     def create_client(self):
         """Create a botocore S3 client"""
         return botocore.session.Session().create_client(
-            's3', **self._client_kwargs)
+            's3', **self._client_kwargs
+        )
 
 
 class TransferMonitor:
@@ -659,6 +679,7 @@ class TransferMonitor:
 
 class TransferState:
     """Represents the current state of an individual transfer"""
+
     # NOTE: Ideally the TransferState object would be used directly by the
     # various different abstractions in the ProcessPoolDownloader and remove
     # the need for the TransferMonitor. However, it would then impose the
@@ -739,9 +760,15 @@ class BaseS3TransferProcess(multiprocessing.Process):
 
 
 class GetObjectSubmitter(BaseS3TransferProcess):
-    def __init__(self, transfer_config, client_factory,
-                 transfer_monitor, osutil, download_request_queue,
-                 worker_queue):
+    def __init__(
+        self,
+        transfer_config,
+        client_factory,
+        transfer_monitor,
+        osutil,
+        download_request_queue,
+        worker_queue,
+    ):
         """Submit GetObjectJobs to fulfill a download file request
 
         :param transfer_config: Configuration for transfers.
@@ -766,29 +793,36 @@ class GetObjectSubmitter(BaseS3TransferProcess):
         while True:
             download_file_request = self._download_request_queue.get()
             if download_file_request == SHUTDOWN_SIGNAL:
-                logger.debug(
-                    'Submitter shutdown signal received.')
+                logger.debug('Submitter shutdown signal received.')
                 return
             try:
                 self._submit_get_object_jobs(download_file_request)
             except Exception as e:
-                logger.debug('Exception caught when submitting jobs for '
-                             'download file request %s: %s',
-                             download_file_request, e, exc_info=True)
+                logger.debug(
+                    'Exception caught when submitting jobs for '
+                    'download file request %s: %s',
+                    download_file_request,
+                    e,
+                    exc_info=True,
+                )
                 self._transfer_monitor.notify_exception(
-                    download_file_request.transfer_id, e)
+                    download_file_request.transfer_id, e
+                )
                 self._transfer_monitor.notify_done(
-                    download_file_request.transfer_id)
+                    download_file_request.transfer_id
+                )
 
     def _submit_get_object_jobs(self, download_file_request):
         size = self._get_size(download_file_request)
         temp_filename = self._allocate_temp_file(download_file_request, size)
         if size < self._transfer_config.multipart_threshold:
             self._submit_single_get_object_job(
-                download_file_request, temp_filename)
+                download_file_request, temp_filename
+            )
         else:
             self._submit_ranged_get_object_jobs(
-                download_file_request, temp_filename, size)
+                download_file_request, temp_filename, size
+            )
 
     def _get_size(self, download_file_request):
         expected_size = download_file_request.expected_size
@@ -796,7 +830,8 @@ class GetObjectSubmitter(BaseS3TransferProcess):
             expected_size = self._client.head_object(
                 Bucket=download_file_request.bucket,
                 Key=download_file_request.key,
-                **download_file_request.extra_args)['ContentLength']
+                **download_file_request.extra_args
+            )['ContentLength']
         return expected_size
 
     def _allocate_temp_file(self, download_file_request, size):
@@ -806,10 +841,10 @@ class GetObjectSubmitter(BaseS3TransferProcess):
         self._osutil.allocate(temp_filename, size)
         return temp_filename
 
-    def _submit_single_get_object_job(self, download_file_request,
-                                      temp_filename):
-        self._notify_jobs_to_complete(
-            download_file_request.transfer_id, 1)
+    def _submit_single_get_object_job(
+        self, download_file_request, temp_filename
+    ):
+        self._notify_jobs_to_complete(download_file_request.transfer_id, 1)
         self._submit_get_object_job(
             transfer_id=download_file_request.transfer_id,
             bucket=download_file_request.bucket,
@@ -817,19 +852,22 @@ class GetObjectSubmitter(BaseS3TransferProcess):
             temp_filename=temp_filename,
             offset=0,
             extra_args=download_file_request.extra_args,
-            filename=download_file_request.filename
+            filename=download_file_request.filename,
         )
 
-    def _submit_ranged_get_object_jobs(self, download_file_request,
-                                       temp_filename, size):
+    def _submit_ranged_get_object_jobs(
+        self, download_file_request, temp_filename, size
+    ):
         part_size = self._transfer_config.multipart_chunksize
         num_parts = calculate_num_parts(size, part_size)
         self._notify_jobs_to_complete(
-            download_file_request.transfer_id, num_parts)
+            download_file_request.transfer_id, num_parts
+        )
         for i in range(num_parts):
             offset = i * part_size
             range_parameter = calculate_range_parameter(
-                part_size, i, num_parts)
+                part_size, i, num_parts
+            )
             get_object_kwargs = {'Range': range_parameter}
             get_object_kwargs.update(download_file_request.extra_args)
             self._submit_get_object_job(
@@ -848,10 +886,12 @@ class GetObjectSubmitter(BaseS3TransferProcess):
     def _notify_jobs_to_complete(self, transfer_id, jobs_to_complete):
         logger.debug(
             'Notifying %s job(s) to complete for transfer_id %s.',
-            jobs_to_complete, transfer_id
+            jobs_to_complete,
+            transfer_id,
         )
         self._transfer_monitor.notify_expected_jobs_to_complete(
-            transfer_id, jobs_to_complete)
+            transfer_id, jobs_to_complete
+        )
 
 
 class GetObjectWorker(BaseS3TransferProcess):
@@ -883,20 +923,24 @@ class GetObjectWorker(BaseS3TransferProcess):
         while True:
             job = self._queue.get()
             if job == SHUTDOWN_SIGNAL:
-                logger.debug(
-                    'Worker shutdown signal received.')
+                logger.debug('Worker shutdown signal received.')
                 return
             if not self._transfer_monitor.get_exception(job.transfer_id):
                 self._run_get_object_job(job)
             else:
                 logger.debug(
                     'Skipping get object job %s because there was a previous '
-                    'exception.', job)
+                    'exception.',
+                    job,
+                )
             remaining = self._transfer_monitor.notify_job_complete(
-                job.transfer_id)
+                job.transfer_id
+            )
             logger.debug(
-                '%s jobs remaining for transfer_id %s.', remaining,
-                job.transfer_id)
+                '%s jobs remaining for transfer_id %s.',
+                remaining,
+                job.transfer_id,
+            )
             if not remaining:
                 self._finalize_download(
                     job.transfer_id, job.temp_filename, job.filename
@@ -905,14 +949,20 @@ class GetObjectWorker(BaseS3TransferProcess):
     def _run_get_object_job(self, job):
         try:
             self._do_get_object(
-                bucket=job.bucket, key=job.key,
-                temp_filename=job.temp_filename, extra_args=job.extra_args,
-                offset=job.offset
+                bucket=job.bucket,
+                key=job.key,
+                temp_filename=job.temp_filename,
+                extra_args=job.extra_args,
+                offset=job.offset,
             )
         except Exception as e:
-            logger.debug('Exception caught when downloading object for '
-                         'get object job %s: %s',
-                         job, e, exc_info=True)
+            logger.debug(
+                'Exception caught when downloading object for '
+                'get object job %s: %s',
+                job,
+                e,
+                exc_info=True,
+            )
             self._transfer_monitor.notify_exception(job.transfer_id, e)
 
     def _do_get_object(self, bucket, key, extra_args, temp_filename, offset):
@@ -920,14 +970,19 @@ class GetObjectWorker(BaseS3TransferProcess):
         for i in range(self._MAX_ATTEMPTS):
             try:
                 response = self._client.get_object(
-                    Bucket=bucket, Key=key, **extra_args)
+                    Bucket=bucket, Key=key, **extra_args
+                )
                 self._write_to_file(temp_filename, offset, response['Body'])
                 return
             except S3_RETRYABLE_DOWNLOAD_ERRORS as e:
                 logger.debug(
                     'Retrying exception caught (%s), '
-                    'retrying request, (attempt %s / %s)', e, i+1,
-                    self._MAX_ATTEMPTS, exc_info=True)
+                    'retrying request, (attempt %s / %s)',
+                    e,
+                    i + 1,
+                    self._MAX_ATTEMPTS,
+                    exc_info=True,
+                )
                 last_exception = e
         raise RetriesExceededError(last_exception)
 

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -264,7 +264,7 @@ def _add_ignore_handler_for_interrupts():
     return signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
-class ProcessTransferConfig(object):
+class ProcessTransferConfig:
     def __init__(self,
                  multipart_threshold=8 * MB,
                  multipart_chunksize=8 * MB,
@@ -284,7 +284,7 @@ class ProcessTransferConfig(object):
         self.max_request_processes = max_request_processes
 
 
-class ProcessPoolDownloader(object):
+class ProcessPoolDownloader:
     def __init__(self, client_kwargs=None, config=None):
         """Downloads S3 objects using process pools
 
@@ -536,7 +536,7 @@ class ProcessPoolTransferMeta(BaseTransferMeta):
         return self._user_context
 
 
-class ClientFactory(object):
+class ClientFactory:
     def __init__(self, client_kwargs=None):
         """Creates S3 clients for processes
 
@@ -561,7 +561,7 @@ class ClientFactory(object):
             's3', **self._client_kwargs)
 
 
-class TransferMonitor(object):
+class TransferMonitor:
     def __init__(self):
         """Monitors transfers for cross-process communication
 
@@ -657,7 +657,7 @@ class TransferMonitor(object):
         return self._transfer_states[transfer_id].decrement_jobs_to_complete()
 
 
-class TransferState(object):
+class TransferState:
     """Represents the current state of an individual transfer"""
     # NOTE: Ideally the TransferState object would be used directly by the
     # various different abstractions in the ProcessPoolDownloader and remove
@@ -713,7 +713,7 @@ TransferMonitorManager.register('TransferMonitor', TransferMonitor)
 
 class BaseS3TransferProcess(multiprocessing.Process):
     def __init__(self, client_factory):
-        super(BaseS3TransferProcess, self).__init__()
+        super().__init__()
         self._client_factory = client_factory
         self._client = None
 
@@ -755,7 +755,7 @@ class GetObjectSubmitter(BaseS3TransferProcess):
         :param worker_queue: Queue to submit GetObjectJobs for workers
             to perform.
         """
-        super(GetObjectSubmitter, self).__init__(client_factory)
+        super().__init__(client_factory)
         self._transfer_config = transfer_config
         self._transfer_monitor = transfer_monitor
         self._osutil = osutil
@@ -873,7 +873,7 @@ class GetObjectWorker(BaseS3TransferProcess):
         :param osutil: OSUtils object to use for os-related behavior when
             performing the transfer.
         """
-        super(GetObjectWorker, self).__init__(client_factory)
+        super().__init__(client_factory)
         self._queue = queue
         self._client_factory = client_factory
         self._transfer_monitor = transfer_monitor

--- a/s3transfer/subscribers.py
+++ b/s3transfer/subscribers.py
@@ -10,13 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.compat import six
-
 from s3transfer.compat import accepts_kwargs
 from s3transfer.exceptions import InvalidSubscriberMethodError
 
 
-class BaseSubscriber(object):
+class BaseSubscriber:
     """The base subscriber class
 
     It is recommended that all subscriber implementations subclass and then
@@ -30,13 +28,13 @@ class BaseSubscriber(object):
 
     def __new__(cls, *args, **kwargs):
         cls._validate_subscriber_methods()
-        return super(BaseSubscriber, cls).__new__(cls)
+        return super().__new__(cls)
 
     @classmethod
     def _validate_subscriber_methods(cls):
         for subscriber_type in cls.VALID_SUBSCRIBER_TYPES:
             subscriber_method = getattr(cls, 'on_' + subscriber_type)
-            if not six.callable(subscriber_method):
+            if not callable(subscriber_method):
                 raise InvalidSubscriberMethodError(
                     'Subscriber method %s must be callable.' %
                     subscriber_method)

--- a/s3transfer/subscribers.py
+++ b/s3transfer/subscribers.py
@@ -20,11 +20,8 @@ class BaseSubscriber:
     It is recommended that all subscriber implementations subclass and then
     override the subscription methods (i.e. on_{subsribe_type}() methods).
     """
-    VALID_SUBSCRIBER_TYPES = [
-        'queued',
-        'progress',
-        'done'
-    ]
+
+    VALID_SUBSCRIBER_TYPES = ['queued', 'progress', 'done']
 
     def __new__(cls, *args, **kwargs):
         cls._validate_subscriber_methods()
@@ -36,13 +33,15 @@ class BaseSubscriber:
             subscriber_method = getattr(cls, 'on_' + subscriber_type)
             if not callable(subscriber_method):
                 raise InvalidSubscriberMethodError(
-                    'Subscriber method %s must be callable.' %
-                    subscriber_method)
+                    'Subscriber method %s must be callable.'
+                    % subscriber_method
+                )
 
             if not accepts_kwargs(subscriber_method):
                 raise InvalidSubscriberMethodError(
                     'Subscriber method %s must accept keyword '
-                    'arguments (**kwargs)' % subscriber_method)
+                    'arguments (**kwargs)' % subscriber_method
+                )
 
     def on_queued(self, future, **kwargs):
         """Callback to be invoked when transfer request gets queued

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -18,7 +18,7 @@ from s3transfer.utils import get_callbacks
 logger = logging.getLogger(__name__)
 
 
-class Task(object):
+class Task:
     """A task associated to a TransferFuture request
 
     This is a base class for other classes to subclass from. All subclassed
@@ -84,7 +84,7 @@ class Task(object):
         ]
         main_kwargs_to_display = self._get_kwargs_with_params_to_include(
             self._main_kwargs, params_to_display)
-        return '%s(transfer_id=%s, %s)' % (
+        return '{}(transfer_id={}, {})'.format(
             self.__class__.__name__, self._transfer_coordinator.transfer_id,
             main_kwargs_to_display)
 
@@ -143,7 +143,7 @@ class Task(object):
             kwargs, params_to_exclude)
         # Log what is about to be executed.
         logger.debug(
-            "Executing task %s with kwargs %s" % (self, kwargs_to_display)
+            f"Executing task {self} with kwargs {kwargs_to_display}"
         )
 
         return_value = self._main(**kwargs)

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -15,7 +15,6 @@ import logging
 
 from s3transfer.utils import get_callbacks
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -14,15 +14,20 @@ import math
 
 from botocore.compat import six
 
-from s3transfer.compat import seekable, readable
+from s3transfer.compat import readable, seekable
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
-from s3transfer.tasks import Task
-from s3transfer.tasks import SubmissionTask
-from s3transfer.tasks import CreateMultipartUploadTask
-from s3transfer.tasks import CompleteMultipartUploadTask
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import get_filtered_dict
-from s3transfer.utils import DeferredOpenFile, ChunksizeAdjuster
+from s3transfer.tasks import (
+    CompleteMultipartUploadTask,
+    CreateMultipartUploadTask,
+    SubmissionTask,
+    Task,
+)
+from s3transfer.utils import (
+    ChunksizeAdjuster,
+    DeferredOpenFile,
+    get_callbacks,
+    get_filtered_dict,
+)
 
 
 class AggregatedProgressCallback(object):

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -533,9 +533,7 @@ class ReadFileChunk:
     def seek(self, where, whence=0):
         if whence not in (0, 1, 2):
             # Mimic io's error for invalid whence values
-            raise ValueError(
-                "invalid whence (%s, should be 0, 1 or 2)" % whence
-            )
+            raise ValueError(f"invalid whence ({whence}, should be 0, 1 or 2)")
 
         # Recalculate where based on chunk attributes so seek from file
         # start (whence=0) is always used

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -84,7 +84,7 @@ def calculate_range_parameter(part_size, part_index, num_parts,
             end_range = str(total_size - 1)
     else:
         end_range = start_range + part_size - 1
-    range_param = 'bytes=%s-%s' % (start_range, end_range)
+    range_param = f'bytes={start_range}-{end_range}'
     return range_param
 
 
@@ -152,7 +152,7 @@ def get_filtered_dict(original_dict, whitelisted_keys):
     return filtered_dict
 
 
-class CallArgs(object):
+class CallArgs:
     def __init__(self, **kwargs):
         """A class that records call arguments
 
@@ -164,7 +164,7 @@ class CallArgs(object):
             setattr(self, arg, value)
 
 
-class FunctionContainer(object):
+class FunctionContainer:
     """An object that contains a function and any args or kwargs to call it
 
     When called the provided function will be called with provided args
@@ -176,14 +176,14 @@ class FunctionContainer(object):
         self._kwargs = kwargs
 
     def __repr__(self):
-        return 'Function: %s with args %s and kwargs %s' % (
+        return 'Function: {} with args {} and kwargs {}'.format(
             self._func, self._args, self._kwargs)
 
     def __call__(self):
         return self._func(*self._args, **self._kwargs)
 
 
-class CountCallbackInvoker(object):
+class CountCallbackInvoker:
     """An abstraction to invoke a callback when a shared count reaches zero
 
     :param callback: Callback invoke when finalized count reaches zero
@@ -231,7 +231,7 @@ class CountCallbackInvoker(object):
                 self._callback()
 
 
-class OSUtils(object):
+class OSUtils:
     _MAX_FILENAME_LEN = 255
 
     def get_file_size(self, filename):
@@ -305,12 +305,12 @@ class OSUtils(object):
         try:
             with self.open(filename, 'wb') as f:
                 fallocate(f, size)
-        except (OSError, IOError):
+        except OSError:
             self.remove_file(filename)
             raise
 
 
-class DeferredOpenFile(object):
+class DeferredOpenFile:
     def __init__(self, filename, start_byte=0, mode='rb', open_function=open):
         """A class that defers the opening of a file till needed
 
@@ -377,7 +377,7 @@ class DeferredOpenFile(object):
         self.close()
 
 
-class ReadFileChunk(object):
+class ReadFileChunk:
     def __init__(self, fileobj, chunk_size, full_file_size,
                  callbacks=None, enable_callbacks=True, close_callbacks=None):
         """
@@ -551,7 +551,7 @@ class ReadFileChunk(object):
         return iter([])
 
 
-class StreamReaderProgress(object):
+class StreamReaderProgress:
     """Wrapper for a read only stream that adds progress callbacks."""
     def __init__(self, stream, callbacks=None):
         self._stream = stream
@@ -569,7 +569,7 @@ class NoResourcesAvailable(Exception):
     pass
 
 
-class TaskSemaphore(object):
+class TaskSemaphore:
     def __init__(self, count):
         """A semaphore for the purpose of limiting the number of tasks
 
@@ -602,7 +602,7 @@ class TaskSemaphore(object):
             class but is needed for API compatibility with the
             SlidingWindowSemaphore implementation.
         """
-        logger.debug("Releasing acquire %s/%s" % (tag, acquire_token))
+        logger.debug(f"Releasing acquire {tag}/{acquire_token}")
         self._semaphore.release()
 
 
@@ -701,7 +701,7 @@ class SlidingWindowSemaphore(TaskSemaphore):
             self._condition.release()
 
 
-class ChunksizeAdjuster(object):
+class ChunksizeAdjuster:
     def __init__(self, max_size=MAX_SINGLE_UPLOAD_SIZE,
                  min_size=MIN_UPLOAD_CHUNKSIZE, max_parts=MAX_PARTS):
         self.max_size = max_size

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -10,24 +10,20 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import random
 import functools
+import logging
 import math
 import os
+import random
 import socket
 import stat
 import string
-import logging
 import threading
 from collections import defaultdict
 
-from botocore.exceptions import IncompleteReadError
-from botocore.exceptions import ReadTimeoutError
+from botocore.exceptions import IncompleteReadError, ReadTimeoutError
 
-from s3transfer.compat import SOCKET_ERROR
-from s3transfer.compat import rename_file
-from s3transfer.compat import fallocate
-
+from s3transfer.compat import SOCKET_ERROR, fallocate, rename_file
 
 MAX_PARTS = 10000
 # The maximum file size you can upload via S3 per request.

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -35,7 +35,10 @@ logger = logging.getLogger(__name__)
 
 
 S3_RETRYABLE_DOWNLOAD_ERRORS = (
-    socket.timeout, SOCKET_ERROR, ReadTimeoutError, IncompleteReadError
+    socket.timeout,
+    SOCKET_ERROR,
+    ReadTimeoutError,
+    IncompleteReadError,
 )
 
 
@@ -44,14 +47,16 @@ def random_file_extension(num_digits=8):
 
 
 def signal_not_transferring(request, operation_name, **kwargs):
-    if operation_name in ['PutObject', 'UploadPart'] and \
-            hasattr(request.body, 'signal_not_transferring'):
+    if operation_name in ['PutObject', 'UploadPart'] and hasattr(
+        request.body, 'signal_not_transferring'
+    ):
         request.body.signal_not_transferring()
 
 
 def signal_transferring(request, operation_name, **kwargs):
-    if operation_name in ['PutObject', 'UploadPart'] and \
-            hasattr(request.body, 'signal_transferring'):
+    if operation_name in ['PutObject', 'UploadPart'] and hasattr(
+        request.body, 'signal_transferring'
+    ):
         request.body.signal_transferring()
 
 
@@ -59,8 +64,9 @@ def calculate_num_parts(size, part_size):
     return int(math.ceil(size / float(part_size)))
 
 
-def calculate_range_parameter(part_size, part_index, num_parts,
-                              total_size=None):
+def calculate_range_parameter(
+    part_size, part_index, num_parts, total_size=None
+):
     """Calculate the range parameter for multipart downloads/copies
 
     :type part_size: int
@@ -111,8 +117,7 @@ def get_callbacks(transfer_future, callback_type):
         if hasattr(subscriber, callback_name):
             callbacks.append(
                 functools.partial(
-                    getattr(subscriber, callback_name),
-                    future=transfer_future
+                    getattr(subscriber, callback_name), future=transfer_future
                 )
             )
     return callbacks
@@ -170,6 +175,7 @@ class FunctionContainer:
     When called the provided function will be called with provided args
     and kwargs.
     """
+
     def __init__(self, func, *args, **kwargs):
         self._func = func
         self._args = args
@@ -177,7 +183,8 @@ class FunctionContainer:
 
     def __repr__(self):
         return 'Function: {} with args {} and kwargs {}'.format(
-            self._func, self._args, self._kwargs)
+            self._func, self._args, self._kwargs
+        )
 
     def __call__(self):
         return self._func(*self._args, **self._kwargs)
@@ -188,6 +195,7 @@ class CountCallbackInvoker:
 
     :param callback: Callback invoke when finalized count reaches zero
     """
+
     def __init__(self, callback):
         self._lock = threading.Lock()
         self._callback = callback
@@ -214,7 +222,8 @@ class CountCallbackInvoker:
         with self._lock:
             if self._count == 0:
                 raise RuntimeError(
-                    'Counter is at zero. It cannot dip below zero')
+                    'Counter is at zero. It cannot dip below zero'
+                )
             self._count -= 1
             if self._is_finalized and self._count == 0:
                 self._callback()
@@ -238,17 +247,26 @@ class OSUtils:
         return os.path.getsize(filename)
 
     def open_file_chunk_reader(self, filename, start_byte, size, callbacks):
-        return ReadFileChunk.from_filename(filename, start_byte,
-                                           size, callbacks,
-                                           enable_callbacks=False)
+        return ReadFileChunk.from_filename(
+            filename, start_byte, size, callbacks, enable_callbacks=False
+        )
 
-    def open_file_chunk_reader_from_fileobj(self, fileobj, chunk_size,
-                                            full_file_size, callbacks,
-                                            close_callbacks=None):
+    def open_file_chunk_reader_from_fileobj(
+        self,
+        fileobj,
+        chunk_size,
+        full_file_size,
+        callbacks,
+        close_callbacks=None,
+    ):
         return ReadFileChunk(
-            fileobj, chunk_size, full_file_size,
-            callbacks=callbacks, enable_callbacks=False,
-            close_callbacks=close_callbacks)
+            fileobj,
+            chunk_size,
+            full_file_size,
+            callbacks=callbacks,
+            enable_callbacks=False,
+            close_callbacks=close_callbacks,
+        )
 
     def open(self, filename, mode):
         return open(filename, mode)
@@ -298,7 +316,7 @@ class OSUtils:
         suffix = os.extsep + random_file_extension()
         path = os.path.dirname(filename)
         name = os.path.basename(filename)
-        temp_filename = name[:self._MAX_FILENAME_LEN - len(suffix)] + suffix
+        temp_filename = name[: self._MAX_FILENAME_LEN - len(suffix)] + suffix
         return os.path.join(path, temp_filename)
 
     def allocate(self, filename, size):
@@ -378,8 +396,15 @@ class DeferredOpenFile:
 
 
 class ReadFileChunk:
-    def __init__(self, fileobj, chunk_size, full_file_size,
-                 callbacks=None, enable_callbacks=True, close_callbacks=None):
+    def __init__(
+        self,
+        fileobj,
+        chunk_size,
+        full_file_size,
+        callbacks=None,
+        enable_callbacks=True,
+        close_callbacks=None,
+    ):
         """
 
         Given a file object shown below::
@@ -416,8 +441,11 @@ class ReadFileChunk:
         self._fileobj = fileobj
         self._start_byte = self._fileobj.tell()
         self._size = self._calculate_file_size(
-            self._fileobj, requested_size=chunk_size,
-            start_byte=self._start_byte, actual_file_size=full_file_size)
+            self._fileobj,
+            requested_size=chunk_size,
+            start_byte=self._start_byte,
+            actual_file_size=full_file_size,
+        )
         # _amount_read represents the position in the chunk and may exceed
         # the chunk size, but won't allow reads out of bounds.
         self._amount_read = 0
@@ -430,8 +458,14 @@ class ReadFileChunk:
             self._close_callbacks = close_callbacks
 
     @classmethod
-    def from_filename(cls, filename, start_byte, chunk_size, callbacks=None,
-                      enable_callbacks=True):
+    def from_filename(
+        cls,
+        filename,
+        start_byte,
+        chunk_size,
+        callbacks=None,
+        enable_callbacks=True,
+    ):
         """Convenience factory function to create from a filename.
 
         :type start_byte: int
@@ -462,8 +496,9 @@ class ReadFileChunk:
         file_size = os.fstat(f.fileno()).st_size
         return cls(f, chunk_size, file_size, callbacks, enable_callbacks)
 
-    def _calculate_file_size(self, fileobj, requested_size, start_byte,
-                             actual_file_size):
+    def _calculate_file_size(
+        self, fileobj, requested_size, start_byte, actual_file_size
+    ):
         max_chunk_size = actual_file_size - start_byte
         return min(max_chunk_size, requested_size)
 
@@ -499,7 +534,8 @@ class ReadFileChunk:
         if whence not in (0, 1, 2):
             # Mimic io's error for invalid whence values
             raise ValueError(
-                "invalid whence (%s, should be 0, 1 or 2)" % whence)
+                "invalid whence (%s, should be 0, 1 or 2)" % whence
+            )
 
         # Recalculate where based on chunk attributes so seek from file
         # start (whence=0) is always used
@@ -516,7 +552,8 @@ class ReadFileChunk:
             bounded_amount_read = min(self._amount_read, self._size)
             amount = bounded_where - bounded_amount_read
             invoke_progress_callbacks(
-                self._callbacks, bytes_transferred=amount)
+                self._callbacks, bytes_transferred=amount
+            )
         self._amount_read = max(where - self._start_byte, 0)
 
     def close(self):
@@ -553,6 +590,7 @@ class ReadFileChunk:
 
 class StreamReaderProgress:
     """Wrapper for a read only stream that adds progress callbacks."""
+
     def __init__(self, stream, callbacks=None):
         self._stream = stream
         self._callbacks = callbacks
@@ -628,6 +666,7 @@ class SlidingWindowSemaphore(TaskSemaphore):
     when the minimum sequence number for a tag is released.
 
     """
+
     def __init__(self, count):
         self._count = count
         # Dict[tag, next_sequence_number].
@@ -690,20 +729,26 @@ class SlidingWindowSemaphore(TaskSemaphore):
                 # We can't do anything right now because we're still waiting
                 # for the min sequence for the tag to be released.  We have
                 # to queue this for pending release.
-                self._pending_release.setdefault(
-                    tag, []).append(sequence_number)
+                self._pending_release.setdefault(tag, []).append(
+                    sequence_number
+                )
                 self._pending_release[tag].sort(reverse=True)
             else:
                 raise ValueError(
                     "Attempted to release unknown sequence number "
-                    "%s for tag: %s" % (sequence_number, tag))
+                    "%s for tag: %s" % (sequence_number, tag)
+                )
         finally:
             self._condition.release()
 
 
 class ChunksizeAdjuster:
-    def __init__(self, max_size=MAX_SINGLE_UPLOAD_SIZE,
-                 min_size=MIN_UPLOAD_CHUNKSIZE, max_parts=MAX_PARTS):
+    def __init__(
+        self,
+        max_size=MAX_SINGLE_UPLOAD_SIZE,
+        min_size=MIN_UPLOAD_CHUNKSIZE,
+        max_parts=MAX_PARTS,
+    ):
         self.max_size = max_size
         self.min_size = min_size
         self.max_parts = max_parts
@@ -729,12 +774,14 @@ class ChunksizeAdjuster:
         if current_chunksize > self.max_size:
             logger.debug(
                 "Chunksize greater than maximum chunksize. "
-                "Setting to %s from %s." % (self.max_size, current_chunksize))
+                "Setting to %s from %s." % (self.max_size, current_chunksize)
+            )
             return self.max_size
         elif current_chunksize < self.min_size:
             logger.debug(
                 "Chunksize less than minimum chunksize. "
-                "Setting to %s from %s." % (self.min_size, current_chunksize))
+                "Setting to %s from %s." % (self.min_size, current_chunksize)
+            )
             return self.min_size
         else:
             return current_chunksize
@@ -750,7 +797,8 @@ class ChunksizeAdjuster:
         if chunksize != current_chunksize:
             logger.debug(
                 "Chunksize would result in the number of parts exceeding the "
-                "maximum. Setting to %s from %s." %
-                (chunksize, current_chunksize))
+                "maximum. Setting to %s from %s."
+                % (chunksize, current_chunksize)
+            )
 
         return chunksize

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -41,5 +41,5 @@ if __name__ == "__main__":
         wheel_dist = os.listdir('dist')[0]
         package = os.path.join('dist', wheel_dist)
         if args.extras:
-            package = "'%s[%s]'" % (package, args.extras)
+            package = f"'{package}[{args.extras}]'"
         run('pip install %s' % package)

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -29,7 +29,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
-        '-e', '--extras', help='Install extras_require along with normal install'
+        '-e',
+        '--extras',
+        help='Install extras_require along with normal install',
     )
     args = parser.parse_args()
     with cd(REPO_ROOT):

--- a/scripts/new-change
+++ b/scripts/new-change
@@ -117,7 +117,7 @@ def get_values_from_editor(args):
         f.flush()
         env = os.environ
         editor = env.get('VISUAL', env.get('EDITOR', 'vim'))
-        p = subprocess.Popen('%s %s' % (editor, f.name), shell=True)
+        p = subprocess.Popen(f'{editor} {f.name}', shell=True)
         p.communicate()
         with open(f.name) as f:
             filled_in_contents = f.read()
@@ -131,7 +131,7 @@ def replace_issue_references(parsed, repo_name):
     def linkify(match):
         number = match.group()[1:]
         return (
-            '`%s <https://github.com/%s/issues/%s>`__' % (
+            '`{} <https://github.com/{}/issues/{}>`__'.format(
                 match.group(), repo_name, number))
 
     new_description = re.sub(r'#\d+', linkify, description)
@@ -153,10 +153,10 @@ def write_new_change(parsed_values):
         type_name=parsed_values['type'],
         summary=short_summary)
     possible_filename = os.path.join(
-        dirname, '%s-%s.json' % (filename, str(random.randint(1, 100000))))
+        dirname, f'{filename}-{str(random.randint(1, 100000))}.json')
     while os.path.isfile(possible_filename):
         possible_filename = os.path.join(
-            dirname, '%s-%s.json' % (filename, str(random.randint(1, 100000))))
+            dirname, f'{filename}-{str(random.randint(1, 100000))}.json')
     with open(possible_filename, 'w') as f:
         f.write(json.dumps(parsed_values, indent=2) + "\n")
 

--- a/scripts/new-change
+++ b/scripts/new-change
@@ -48,8 +48,7 @@ import tempfile
 
 VALID_CHARS = set(string.ascii_letters + string.digits)
 CHANGES_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    '.changes'
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.changes'
 )
 TEMPLATE = """\
 # Type should be one of: feature, bugfix, enhancement, api-change
@@ -89,7 +88,8 @@ def new_changelog_entry(args):
         parsed_values = get_values_from_editor(args)
     if has_empty_values(parsed_values):
         sys.stderr.write(
-            "Empty changelog values received, skipping entry creation.\n")
+            "Empty changelog values received, skipping entry creation.\n"
+        )
         return 1
     replace_issue_references(parsed_values, args.repo)
     write_new_change(parsed_values)
@@ -97,9 +97,11 @@ def new_changelog_entry(args):
 
 
 def has_empty_values(parsed_values):
-    return not (parsed_values.get('type') and
-                parsed_values.get('category') and
-                parsed_values.get('description'))
+    return not (
+        parsed_values.get('type')
+        and parsed_values.get('category')
+        and parsed_values.get('description')
+    )
 
 
 def all_values_provided(args):
@@ -130,9 +132,9 @@ def replace_issue_references(parsed, repo_name):
 
     def linkify(match):
         number = match.group()[1:]
-        return (
-            '`{} <https://github.com/{}/issues/{}>`__'.format(
-                match.group(), repo_name, number))
+        return '`{} <https://github.com/{}/issues/{}>`__'.format(
+            match.group(), repo_name, number
+        )
 
     new_description = re.sub(r'#\d+', linkify, description)
     parsed['description'] = new_description
@@ -150,13 +152,15 @@ def write_new_change(parsed_values):
     category = parsed_values['category']
     short_summary = ''.join(filter(lambda x: x in VALID_CHARS, category))
     filename = '{type_name}-{summary}'.format(
-        type_name=parsed_values['type'],
-        summary=short_summary)
+        type_name=parsed_values['type'], summary=short_summary
+    )
     possible_filename = os.path.join(
-        dirname, f'{filename}-{str(random.randint(1, 100000))}.json')
+        dirname, f'{filename}-{str(random.randint(1, 100000))}.json'
+    )
     while os.path.isfile(possible_filename):
         possible_filename = os.path.join(
-            dirname, f'{filename}-{str(random.randint(1, 100000))}.json')
+            dirname, f'{filename}-{str(random.randint(1, 100000))}.json'
+        )
     with open(possible_filename, 'w') as f:
         f.write(json.dumps(parsed_values, indent=2) + "\n")
 
@@ -197,15 +201,21 @@ def parse_filled_in_contents(contents):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-t', '--type', dest='change_type',
-                        default='', choices=('bugfix', 'feature',
-                                             'enhancement', 'api-change'))
-    parser.add_argument('-c', '--category', dest='category',
-                        default='')
-    parser.add_argument('-d', '--description', dest='description',
-                        default='')
-    parser.add_argument('-r', '--repo', default='boto/boto3',
-                        help='Optional repo name, e.g: boto/boto3')
+    parser.add_argument(
+        '-t',
+        '--type',
+        dest='change_type',
+        default='',
+        choices=('bugfix', 'feature', 'enhancement', 'api-change'),
+    )
+    parser.add_argument('-c', '--category', dest='category', default='')
+    parser.add_argument('-d', '--description', dest='description', default='')
+    parser.add_argument(
+        '-r',
+        '--repo',
+        default='boto/boto3',
+        help='Optional repo name, e.g: boto/boto3',
+    )
     args = parser.parse_args()
     sys.exit(new_changelog_entry(args))
 

--- a/scripts/new-change
+++ b/scripts/new-change
@@ -36,16 +36,15 @@ You can then use the ``scripts/gen-changelog`` to generate the
 CHANGELOG.rst file.
 
 """
-import os
-import re
-import sys
-import json
-import string
-import random
-import tempfile
-import subprocess
 import argparse
-
+import json
+import os
+import random
+import re
+import string
+import subprocess
+import sys
+import tempfile
 
 VALID_CHARS = set(string.ascii_letters + string.digits)
 CHANGES_DIR = os.path.join(

--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -96,9 +96,19 @@ def run_benchmark(pid, output_file, data_interval):
             recv_rate = recv_delta / dt
 
             # Save all of the data into a CSV file.
-            f.write(','.join(str(val) for val in [
-                current_time, memory_used, cpu_percent, sent_rate,
-                recv_rate]) + '\n')
+            f.write(
+                ','.join(
+                    str(val)
+                    for val in [
+                        current_time,
+                        memory_used,
+                        cpu_percent,
+                        sent_rate,
+                        recv_rate,
+                    ]
+                )
+                + '\n'
+            )
             f.flush()
     return 0
 
@@ -116,14 +126,18 @@ def _get_underlying_python_process(process):
 
 def main():
     parser = argparse.ArgumentParser(usage=__doc__)
+    parser.add_argument('script', help='The script to run for benchmarking')
     parser.add_argument(
-        'script', help='The script to run for benchmarking')
+        '--data-interval',
+        default=1,
+        type=float,
+        help='The interval in seconds to poll for data points',
+    )
     parser.add_argument(
-        '--data-interval', default=1, type=float,
-        help='The interval in seconds to poll for data points')
-    parser.add_argument(
-        '--output-file', default='performance.csv',
-        help='The file to output the data collected to')
+        '--output-file',
+        default='performance.csv',
+        help='The file to output the data collected to',
+    )
     args = parser.parse_args()
     return benchmark(args)
 

--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -20,12 +20,11 @@ If no ``--output-file`` was provided, the data will be saved to
 """
 import argparse
 import os
-import sys
 import subprocess
+import sys
 import time
 
 import psutil
-
 
 # Determine the interface to track network IO depending on the platform.
 if sys.platform.startswith('linux'):

--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -97,17 +97,8 @@ def run_benchmark(pid, output_file, data_interval):
 
             # Save all of the data into a CSV file.
             f.write(
-                ','.join(
-                    str(val)
-                    for val in [
-                        current_time,
-                        memory_used,
-                        cpu_percent,
-                        sent_rate,
-                        recv_rate,
-                    ]
-                )
-                + '\n'
+                f"{current_time},{memory_used},{cpu_percent},"
+                f"{sent_rate},{recv_rate}\n"
             )
             f.flush()
     return 0

--- a/scripts/performance/benchmark-download
+++ b/scripts/performance/benchmark-download
@@ -21,13 +21,13 @@ To benchmark with your own s3 key:
 """
 import argparse
 import os
-import tempfile
 import shutil
 import subprocess
+import tempfile
 
 from botocore.session import get_session
-from s3transfer.manager import TransferManager
 
+from s3transfer.manager import TransferManager
 
 TEMP_FILE = 'temp'
 TEMP_KEY = 'temp'

--- a/scripts/performance/benchmark-download
+++ b/scripts/performance/benchmark-download
@@ -57,8 +57,7 @@ def human_readable_to_bytes(value):
         suffix = value[-3:].lower()
     else:
         suffix = value[-2:].lower()
-    has_size_identifier = (
-        len(value) >= 2 and suffix in SIZE_SUFFIX)
+    has_size_identifier = len(value) >= 2 and suffix in SIZE_SUFFIX
     if not has_size_identifier:
         try:
             return int(value)
@@ -66,7 +65,7 @@ def human_readable_to_bytes(value):
             raise ValueError("Invalid size value: %s" % value)
     else:
         multiplier = SIZE_SUFFIX[suffix]
-        return int(value[:-len(suffix)]) * multiplier
+        return int(value[: -len(suffix)]) * multiplier
 
 
 def create_file(filename, file_size):
@@ -81,8 +80,7 @@ def benchmark_download(args):
     temp_file = os.path.join(tempdir, TEMP_FILE)
 
     if args.target_download:
-        temp_file = os.path.abspath(
-            os.path.expanduser(args.target_download))
+        temp_file = os.path.abspath(os.path.expanduser(args.target_download))
     session = get_session()
     client = session.create_client('s3')
     s3_key = args.existing_s3_key
@@ -99,8 +97,7 @@ def benchmark_download(args):
 
         download_file_script = (
             './download-file --file-name %s --file-type %s --s3-bucket %s '
-            '--s3-key %s' % (
-                temp_file, args.file_type, args.s3_bucket, s3_key)
+            '--s3-key %s' % (temp_file, args.file_type, args.s3_bucket, s3_key)
         )
         benchmark_args = ['./benchmark', download_file_script]
         if args.output_file:
@@ -121,39 +118,45 @@ def main():
     parser = argparse.ArgumentParser()
     file_group = parser.add_mutually_exclusive_group(required=True)
     file_group.add_argument(
-        '--file-size', type=human_readable_to_bytes,
+        '--file-size',
+        type=human_readable_to_bytes,
         help=(
             'The size of the temporary file to create and then upload to s3. '
             'You can also specify your own key with --existing-s3-key to '
             'avoid going through this setup step.'
-        )
+        ),
     )
     parser.add_argument(
-        '--file-type', choices=['filename', 'seekable', 'nonseekable'],
-        required=True, help='The way to represent the file when downloading')
+        '--file-type',
+        choices=['filename', 'seekable', 'nonseekable'],
+        required=True,
+        help='The way to represent the file when downloading',
+    )
     parser.add_argument(
-        '--s3-bucket', required=True,
-        help='The S3 bucket to download the file to')
+        '--s3-bucket',
+        required=True,
+        help='The S3 bucket to download the file to',
+    )
     file_group.add_argument(
         '--existing-s3-key',
         help=(
             'The existing s3 key to download from. You can also use '
             '--file-size to create a temporary file and key to download from.'
-        )
+        ),
     )
     parser.add_argument(
         '--target-download',
         help=(
             'The filename to download to. Note that this file will '
             'always be cleaned up for you.'
-        )
+        ),
     )
     parser.add_argument(
         '--output-file',
         help=(
             'The file to output the data collected to. The default '
             'location performance.csv'
-        )
+        ),
     )
     args = parser.parse_args()
     benchmark_download(args)

--- a/scripts/performance/benchmark-upload
+++ b/scripts/performance/benchmark-upload
@@ -21,12 +21,11 @@ To benchmark with your own local file::
 """
 import argparse
 import os
-import tempfile
 import shutil
 import subprocess
+import tempfile
 
 from botocore.session import get_session
-
 
 TEMP_FILE = 'temp'
 TEMP_KEY = 'temp'

--- a/scripts/performance/benchmark-upload
+++ b/scripts/performance/benchmark-upload
@@ -55,8 +55,7 @@ def human_readable_to_bytes(value):
         suffix = value[-3:].lower()
     else:
         suffix = value[-2:].lower()
-    has_size_identifier = (
-        len(value) >= 2 and suffix in SIZE_SUFFIX)
+    has_size_identifier = len(value) >= 2 and suffix in SIZE_SUFFIX
     if not has_size_identifier:
         try:
             return int(value)
@@ -64,7 +63,7 @@ def human_readable_to_bytes(value):
             raise ValueError("Invalid size value: %s" % value)
     else:
         multiplier = SIZE_SUFFIX[suffix]
-        return int(value[:-len(suffix)]) * multiplier
+        return int(value[: -len(suffix)]) * multiplier
 
 
 def create_file(filename, file_size):
@@ -88,8 +87,8 @@ def benchmark_upload(args):
 
         upload_file_script = (
             './upload-file --file-name %s --file-type %s --s3-bucket %s '
-            '--s3-key %s' % (
-                source_file, args.file_type, args.s3_bucket, TEMP_KEY)
+            '--s3-key %s'
+            % (source_file, args.file_type, args.s3_bucket, TEMP_KEY)
         )
         benchmark_args = ['./benchmark', upload_file_script]
         if args.output_file:
@@ -109,27 +108,33 @@ def main():
         help=(
             'The local file to upload. Note this is optional. You can also '
             'use --file-size which will create a temporary file for you.'
-        )
+        ),
     )
     source_file_group.add_argument(
-        '--file-size', type=human_readable_to_bytes,
+        '--file-size',
+        type=human_readable_to_bytes,
         help=(
             'The size of the temporary file to create. You can also specify '
             'your own file with --source-file'
-        )
+        ),
     )
     parser.add_argument(
-        '--file-type', choices=['filename', 'seekable', 'nonseekable'],
-        required=True, help='The way to represent the file when uploading')
+        '--file-type',
+        choices=['filename', 'seekable', 'nonseekable'],
+        required=True,
+        help='The way to represent the file when uploading',
+    )
     parser.add_argument(
-        '--s3-bucket', required=True,
-        help='The S3 bucket to upload the file to')
+        '--s3-bucket',
+        required=True,
+        help='The S3 bucket to upload the file to',
+    )
     parser.add_argument(
         '--output-file',
         help=(
             'The file to output the data collected to. The default '
             'location performance.csv'
-        )
+        ),
     )
     args = parser.parse_args()
     benchmark_upload(args)

--- a/scripts/performance/download-file
+++ b/scripts/performance/download-file
@@ -21,7 +21,7 @@ from botocore.session import get_session
 from s3transfer.manager import TransferManager
 
 
-class NonSeekableWriter(object):
+class NonSeekableWriter:
     """A wrapper to hide the ability to seek for a fileobj"""
     def __init__(self, fileobj):
         self._fileobj = fileobj
@@ -30,7 +30,7 @@ class NonSeekableWriter(object):
         return self._fileobj.write(b)
 
 
-class Downloader(object):
+class Downloader:
     def download(self, args):
         session = get_session()
         client = session.create_client('s3')

--- a/scripts/performance/download-file
+++ b/scripts/performance/download-file
@@ -23,6 +23,7 @@ from s3transfer.manager import TransferManager
 
 class NonSeekableWriter:
     """A wrapper to hide the ability to seek for a fileobj"""
+
     def __init__(self, fileobj):
         self._fileobj = fileobj
 
@@ -39,7 +40,8 @@ class Downloader:
             session.set_debug_logger('')
         with TransferManager(client) as manager:
             getattr(self, 'download_' + file_type)(
-                manager, args.file_name, args.s3_bucket, args.s3_key)
+                manager, args.file_name, args.s3_bucket, args.s3_key
+            )
 
     def download_filename(self, manager, filename, bucket, s3_key):
         manager.download(bucket, s3_key, filename)
@@ -51,8 +53,7 @@ class Downloader:
 
     def download_nonseekable(self, manager, filename, bucket, s3_key):
         with open(filename, 'wb') as f:
-            future = manager.download(
-                bucket, s3_key, NonSeekableWriter(f))
+            future = manager.download(bucket, s3_key, NonSeekableWriter(f))
             future.result()
 
 
@@ -60,16 +61,24 @@ def main():
     parser = argparse.ArgumentParser(usage=__doc__)
     parser.add_argument('--file-name', required=True, help='The name of file')
     parser.add_argument(
-        '--file-type', choices=['filename', 'seekable', 'nonseekable'],
-        required=True, help='The way to represent the file when downloading')
+        '--file-type',
+        choices=['filename', 'seekable', 'nonseekable'],
+        required=True,
+        help='The way to represent the file when downloading',
+    )
     parser.add_argument(
-        '--s3-bucket', required=True,
-        help='The S3 bucket to download the file to')
+        '--s3-bucket',
+        required=True,
+        help='The S3 bucket to download the file to',
+    )
     parser.add_argument(
-        '--s3-key', required=True, help='The key to download to')
+        '--s3-key', required=True, help='The key to download to'
+    )
     parser.add_argument(
-        '--debug', action='store_true',
-        help='Whether to turn debugging on. This will get printed to stderr')
+        '--debug',
+        action='store_true',
+        help='Whether to turn debugging on. This will get printed to stderr',
+    )
     args = parser.parse_args()
     Downloader().download(args)
 

--- a/scripts/performance/download-file
+++ b/scripts/performance/download-file
@@ -17,6 +17,7 @@ To download a file::
 import argparse
 
 from botocore.session import get_session
+
 from s3transfer.manager import TransferManager
 
 

--- a/scripts/performance/processpool-download
+++ b/scripts/performance/processpool-download
@@ -29,18 +29,19 @@ MB = 1024 * 1024
 def download(bucket, key, filename, num_processes, mb_chunksize):
     config = ProcessTransferConfig(
         multipart_chunksize=mb_chunksize * MB,
-        max_request_processes=num_processes
+        max_request_processes=num_processes,
     )
     with ProcessPoolDownloader(config=config) as downloader:
         future = downloader.download_file(
-            bucket=bucket, key=key, filename=filename)
+            bucket=bucket, key=key, filename=filename
+        )
         future.result()
 
 
 def recursive_download(bucket, prefix, dirname, num_processes, mb_chunksize):
     config = ProcessTransferConfig(
         multipart_chunksize=mb_chunksize * MB,
-        max_request_processes=num_processes
+        max_request_processes=num_processes,
     )
     s3 = botocore.session.get_session().create_client('s3')
     with ProcessPoolDownloader(config=config) as downloader:
@@ -49,7 +50,7 @@ def recursive_download(bucket, prefix, dirname, num_processes, mb_chunksize):
             contents = response.get('Contents', [])
             for content in contents:
                 key = content['Key']
-                filename = os.path.join(dirname, key[len(prefix):])
+                filename = os.path.join(dirname, key[len(prefix) :])
                 parent_dirname = os.path.dirname(filename)
                 if not os.path.exists(parent_dirname):
                     os.makedirs(parent_dirname)
@@ -57,41 +58,64 @@ def recursive_download(bucket, prefix, dirname, num_processes, mb_chunksize):
                 # does not need to be made for each of these objects that
                 # get downloaded.
                 downloader.download_file(
-                    bucket, key, filename=filename,
-                    expected_size=content['Size'])
+                    bucket,
+                    key,
+                    filename=filename,
+                    expected_size=content['Size'],
+                )
 
 
 def main():
     parser = argparse.ArgumentParser(usage=__doc__)
-    parser.add_argument('-b', '--bucket', required=True,
-                        help='The S3 bucket to download from')
+    parser.add_argument(
+        '-b', '--bucket', required=True, help='The S3 bucket to download from'
+    )
     single_file_group = parser.add_argument_group('Single file downloads')
-    single_file_group.add_argument('-k', '--key',
-                                   help='The key to download from')
-    single_file_group.add_argument('-f', '--filename',
-                                   help='The name of file to download to')
+    single_file_group.add_argument(
+        '-k', '--key', help='The key to download from'
+    )
+    single_file_group.add_argument(
+        '-f', '--filename', help='The name of file to download to'
+    )
     recursive_file_group = parser.add_argument_group(
-        'Recursive file downloads')
-    recursive_file_group.add_argument('-p', '--prefix',
-                                      help='The prefix to download from')
-    recursive_file_group.add_argument('-d', '--dirname',
-                                      help='The directory to download to')
+        'Recursive file downloads'
+    )
+    recursive_file_group.add_argument(
+        '-p', '--prefix', help='The prefix to download from'
+    )
+    recursive_file_group.add_argument(
+        '-d', '--dirname', help='The directory to download to'
+    )
     parser.add_argument(
-        '-n', '--num-processes', type=int, default=10,
-        help='The number of processes to run the download. 10 by default.')
+        '-n',
+        '--num-processes',
+        type=int,
+        default=10,
+        help='The number of processes to run the download. 10 by default.',
+    )
     parser.add_argument(
-        '-c', '--mb-chunksize', type=int, default=8,
-        help='The part size in MB to use for the download. 8 MB by default.')
+        '-c',
+        '--mb-chunksize',
+        type=int,
+        default=8,
+        help='The part size in MB to use for the download. 8 MB by default.',
+    )
     args = parser.parse_args()
     if args.filename and args.key:
         download(
-            args.bucket, args.key, args.filename, args.num_processes,
-            args.mb_chunksize
+            args.bucket,
+            args.key,
+            args.filename,
+            args.num_processes,
+            args.mb_chunksize,
         )
     elif args.prefix and args.dirname:
         recursive_download(
-            args.bucket, args.prefix, args.dirname, args.num_processes,
-            args.mb_chunksize
+            args.bucket,
+            args.prefix,
+            args.dirname,
+            args.num_processes,
+            args.mb_chunksize,
         )
     else:
         raise ValueError(

--- a/scripts/performance/processpool-download
+++ b/scripts/performance/processpool-download
@@ -20,7 +20,8 @@ import argparse
 import os
 
 import botocore.session
-from s3transfer.processpool import ProcessTransferConfig, ProcessPoolDownloader
+
+from s3transfer.processpool import ProcessPoolDownloader, ProcessTransferConfig
 
 MB = 1024 * 1024
 

--- a/scripts/performance/summarize
+++ b/scripts/performance/summarize
@@ -85,10 +85,10 @@ def human_readable_size(value):
     for i, suffix in enumerate(hummanize_suffixes):
         unit = base ** (i+2)
         if round((bytes_int / unit) * base) < base:
-            return '%.1f %s' % ((base * bytes_int / unit), suffix)
+            return f'{(base * bytes_int / unit):.1f} {suffix}'
 
 
-class Summarizer(object):
+class Summarizer:
     DATA_INDEX_IN_ROW = {
         'time': 0,
         'memory': 1,
@@ -216,7 +216,7 @@ class Summarizer(object):
             self.total_files += 1
 
     def process_individual_file(self, benchmark_file):
-        with open(benchmark_file, 'r') as f:
+        with open(benchmark_file) as f:
             reader = csv.reader(f)
             # Process each row from the CSV file
             row = None

--- a/scripts/performance/summarize
+++ b/scripts/performance/summarize
@@ -83,17 +83,13 @@ def human_readable_size(value):
         return '%d Bytes' % bytes_int
 
     for i, suffix in enumerate(hummanize_suffixes):
-        unit = base ** (i+2)
+        unit = base ** (i + 2)
         if round((bytes_int / unit) * base) < base:
             return f'{(base * bytes_int / unit):.1f} {suffix}'
 
 
 class Summarizer:
-    DATA_INDEX_IN_ROW = {
-        'time': 0,
-        'memory': 1,
-        'cpu': 2
-    }
+    DATA_INDEX_IN_ROW = {'time': 0, 'memory': 1, 'cpu': 2}
 
     def __init__(self):
         self.total_files = 0
@@ -110,12 +106,8 @@ class Summarizer:
         self._averages = {
             'memory': 0.0,
             'cpu': 0.0,
-
         }
-        self._maximums = {
-            'memory': 0.0,
-            'cpu': 0.0
-        }
+        self._maximums = {'memory': 0.0, 'cpu': 0.0}
 
     @property
     def total_time(self):
@@ -158,13 +150,13 @@ class Summarizer:
         return self._standard_deviation_across_all_files('average_memory')
 
     def _average_across_all_files(self, name):
-        return sum(self._totals[name])/len(self._totals[name])
+        return sum(self._totals[name]) / len(self._totals[name])
 
     def _standard_deviation_across_all_files(self, name):
         mean = self._average_across_all_files(name)
         differences = [total - mean for total in self._totals[name]]
         sq_differences = [difference ** 2 for difference in differences]
-        return sqrt(sum(sq_differences)/len(self._totals[name]))
+        return sqrt(sum(sq_differences) / len(self._totals[name]))
 
     def summarize_as_table(self):
         """Formats the processed data as pretty printed table.
@@ -173,24 +165,36 @@ class Summarizer:
         """
         h = human_readable_size
         table = [
-            ['Total Time (seconds)', '%.3f' % self.total_time,
-             self.std_dev_total_time],
+            [
+                'Total Time (seconds)',
+                '%.3f' % self.total_time,
+                self.std_dev_total_time,
+            ],
             ['Maximum Memory', h(self.max_memory), h(self.std_dev_max_memory)],
-            ['Maximum CPU (percent)', '%.1f' % self.max_cpu,
-             self.std_dev_max_cpu],
-            ['Average Memory', h(self.average_memory),
-             h(self.std_dev_average_memory)],
-            ['Average CPU (percent)', '%.1f' % self.average_cpu,
-             self.std_dev_average_cpu],
+            [
+                'Maximum CPU (percent)',
+                '%.1f' % self.max_cpu,
+                self.std_dev_max_cpu,
+            ],
+            [
+                'Average Memory',
+                h(self.average_memory),
+                h(self.std_dev_average_memory),
+            ],
+            [
+                'Average CPU (percent)',
+                '%.1f' % self.average_cpu,
+                self.std_dev_average_cpu,
+            ],
         ]
         return tabulate(
             table,
             headers=[
                 'Metric over %s run(s)' % (self.total_files),
                 'Mean',
-                'Standard Deviation'
+                'Standard Deviation',
             ],
-            tablefmt="grid"
+            tablefmt="grid",
         )
 
     def summarize_as_json(self):
@@ -198,16 +202,19 @@ class Summarizer:
 
         :return: str of formatted JSON
         """
-        return json.dumps({
-            'total_time': self.total_time,
-            'std_dev_total_time': self.std_dev_total_time,
-            'max_memory': self.max_memory,
-            'std_dev_max_memory': self.std_dev_max_memory,
-            'average_memory': self.average_memory,
-            'std_dev_average_memory': self.std_dev_average_memory,
-            'average_cpu': self.average_cpu,
-            'std_dev_average_cpu': self.std_dev_average_cpu,
-        }, indent=2)
+        return json.dumps(
+            {
+                'total_time': self.total_time,
+                'std_dev_total_time': self.std_dev_total_time,
+                'max_memory': self.max_memory,
+                'std_dev_max_memory': self.std_dev_max_memory,
+                'average_memory': self.average_memory,
+                'std_dev_average_memory': self.std_dev_average_memory,
+                'average_cpu': self.average_cpu,
+                'std_dev_average_cpu': self.std_dev_average_cpu,
+            },
+            indent=2,
+        )
 
     def process(self, args):
         """Processes the data from the CSV file"""
@@ -231,7 +238,8 @@ class Summarizer:
         if not row:
             raise RuntimeError(
                 'Row: %s could not be processed. The CSV file (%s) may be '
-                'empty.' % (row, filename))
+                'empty.' % (row, filename)
+            )
 
     def process_data_row(self, row):
         # If the row is the first row collect the start time.
@@ -256,9 +264,11 @@ class Summarizer:
         self._totals['max_cpu'].append(self._maximums['cpu'])
         self._totals['max_memory'].append(self._maximums['memory'])
         self._totals['average_cpu'].append(
-            self._averages['cpu']/self._num_rows)
+            self._averages['cpu'] / self._num_rows
+        )
         self._totals['average_memory'].append(
-            self._averages['memory']/self._num_rows)
+            self._averages['memory'] / self._num_rows
+        )
 
         # Reset some of the data needed to be tracked for each specific
         # file.
@@ -280,20 +290,24 @@ class Summarizer:
 def main():
     parser = argparse.ArgumentParser(usage=__doc__)
     parser.add_argument(
-        'benchmark_files', nargs='+',
+        'benchmark_files',
+        nargs='+',
         help=(
             'The CSV output file from the benchmark script. If you provide'
             'more than one of these files, it will give you the average '
             'across all of the files for each metric.'
-        )
+        ),
     )
     parser.add_argument(
-        '-f', '--output-format', default='table', choices=['table', 'json'],
+        '-f',
+        '--output-format',
+        default='table',
+        choices=['table', 'json'],
         help=(
             'Specify what output format to use for displaying results. '
             'By default, a pretty printed table is used, but you can also '
             'specify "json" to display pretty printed JSON.'
-        )
+        ),
     )
     args = parser.parse_args()
     summarizer = Summarizer()

--- a/scripts/performance/upload-file
+++ b/scripts/performance/upload-file
@@ -21,7 +21,7 @@ from botocore.session import get_session
 from s3transfer.manager import TransferManager
 
 
-class NonSeekableReader(object):
+class NonSeekableReader:
     """A wrapper to hide the ability to seek for a fileobj"""
     def __init__(self, fileobj):
         self._fileobj = fileobj
@@ -30,7 +30,7 @@ class NonSeekableReader(object):
         return self._fileobj.read(amt)
 
 
-class Uploader(object):
+class Uploader:
     def upload(self, args):
         session = get_session()
         client = session.create_client('s3')

--- a/scripts/performance/upload-file
+++ b/scripts/performance/upload-file
@@ -23,6 +23,7 @@ from s3transfer.manager import TransferManager
 
 class NonSeekableReader:
     """A wrapper to hide the ability to seek for a fileobj"""
+
     def __init__(self, fileobj):
         self._fileobj = fileobj
 
@@ -39,7 +40,8 @@ class Uploader:
             session.set_debug_logger('')
         with TransferManager(client) as manager:
             getattr(self, 'upload_' + file_type)(
-                manager, args.file_name, args.s3_bucket, args.s3_key)
+                manager, args.file_name, args.s3_bucket, args.s3_key
+            )
 
     def upload_filename(self, manager, filename, bucket, s3_key):
         manager.upload(filename, bucket, s3_key)
@@ -51,8 +53,7 @@ class Uploader:
 
     def upload_nonseekable(self, manager, filename, bucket, s3_key):
         with open(filename, 'rb') as f:
-            future = manager.upload(
-                NonSeekableReader(f), bucket, s3_key)
+            future = manager.upload(NonSeekableReader(f), bucket, s3_key)
             future.result()
 
 
@@ -60,15 +61,22 @@ def main():
     parser = argparse.ArgumentParser(usage=__doc__)
     parser.add_argument('--file-name', required=True, help='The name of file')
     parser.add_argument(
-        '--file-type', choices=['filename', 'seekable', 'nonseekable'],
-        required=True, help='The way to represent the file when uploading')
+        '--file-type',
+        choices=['filename', 'seekable', 'nonseekable'],
+        required=True,
+        help='The way to represent the file when uploading',
+    )
     parser.add_argument(
-        '--s3-bucket', required=True,
-        help='The S3 bucket to upload the file to')
+        '--s3-bucket',
+        required=True,
+        help='The S3 bucket to upload the file to',
+    )
     parser.add_argument('--s3-key', required=True, help='The key to upload to')
     parser.add_argument(
-        '--debug', action='store_true',
-        help='Whether to turn debugging on. This will get printed to stderr')
+        '--debug',
+        action='store_true',
+        help='Whether to turn debugging on. This will get printed to stderr',
+    )
     args = parser.parse_args()
     Uploader().upload(args)
 

--- a/scripts/performance/upload-file
+++ b/scripts/performance/upload-file
@@ -17,6 +17,7 @@ To upload a file::
 import argparse
 
 from botocore.session import get_session
+
 from s3transfer.manager import TransferManager
 
 

--- a/scripts/stress/timeout
+++ b/scripts/stress/timeout
@@ -67,14 +67,15 @@ def run_script(args):
 
 def main():
     parser = argparse.ArgumentParser(usage=__doc__)
+    parser.add_argument('script', help='The script to run for benchmarking')
     parser.add_argument(
-        'script', help='The script to run for benchmarking')
-    parser.add_argument(
-        '--timeout-after', required=True, type=float,
+        '--timeout-after',
+        required=True,
+        type=float,
         help=(
             'The length of time in seconds allowed for the script to run '
             'before it time\'s out.'
-        )
+        ),
     )
     args = parser.parse_args()
     return timeout(args)

--- a/scripts/stress/timeout
+++ b/scripts/stress/timeout
@@ -15,8 +15,8 @@ To use the script, run::
 """
 import argparse
 import os
-import sys
 import subprocess
+import sys
 import time
 
 import psutil

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@
 import os
 import re
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 ROOT = os.path.dirname(__file__)
 VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,8 +10,8 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import io
 import hashlib
+import io
 import math
 import os
 import platform
@@ -22,23 +22,26 @@ import unittest
 from unittest import mock  # noqa: F401
 
 import botocore.session
-from botocore.stub import Stubber
 from botocore.compat import six
+from botocore.stub import Stubber
 
+from s3transfer.futures import (
+    IN_MEMORY_DOWNLOAD_TAG,
+    IN_MEMORY_UPLOAD_TAG,
+    BoundedExecutor,
+    NonThreadedExecutor,
+    TransferCoordinator,
+    TransferFuture,
+    TransferMeta,
+)
 from s3transfer.manager import TransferConfig
-from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
-from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
-from s3transfer.futures import TransferCoordinator
-from s3transfer.futures import TransferMeta
-from s3transfer.futures import TransferFuture
-from s3transfer.futures import BoundedExecutor
-from s3transfer.futures import NonThreadedExecutor
 from s3transfer.subscribers import BaseSubscriber
-from s3transfer.utils import OSUtils
-from s3transfer.utils import CallArgs
-from s3transfer.utils import TaskSemaphore
-from s3transfer.utils import SlidingWindowSemaphore
-
+from s3transfer.utils import (
+    CallArgs,
+    OSUtils,
+    SlidingWindowSemaphore,
+    TaskSemaphore,
+)
 
 ORIGINAL_EXECUTOR_CLS = BoundedExecutor.EXECUTOR_CLS
 # Detect if CRT is available for use

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,6 @@ import unittest
 from unittest import mock  # noqa: F401
 
 import botocore.session
-from botocore.compat import six
 from botocore.stub import Stubber
 
 from s3transfer.futures import (
@@ -67,12 +66,12 @@ def is_serial_implementation():
 
 def assert_files_equal(first, second):
     if os.path.getsize(first) != os.path.getsize(second):
-        raise AssertionError("Files are not equal: %s, %s" % (first, second))
+        raise AssertionError(f"Files are not equal: {first}, {second}")
     first_md5 = md5_checksum(first)
     second_md5 = md5_checksum(second)
     if first_md5 != second_md5:
         raise AssertionError(
-            "Files are not equal: %s(md5=%s) != %s(md5=%s)" % (
+            "Files are not equal: {}(md5={}) != {}(md5={})".format(
                 first, first_md5, second, second_md5))
 
 
@@ -120,7 +119,7 @@ def requires_crt(cls, reason=None):
     return unittest.skipIf(not HAS_CRT, reason)(cls)
 
 
-class StreamWithError(object):
+class StreamWithError:
     """A wrapper to simulate errors while reading from a stream
 
     :param stream: The underlying stream to read from
@@ -143,7 +142,7 @@ class StreamWithError(object):
         return self._stream.read(n)
 
 
-class FileSizeProvider(object):
+class FileSizeProvider:
     def __init__(self, file_size):
         self.file_size = file_size
 
@@ -151,7 +150,7 @@ class FileSizeProvider(object):
         future.meta.provide_transfer_size(self.file_size)
 
 
-class FileCreator(object):
+class FileCreator:
     def __init__(self):
         self.rootdir = tempfile.mkdtemp()
 
@@ -205,17 +204,17 @@ class RecordingOSUtils(OSUtils):
     """An OSUtil abstraction that records openings and renamings"""
 
     def __init__(self):
-        super(RecordingOSUtils, self).__init__()
+        super().__init__()
         self.open_records = []
         self.rename_records = []
 
     def open(self, filename, mode):
         self.open_records.append((filename, mode))
-        return super(RecordingOSUtils, self).open(filename, mode)
+        return super().open(filename, mode)
 
     def rename_file(self, current_filename, new_filename):
         self.rename_records.append((current_filename, new_filename))
-        super(RecordingOSUtils, self).rename_file(
+        super().rename_file(
             current_filename, new_filename)
 
 
@@ -248,7 +247,7 @@ class TransferCoordinatorWithInterrupt(TransferCoordinator):
         raise KeyboardInterrupt()
 
 
-class RecordingExecutor(object):
+class RecordingExecutor:
     """A wrapper on an executor to record calls made to submit()
 
     You can access the submissions property to receive a list of dictionaries
@@ -308,7 +307,7 @@ class StubbedClientTest(unittest.TestCase):
 
 class BaseTaskTest(StubbedClientTest):
     def setUp(self):
-        super(BaseTaskTest, self).setUp()
+        super().setUp()
         self.transfer_coordinator = TransferCoordinator()
 
     def get_task(self, task_cls, **kwargs):
@@ -325,7 +324,7 @@ class BaseTaskTest(StubbedClientTest):
 
 class BaseSubmissionTaskTest(BaseTaskTest):
     def setUp(self):
-        super(BaseSubmissionTaskTest, self).setUp()
+        super().setUp()
         self.config = TransferConfig()
         self.osutil = OSUtils()
         self.executor = BoundedExecutor(
@@ -338,7 +337,7 @@ class BaseSubmissionTaskTest(BaseTaskTest):
         )
 
     def tearDown(self):
-        super(BaseSubmissionTaskTest, self).tearDown()
+        super().tearDown()
         self.executor.shutdown()
 
 
@@ -483,8 +482,8 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
 
 class NonSeekableReader(io.RawIOBase):
     def __init__(self, b=b''):
-        super(NonSeekableReader, self).__init__()
-        self._data = six.BytesIO(b)
+        super().__init__()
+        self._data = io.BytesIO(b)
 
     def seekable(self):
         return False
@@ -506,7 +505,7 @@ class NonSeekableReader(io.RawIOBase):
 
 class NonSeekableWriter(io.RawIOBase):
     def __init__(self, fileobj):
-        super(NonSeekableWriter, self).__init__()
+        super().__init__()
         self._fileobj = fileobj
 
     def seekable(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,6 +46,7 @@ ORIGINAL_EXECUTOR_CLS = BoundedExecutor.EXECUTOR_CLS
 # Detect if CRT is available for use
 try:
     import awscrt.s3  # noqa: F401
+
     HAS_CRT = True
 except ImportError:
     HAS_CRT = False
@@ -72,7 +73,9 @@ def assert_files_equal(first, second):
     if first_md5 != second_md5:
         raise AssertionError(
             "Files are not equal: {}(md5={}) != {}(md5={})".format(
-                first, first_md5, second, second_md5))
+                first, first_md5, second, second_md5
+            )
+        )
 
 
 def md5_checksum(filename):
@@ -99,17 +102,21 @@ def skip_if_windows(reason):
             self.assertEqual(...)
 
     """
+
     def decorator(func):
         return unittest.skipIf(
-            platform.system() not in ['Darwin', 'Linux'], reason)(func)
+            platform.system() not in ['Darwin', 'Linux'], reason
+        )(func)
+
     return decorator
 
 
 def skip_if_using_serial_implementation(reason):
     """Decorator to skip tests when running as the serial implementation"""
+
     def decorator(func):
-        return unittest.skipIf(
-            is_serial_implementation(), reason)(func)
+        return unittest.skipIf(is_serial_implementation(), reason)(func)
+
     return decorator
 
 
@@ -214,8 +221,7 @@ class RecordingOSUtils(OSUtils):
 
     def rename_file(self, current_filename, new_filename):
         self.rename_records.append((current_filename, new_filename))
-        super().rename_file(
-            current_filename, new_filename)
+        super().rename_file(current_filename, new_filename)
 
 
 class RecordingSubscriber(BaseSubscriber):
@@ -266,13 +272,7 @@ class RecordingExecutor:
 
     def submit(self, task, tag=None, block=True):
         future = self._executor.submit(task, tag, block)
-        self.submissions.append(
-            {
-                'task': task,
-                'tag': tag,
-                'block': block
-            }
-        )
+        self.submissions.append({'task': task, 'tag': tag, 'block': block})
         return future
 
     def shutdown(self):
@@ -284,8 +284,11 @@ class StubbedClientTest(unittest.TestCase):
         self.session = botocore.session.get_session()
         self.region = 'us-west-2'
         self.client = self.session.create_client(
-            's3', self.region, aws_access_key_id='foo',
-            aws_secret_access_key='bar')
+            's3',
+            self.region,
+            aws_access_key_id='foo',
+            aws_secret_access_key='bar',
+        )
         self.stubber = Stubber(self.client)
         self.stubber.activate()
 
@@ -297,7 +300,7 @@ class StubbedClientTest(unittest.TestCase):
             'service_name': 's3',
             'region_name': self.region,
             'aws_access_key_id': 'foo',
-            'aws_secret_access_key': 'bar'
+            'aws_secret_access_key': 'bar',
         }
         client_kwargs.update(override_client_kwargs)
         self.client = self.session.create_client(**client_kwargs)
@@ -317,8 +320,7 @@ class BaseTaskTest(StubbedClientTest):
 
     def get_transfer_future(self, call_args=None):
         return TransferFuture(
-            meta=TransferMeta(call_args),
-            coordinator=self.transfer_coordinator
+            meta=TransferMeta(call_args), coordinator=self.transfer_coordinator
         )
 
 
@@ -332,8 +334,8 @@ class BaseSubmissionTaskTest(BaseTaskTest):
             1,
             {
                 IN_MEMORY_UPLOAD_TAG: TaskSemaphore(10),
-                IN_MEMORY_DOWNLOAD_TAG: SlidingWindowSemaphore(10)
-            }
+                IN_MEMORY_DOWNLOAD_TAG: SlidingWindowSemaphore(10),
+            },
         )
 
     def tearDown(self):
@@ -348,6 +350,7 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
     the various tests that all TransferManager method must pass from a
     functionality standpoint.
     """
+
     __test__ = False
 
     def manager(self):
@@ -366,7 +369,8 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
     def create_invalid_extra_args(self):
         """A value for extra_args that will cause validation errors"""
         raise NotImplementedError(
-            'create_invalid_extra_args is not implemented')
+            'create_invalid_extra_args is not implemented'
+        )
 
     def create_stubbed_responses(self):
         """A list of stubbed responses that will cause the request to succeed
@@ -377,7 +381,8 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
             [{'method': 'put_object', 'service_response': {}}]
         """
         raise NotImplementedError(
-            'create_stubbed_responses is not implemented')
+            'create_stubbed_responses is not implemented'
+        )
 
     def create_expected_progress_callback_info(self):
         """A list of kwargs expected to be passed to each progress callback
@@ -397,7 +402,8 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
         values.
         """
         raise NotImplementedError(
-            'create_expected_progress_callback_info is not implemented')
+            'create_expected_progress_callback_info is not implemented'
+        )
 
     def _setup_default_stubbed_responses(self):
         for stubbed_response in self.create_stubbed_responses():
@@ -454,7 +460,7 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
         with self.assertRaisesRegex(ValueError, 'Invalid extra_args'):
             self.method(
                 extra_args=self.create_invalid_extra_args(),
-                **self.create_call_kwargs()
+                **self.create_call_kwargs(),
             )
 
     def test_for_callback_kwargs_correctness(self):
@@ -463,7 +469,8 @@ class BaseGeneralInterfaceTest(StubbedClientTest):
 
         subscriber = RecordingSubscriber()
         future = self.method(
-            subscribers=[subscriber], **self.create_call_kwargs())
+            subscribers=[subscriber], **self.create_call_kwargs()
+        )
         # We call shutdown instead of result on future because the future
         # could be finished but the done callback could still be going.
         # The manager's shutdown method ensures everything completes.

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -13,11 +13,9 @@
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 
-from tests import BaseGeneralInterfaceTest
-from tests import FileSizeProvider
-from s3transfer.manager import TransferManager
-from s3transfer.manager import TransferConfig
+from s3transfer.manager import TransferConfig, TransferManager
 from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE
+from tests import BaseGeneralInterfaceTest, FileSizeProvider
 
 
 class BaseCopyTest(BaseGeneralInterfaceTest):

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -20,7 +20,7 @@ from tests import BaseGeneralInterfaceTest, FileSizeProvider
 
 class BaseCopyTest(BaseGeneralInterfaceTest):
     def setUp(self):
-        super(BaseCopyTest, self).setUp()
+        super().setUp()
         self.config = TransferConfig(
             max_request_concurrency=1,
             multipart_chunksize=MIN_UPLOAD_CHUNKSIZE,
@@ -293,7 +293,7 @@ class TestMultipartCopy(BaseCopyTest):
     __test__ = True
 
     def setUp(self):
-        super(TestMultipartCopy, self).setUp()
+        super().setUp()
         self.config = TransferConfig(
             max_request_concurrency=1, multipart_threshold=1,
             multipart_chunksize=4)

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -24,17 +24,14 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         self.config = TransferConfig(
             max_request_concurrency=1,
             multipart_chunksize=MIN_UPLOAD_CHUNKSIZE,
-            multipart_threshold=MIN_UPLOAD_CHUNKSIZE * 4
+            multipart_threshold=MIN_UPLOAD_CHUNKSIZE * 4,
         )
         self._manager = TransferManager(self.client, self.config)
 
         # Initialize some default arguments
         self.bucket = 'mybucket'
         self.key = 'mykey'
-        self.copy_source = {
-            'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
-        }
+        self.copy_source = {'Bucket': 'mysourcebucket', 'Key': 'mysourcekey'}
         self.extra_args = {}
         self.subscribers = []
 
@@ -57,22 +54,15 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         }
 
     def create_invalid_extra_args(self):
-        return {
-            'Foo': 'bar'
-        }
+        return {'Foo': 'bar'}
 
     def create_stubbed_responses(self):
         return [
             {
                 'method': 'head_object',
-                'service_response': {
-                    'ContentLength': len(self.content)
-                }
+                'service_response': {'ContentLength': len(self.content)},
             },
-            {
-                'method': 'copy_object',
-                'service_response': {}
-            }
+            {'method': 'copy_object', 'service_response': {}},
         ]
 
     def create_expected_progress_callback_info(self):
@@ -89,8 +79,11 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         stubber.add_response(**head_response)
 
     def add_successful_copy_responses(
-            self, expected_copy_params=None, expected_create_mpu_params=None,
-            expected_complete_mpu_params=None):
+        self,
+        expected_copy_params=None,
+        expected_create_mpu_params=None,
+        expected_complete_mpu_params=None,
+    ):
 
         # Add all responses needed to do the copy of the object.
         # Should account for both ranged and nonranged downloads.
@@ -105,7 +98,8 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         # Add the expected create multipart upload params.
         if expected_create_mpu_params:
             stubbed_responses[0][
-                'expected_params'] = expected_create_mpu_params
+                'expected_params'
+            ] = expected_create_mpu_params
 
         # Add any expected copy parameters.
         if expected_copy_params:
@@ -118,7 +112,8 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         # Add the expected complete multipart upload params.
         if expected_complete_mpu_params:
             stubbed_responses[-1][
-                'expected_params'] = expected_complete_mpu_params
+                'expected_params'
+            ] = expected_complete_mpu_params
 
         # Add the responses to the stubber.
         for stubbed_response in stubbed_responses:
@@ -142,7 +137,7 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         expected_params = {
             'Bucket': 'mysourcebucket',
             'Key': 'mysourcekey',
-            'VersionId': 'mysourceversionid'
+            'VersionId': 'mysourceversionid',
         }
 
         self.add_head_object_response(expected_params=expected_params)
@@ -160,8 +155,11 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
 
     def test_provide_copy_source_client(self):
         source_client = self.session.create_client(
-            's3', 'eu-central-1', aws_access_key_id='foo',
-            aws_secret_access_key='bar')
+            's3',
+            'eu-central-1',
+            aws_access_key_id='foo',
+            aws_secret_access_key='bar',
+        )
         source_stubber = Stubber(source_client)
         source_stubber.activate()
         self.addCleanup(source_stubber.deactivate)
@@ -186,16 +184,17 @@ class TestNonMultipartCopy(BaseCopyTest):
     def test_copy(self):
         expected_head_params = {
             'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
+            'Key': 'mysourcekey',
         }
         expected_copy_object = {
             'Bucket': self.bucket,
             'Key': self.key,
-            'CopySource': self.copy_source
+            'CopySource': self.copy_source,
         }
         self.add_head_object_response(expected_params=expected_head_params)
         self.add_successful_copy_responses(
-            expected_copy_params=expected_copy_object)
+            expected_copy_params=expected_copy_object
+        )
 
         future = self.manager.copy(**self.create_call_kwargs())
         future.result()
@@ -206,18 +205,19 @@ class TestNonMultipartCopy(BaseCopyTest):
 
         expected_head_params = {
             'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
+            'Key': 'mysourcekey',
         }
         expected_copy_object = {
             'Bucket': self.bucket,
             'Key': self.key,
             'CopySource': self.copy_source,
-            'MetadataDirective': 'REPLACE'
+            'MetadataDirective': 'REPLACE',
         }
 
         self.add_head_object_response(expected_params=expected_head_params)
         self.add_successful_copy_responses(
-            expected_copy_params=expected_copy_object)
+            expected_copy_params=expected_copy_object
+        )
 
         call_kwargs = self.create_call_kwargs()
         call_kwargs['extra_args'] = self.extra_args
@@ -231,18 +231,19 @@ class TestNonMultipartCopy(BaseCopyTest):
         expected_head_params = {
             'Bucket': 'mysourcebucket',
             'Key': 'mysourcekey',
-            'SSECustomerAlgorithm': 'AES256'
+            'SSECustomerAlgorithm': 'AES256',
         }
         expected_copy_object = {
             'Bucket': self.bucket,
             'Key': self.key,
             'CopySource': self.copy_source,
-            'CopySourceSSECustomerAlgorithm': 'AES256'
+            'CopySourceSSECustomerAlgorithm': 'AES256',
         }
 
         self.add_head_object_response(expected_params=expected_head_params)
         self.add_successful_copy_responses(
-            expected_copy_params=expected_copy_object)
+            expected_copy_params=expected_copy_object
+        )
 
         call_kwargs = self.create_call_kwargs()
         call_kwargs['extra_args'] = self.extra_args
@@ -256,9 +257,7 @@ class TestNonMultipartCopy(BaseCopyTest):
             self.assertIn(allowed_upload_arg, op_model.input_shape.members)
 
     def test_copy_with_tagging(self):
-        extra_args = {
-            'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'
-        }
+        extra_args = {'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'}
         self.add_head_object_response()
         self.add_successful_copy_responses(
             expected_copy_params={
@@ -266,11 +265,12 @@ class TestNonMultipartCopy(BaseCopyTest):
                 'Key': self.key,
                 'CopySource': self.copy_source,
                 'Tagging': 'tag1=val1',
-                'TaggingDirective': 'REPLACE'
+                'TaggingDirective': 'REPLACE',
             }
         )
         future = self.manager.copy(
-            self.copy_source, self.bucket, self.key, extra_args)
+            self.copy_source, self.bucket, self.key, extra_args
+        )
         future.result()
         self.stubber.assert_no_pending_responses()
 
@@ -283,8 +283,10 @@ class TestNonMultipartCopy(BaseCopyTest):
             self.manager.copy(self.copy_source, s3_object_lambda_arn, self.key)
 
     def test_raise_exception_on_s3_object_lambda_resource_as_source(self):
-        source = {'Bucket': 'arn:aws:s3-object-lambda:us-west-2:123456789012:'
-                            'accesspoint:my-accesspoint'}
+        source = {
+            'Bucket': 'arn:aws:s3-object-lambda:us-west-2:123456789012:'
+            'accesspoint:my-accesspoint'
+        }
         with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.copy(source, self.bucket, self.key)
 
@@ -295,52 +297,35 @@ class TestMultipartCopy(BaseCopyTest):
     def setUp(self):
         super().setUp()
         self.config = TransferConfig(
-            max_request_concurrency=1, multipart_threshold=1,
-            multipart_chunksize=4)
+            max_request_concurrency=1,
+            multipart_threshold=1,
+            multipart_chunksize=4,
+        )
         self._manager = TransferManager(self.client, self.config)
 
     def create_stubbed_responses(self):
         return [
             {
                 'method': 'head_object',
-                'service_response': {
-                    'ContentLength': len(self.content)
-                }
+                'service_response': {'ContentLength': len(self.content)},
             },
             {
                 'method': 'create_multipart_upload',
-                'service_response': {
-                    'UploadId': 'my-upload-id'
-                }
+                'service_response': {'UploadId': 'my-upload-id'},
             },
             {
                 'method': 'upload_part_copy',
-                'service_response': {
-                    'CopyPartResult': {
-                        'ETag': 'etag-1'
-                    }
-                }
+                'service_response': {'CopyPartResult': {'ETag': 'etag-1'}},
             },
             {
                 'method': 'upload_part_copy',
-                'service_response': {
-                    'CopyPartResult': {
-                        'ETag': 'etag-2'
-                    }
-                }
+                'service_response': {'CopyPartResult': {'ETag': 'etag-2'}},
             },
             {
                 'method': 'upload_part_copy',
-                'service_response': {
-                    'CopyPartResult': {
-                        'ETag': 'etag-3'
-                    }
-                }
+                'service_response': {'CopyPartResult': {'ETag': 'etag-3'}},
             },
-            {
-                'method': 'complete_multipart_upload',
-                'service_response': {}
-            }
+            {'method': 'complete_multipart_upload', 'service_response': {}},
         ]
 
     def create_expected_progress_callback_info(self):
@@ -349,7 +334,7 @@ class TestMultipartCopy(BaseCopyTest):
         return [
             {'bytes_transferred': MIN_UPLOAD_CHUNKSIZE},
             {'bytes_transferred': MIN_UPLOAD_CHUNKSIZE},
-            {'bytes_transferred': self.half_chunksize}
+            {'bytes_transferred': self.half_chunksize},
         ]
 
     def add_create_multipart_upload_response(self):
@@ -372,8 +357,11 @@ class TestMultipartCopy(BaseCopyTest):
 
         expected_copy_params = []
         # Add expected parameters to the copy part
-        ranges = ['bytes=0-5242879', 'bytes=5242880-10485759',
-                  'bytes=10485760-13107199']
+        ranges = [
+            'bytes=0-5242879',
+            'bytes=5242880-10485759',
+            'bytes=10485760-13107199',
+        ]
         for i, range_val in enumerate(ranges):
             expected_copy_params.append(
                 {
@@ -382,21 +370,22 @@ class TestMultipartCopy(BaseCopyTest):
                     'CopySource': self.copy_source,
                     'UploadId': upload_id,
                     'PartNumber': i + 1,
-                    'CopySourceRange': range_val
+                    'CopySourceRange': range_val,
                 }
             )
 
         # Add expected parameters for the complete multipart
         expected_complete_mpu_params = {
             'Bucket': self.bucket,
-            'Key': self.key, 'UploadId': upload_id,
+            'Key': self.key,
+            'UploadId': upload_id,
             'MultipartUpload': {
                 'Parts': [
                     {'ETag': 'etag-1', 'PartNumber': 1},
                     {'ETag': 'etag-2', 'PartNumber': 2},
-                    {'ETag': 'etag-3', 'PartNumber': 3}
+                    {'ETag': 'etag-3', 'PartNumber': 3},
                 ]
-            }
+            },
         }
 
         return expected_head_params, {
@@ -406,7 +395,8 @@ class TestMultipartCopy(BaseCopyTest):
         }
 
     def _add_params_to_expected_params(
-            self, add_copy_kwargs, operation_types, new_params):
+        self, add_copy_kwargs, operation_types, new_params
+    ):
 
         expected_params_to_update = []
         for operation_type in operation_types:
@@ -439,8 +429,10 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response(expected_params=head_params)
 
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['create_mpu', 'copy', 'complete_mpu'],
-            self.extra_args)
+            add_copy_kwargs,
+            ['create_mpu', 'copy', 'complete_mpu'],
+            self.extra_args,
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -470,7 +462,8 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response(expected_params=head_params)
 
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['create_mpu'], self.extra_args)
+            add_copy_kwargs, ['create_mpu'], self.extra_args
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -488,7 +481,8 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response(expected_params=head_params)
 
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['create_mpu', 'copy'], self.extra_args)
+            add_copy_kwargs, ['create_mpu', 'copy'], self.extra_args
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -509,7 +503,8 @@ class TestMultipartCopy(BaseCopyTest):
 
         # However, it needs to remain the same for UploadPartCopy.
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['copy'], self.extra_args)
+            add_copy_kwargs, ['copy'], self.extra_args
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -533,8 +528,8 @@ class TestMultipartCopy(BaseCopyTest):
             expected_params={
                 'Bucket': self.bucket,
                 'Key': self.key,
-                'UploadId': 'my-upload-id'
-            }
+                'UploadId': 'my-upload-id',
+            },
         )
 
         future = self.manager.copy(**self.create_call_kwargs())
@@ -543,9 +538,7 @@ class TestMultipartCopy(BaseCopyTest):
         self.stubber.assert_no_pending_responses()
 
     def test_mp_copy_with_tagging_directive(self):
-        extra_args = {
-            'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'
-        }
+        extra_args = {'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'}
         self.add_head_object_response()
         self.add_successful_copy_responses(
             expected_create_mpu_params={
@@ -555,6 +548,7 @@ class TestMultipartCopy(BaseCopyTest):
             }
         )
         future = self.manager.copy(
-            self.copy_source, self.bucket, self.key, extra_args)
+            self.copy_source, self.bucket, self.key, extra_args
+        )
         future.result()
         self.stubber.assert_no_pending_responses()

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -18,14 +18,12 @@ from concurrent.futures import Future
 from botocore.session import Session
 
 from s3transfer.subscribers import BaseSubscriber
-
-from tests import (
-    FileCreator, requires_crt, HAS_CRT, unittest, mock
-)
+from tests import HAS_CRT, FileCreator, mock, requires_crt, unittest
 
 if HAS_CRT:
-    import s3transfer.crt
     import awscrt
+
+    import s3transfer.crt
 
 
 class submitThread(threading.Thread):

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -70,10 +70,12 @@ class TestCRTTransferManager(unittest.TestCase):
         self.session = Session()
         self.session.set_config_variable('region', self.region)
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
-            self.session)
+            self.session
+        )
         self.transfer_manager = s3transfer.crt.CRTTransferManager(
             crt_s3_client=self.s3_crt_client,
-            crt_request_serializer=self.request_serializer)
+            crt_request_serializer=self.request_serializer,
+        )
         self.record_subscriber = RecordingSubscriber()
 
     def tearDown(self):
@@ -84,11 +86,11 @@ class TestCRTTransferManager(unittest.TestCase):
         self.assertTrue(self.record_subscriber.on_done_called)
         if expected_future:
             self.assertIs(
-                self.record_subscriber.on_queued_future,
-                expected_future)
+                self.record_subscriber.on_queued_future, expected_future
+            )
             self.assertIs(
-                self.record_subscriber.on_done_future,
-                expected_future)
+                self.record_subscriber.on_done_future, expected_future
+            )
 
     def _invoke_done_callbacks(self, **kwargs):
         callargs = self.s3_crt_client.make_request.call_args
@@ -106,17 +108,21 @@ class TestCRTTransferManager(unittest.TestCase):
         return mock.DEFAULT
 
     def test_upload(self):
-        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
+        self.s3_crt_client.make_request.side_effect = (
+            self._simulate_make_request_side_effect
+        )
         future = self.transfer_manager.upload(
-            self.filename, self.bucket, self.key, {}, [self.record_subscriber])
+            self.filename, self.bucket, self.key, {}, [self.record_subscriber]
+        )
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
         callargs_kwargs = callargs[1]
         self.assertEqual(callargs_kwargs["send_filepath"], self.filename)
         self.assertIsNone(callargs_kwargs["recv_filepath"])
-        self.assertEqual(callargs_kwargs["type"],
-                         awscrt.s3.S3RequestType.PUT_OBJECT)
+        self.assertEqual(
+            callargs_kwargs["type"], awscrt.s3.S3RequestType.PUT_OBJECT
+        )
         crt_request = callargs_kwargs["request"]
         self.assertEqual("PUT", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
@@ -124,9 +130,12 @@ class TestCRTTransferManager(unittest.TestCase):
         self._assert_subscribers_called(future)
 
     def test_download(self):
-        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
+        self.s3_crt_client.make_request.side_effect = (
+            self._simulate_make_request_side_effect
+        )
         future = self.transfer_manager.download(
-            self.bucket, self.key, self.filename, {}, [self.record_subscriber])
+            self.bucket, self.key, self.filename, {}, [self.record_subscriber]
+        )
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
@@ -135,12 +144,14 @@ class TestCRTTransferManager(unittest.TestCase):
         # random suffix
         self.assertTrue(
             fnmatch.fnmatch(
-                callargs_kwargs["recv_filepath"], f'{self.filename}.*',
+                callargs_kwargs["recv_filepath"],
+                f'{self.filename}.*',
             )
         )
         self.assertIsNone(callargs_kwargs["send_filepath"])
-        self.assertEqual(callargs_kwargs["type"],
-                         awscrt.s3.S3RequestType.GET_OBJECT)
+        self.assertEqual(
+            callargs_kwargs["type"], awscrt.s3.S3RequestType.GET_OBJECT
+        )
         crt_request = callargs_kwargs["request"]
         self.assertEqual("GET", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
@@ -151,17 +162,21 @@ class TestCRTTransferManager(unittest.TestCase):
             self.assertEqual(f.read(), b'fake response')
 
     def test_delete(self):
-        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
+        self.s3_crt_client.make_request.side_effect = (
+            self._simulate_make_request_side_effect
+        )
         future = self.transfer_manager.delete(
-            self.bucket, self.key, {}, [self.record_subscriber])
+            self.bucket, self.key, {}, [self.record_subscriber]
+        )
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
         callargs_kwargs = callargs[1]
         self.assertIsNone(callargs_kwargs["send_filepath"])
         self.assertIsNone(callargs_kwargs["recv_filepath"])
-        self.assertEqual(callargs_kwargs["type"],
-                         awscrt.s3.S3RequestType.DEFAULT)
+        self.assertEqual(
+            callargs_kwargs["type"], awscrt.s3.S3RequestType.DEFAULT
+        )
         crt_request = callargs_kwargs["request"]
         self.assertEqual("DELETE", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
@@ -182,8 +197,8 @@ class TestCRTTransferManager(unittest.TestCase):
         while len(futures) < max_request_processes:
             time.sleep(0.05)
         self.assertLessEqual(
-            self.s3_crt_client.make_request.call_count,
-            max_request_processes)
+            self.s3_crt_client.make_request.call_count, max_request_processes
+        )
         # Release lock
         callargs = self.s3_crt_client.make_request.call_args
         callargs_kwargs = callargs[1]
@@ -192,13 +207,14 @@ class TestCRTTransferManager(unittest.TestCase):
         for thread in threads:
             thread.join()
         self.assertEqual(
-            self.s3_crt_client.make_request.call_count,
-            all_concurrent)
+            self.s3_crt_client.make_request.call_count, all_concurrent
+        )
 
     def _cancel_function(self):
         self.cancel_called = True
         self.s3_request.finished_future.set_exception(
-            awscrt.exceptions.from_code(0))
+            awscrt.exceptions.from_code(0)
+        )
         self._invoke_done_callbacks()
 
     def test_cancel(self):
@@ -208,7 +224,8 @@ class TestCRTTransferManager(unittest.TestCase):
         try:
             with self.transfer_manager:
                 future = self.transfer_manager.upload(
-                    self.filename, self.bucket, self.key, {}, [])
+                    self.filename, self.bucket, self.key, {}, []
+                )
                 raise KeyboardInterrupt()
         except KeyboardInterrupt:
             pass
@@ -218,28 +235,33 @@ class TestCRTTransferManager(unittest.TestCase):
         self.assertTrue(self.cancel_called)
 
     def test_serializer_error_handling(self):
-
         class SerializationException(Exception):
             pass
 
-        class ExceptionRaisingSerializer(s3transfer.crt.BaseCRTRequestSerializer):
+        class ExceptionRaisingSerializer(
+            s3transfer.crt.BaseCRTRequestSerializer
+        ):
             def serialize_http_request(self, transfer_type, future):
                 raise SerializationException()
 
         not_impl_serializer = ExceptionRaisingSerializer()
         transfer_manager = s3transfer.crt.CRTTransferManager(
             crt_s3_client=self.s3_crt_client,
-            crt_request_serializer=not_impl_serializer)
+            crt_request_serializer=not_impl_serializer,
+        )
         future = transfer_manager.upload(
-            self.filename, self.bucket, self.key, {}, [])
+            self.filename, self.bucket, self.key, {}, []
+        )
 
         with self.assertRaises(SerializationException):
             future.result()
 
     def test_crt_s3_client_error_handling(self):
-        self.s3_crt_client.make_request.side_effect = awscrt.exceptions.from_code(
-            0)
+        self.s3_crt_client.make_request.side_effect = (
+            awscrt.exceptions.from_code(0)
+        )
         future = self.transfer_manager.upload(
-            self.filename, self.bucket, self.key, {}, [])
+            self.filename, self.bucket, self.key, {}, []
+        )
         with self.assertRaises(awscrt.exceptions.AwsCrtError):
             future.result()

--- a/tests/functional/test_delete.py
+++ b/tests/functional/test_delete.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import BaseGeneralInterfaceTest
 from s3transfer.manager import TransferManager
+from tests import BaseGeneralInterfaceTest
 
 
 class TestDeleteObject(BaseGeneralInterfaceTest):

--- a/tests/functional/test_delete.py
+++ b/tests/functional/test_delete.py
@@ -49,18 +49,21 @@ class TestDeleteObject(BaseGeneralInterfaceTest):
 
             [{'method': 'put_object', 'service_response': {}}]
         """
-        return [{
-            'method': 'delete_object',
-            'service_response': {},
-            'expected_params': {'Bucket': self.bucket, 'Key': self.key},
-        }]
+        return [
+            {
+                'method': 'delete_object',
+                'service_response': {},
+                'expected_params': {'Bucket': self.bucket, 'Key': self.key},
+            }
+        ]
 
     def create_expected_progress_callback_info(self):
         return []
 
     def test_known_allowed_args_in_input_shape(self):
         op_model = self.client.meta.service_model.operation_model(
-            'DeleteObject')
+            'DeleteObject'
+        )
         for allowed_arg in self.manager.ALLOWED_DELETE_ARGS:
             self.assertIn(allowed_arg, op_model.input_shape.members)
 

--- a/tests/functional/test_delete.py
+++ b/tests/functional/test_delete.py
@@ -19,7 +19,7 @@ class TestDeleteObject(BaseGeneralInterfaceTest):
     __test__ = True
 
     def setUp(self):
-        super(TestDeleteObject, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'mykey'
         self.manager = TransferManager(self.client)

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -16,10 +16,11 @@ import os
 import shutil
 import tempfile
 import time
+from io import BytesIO
 
 from botocore.exceptions import ClientError
 
-from s3transfer.compat import SOCKET_ERROR, six
+from s3transfer.compat import SOCKET_ERROR
 from s3transfer.exceptions import RetriesExceededError
 from s3transfer.manager import TransferConfig, TransferManager
 from tests import (
@@ -36,7 +37,7 @@ from tests import (
 
 class BaseDownloadTest(BaseGeneralInterfaceTest):
     def setUp(self):
-        super(BaseDownloadTest, self).setUp()
+        super().setUp()
         self.config = TransferConfig(max_request_concurrency=1)
         self._manager = TransferManager(self.client, self.config)
 
@@ -52,10 +53,10 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
 
         # Create a stream to read from
         self.content = b'my content'
-        self.stream = six.BytesIO(self.content)
+        self.stream = BytesIO(self.content)
 
     def tearDown(self):
-        super(BaseDownloadTest, self).tearDown()
+        super().tearDown()
         shutil.rmtree(self.tempdir)
 
     @property
@@ -165,7 +166,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
 
         # Create a file-like object to test. In this case, it is a BytesIO
         # object.
-        bytes_io = six.BytesIO()
+        bytes_io = BytesIO()
 
         future = self.manager.download(
             self.bucket, self.key, bytes_io, self.extra_args)
@@ -379,7 +380,7 @@ class TestNonRangedDownload(BaseDownloadTest):
 
     def test_download_empty_object(self):
         self.content = b''
-        self.stream = six.BytesIO(self.content)
+        self.stream = BytesIO(self.content)
         self.add_head_object_response()
         self.add_successful_get_object_responses()
         future = self.manager.download(
@@ -392,7 +393,7 @@ class TestNonRangedDownload(BaseDownloadTest):
 
     def test_uses_bandwidth_limiter(self):
         self.content = b'a' * 1024 * 1024
-        self.stream = six.BytesIO(self.content)
+        self.stream = BytesIO(self.content)
         self.config = TransferConfig(
             max_request_concurrency=1, max_bandwidth=len(self.content)/2)
         self._manager = TransferManager(self.client, self.config)
@@ -428,7 +429,7 @@ class TestRangedDownload(BaseDownloadTest):
     __test__ = True
 
     def setUp(self):
-        super(TestRangedDownload, self).setUp()
+        super().setUp()
         self.config = TransferConfig(
             max_request_concurrency=1, multipart_threshold=1,
             multipart_chunksize=4)
@@ -445,19 +446,19 @@ class TestRangedDownload(BaseDownloadTest):
             {
                 'method': 'get_object',
                 'service_response': {
-                    'Body': six.BytesIO(self.content[0:4])
+                    'Body': BytesIO(self.content[0:4])
                 }
             },
             {
                 'method': 'get_object',
                 'service_response': {
-                    'Body': six.BytesIO(self.content[4:8])
+                    'Body': BytesIO(self.content[4:8])
                 }
             },
             {
                 'method': 'get_object',
                 'service_response': {
-                    'Body': six.BytesIO(self.content[8:])
+                    'Body': BytesIO(self.content[8:])
                 }
             }
         ]

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -71,13 +71,11 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         return {
             'bucket': self.bucket,
             'key': self.key,
-            'fileobj': self.filename
+            'fileobj': self.filename,
         }
 
     def create_invalid_extra_args(self):
-        return {
-            'Foo': 'bar'
-        }
+        return {'Foo': 'bar'}
 
     def create_stubbed_responses(self):
         # We want to make sure the beginning of the stream is always used
@@ -86,24 +84,18 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         return [
             {
                 'method': 'head_object',
-                'service_response': {
-                    'ContentLength': len(self.content)
-                }
+                'service_response': {'ContentLength': len(self.content)},
             },
             {
                 'method': 'get_object',
-                'service_response': {
-                    'Body': self.stream
-                }
-            }
+                'service_response': {'Body': self.stream},
+            },
         ]
 
     def create_expected_progress_callback_info(self):
         # Note that last read is from the empty sentinel indicating
         # that the stream is done.
-        return [
-            {'bytes_transferred': 10}
-        ]
+        return [{'bytes_transferred': 10}]
 
     def add_head_object_response(self, expected_params=None):
         head_response = self.create_stubbed_responses()[0]
@@ -112,17 +104,21 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         self.stubber.add_response(**head_response)
 
     def add_successful_get_object_responses(
-            self, expected_params=None, expected_ranges=None):
+        self, expected_params=None, expected_ranges=None
+    ):
         # Add all get_object responses needed to complete the download.
         # Should account for both ranged and nonranged downloads.
         for i, stubbed_response in enumerate(
-                self.create_stubbed_responses()[1:]):
+            self.create_stubbed_responses()[1:]
+        ):
             if expected_params:
                 stubbed_response['expected_params'] = copy.deepcopy(
-                    expected_params)
+                    expected_params
+                )
                 if expected_ranges:
                     stubbed_response['expected_params'][
-                        'Range'] = expected_ranges[i]
+                        'Range'
+                    ] = expected_ranges[i]
             self.stubber.add_response(**stubbed_response)
 
     def add_n_retryable_get_object_responses(self, n, num_reads=0):
@@ -131,8 +127,9 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
                 method='get_object',
                 service_response={
                     'Body': StreamWithError(
-                        copy.deepcopy(self.stream), SOCKET_ERROR, num_reads)
-                }
+                        copy.deepcopy(self.stream), SOCKET_ERROR, num_reads
+                    )
+                },
             )
 
     def test_download_temporary_file_does_not_exist(self):
@@ -153,7 +150,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
 
         with open(self.filename, 'wb') as f:
             future = self.manager.download(
-                self.bucket, self.key, f, self.extra_args)
+                self.bucket, self.key, f, self.extra_args
+            )
             future.result()
 
         # Ensure that the contents are correct
@@ -169,7 +167,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         bytes_io = BytesIO()
 
         future = self.manager.download(
-            self.bucket, self.key, bytes_io, self.extra_args)
+            self.bucket, self.key, bytes_io, self.extra_args
+        )
         future.result()
 
         # Ensure that the contents are correct
@@ -182,7 +181,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
 
         with open(self.filename, 'wb') as f:
             future = self.manager.download(
-                self.bucket, self.key, NonSeekableWriter(f), self.extra_args)
+                self.bucket, self.key, NonSeekableWriter(f), self.extra_args
+            )
             future.result()
 
         # Ensure that the contents are correct
@@ -210,7 +210,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
 
         call_kwargs = self.create_call_kwargs()
         call_kwargs['fileobj'] = os.path.join(
-            self.tempdir, 'missing-directory', 'myfile')
+            self.tempdir, 'missing-directory', 'myfile'
+        )
         future = self.manager.download(**call_kwargs)
         with self.assertRaises(IOError):
             future.result()
@@ -264,7 +265,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         # currently provide to it to simulate rewinds of callbacks.
         self.config.io_chunksize = 3
         future = self.manager.download(
-            subscribers=[recorder_subscriber], **self.create_call_kwargs())
+            subscribers=[recorder_subscriber], **self.create_call_kwargs()
+        )
         future.result()
 
         # Ensure that there is no more remaining responses and that contents
@@ -276,14 +278,15 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         # Assert that the number of bytes seen is equal to the length of
         # downloaded content.
         self.assertEqual(
-            recorder_subscriber.calculate_bytes_seen(), len(self.content))
+            recorder_subscriber.calculate_bytes_seen(), len(self.content)
+        )
 
         # Also ensure that the second progress invocation was negative three
         # because a retry happened on the second read of the stream and we
         # know that the chunk size for each read is 3.
         progress_byte_amts = [
-            call['bytes_transferred'] for call in
-            recorder_subscriber.on_progress_calls
+            call['bytes_transferred']
+            for call in recorder_subscriber.on_progress_calls
         ]
         self.assertEqual(-3, progress_byte_amts[1])
 
@@ -320,7 +323,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
 
     @skip_if_windows('Windows does not support UNIX special files')
     @skip_if_using_serial_implementation(
-        'A separate thread is needed to read from the fifo')
+        'A separate thread is needed to read from the fifo'
+    )
     def test_download_for_fifo_file(self):
         self.add_head_object_response()
         self.add_successful_get_object_responses()
@@ -329,7 +333,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         os.mkfifo(self.filename)
 
         future = self.manager.download(
-            self.bucket, self.key, self.filename, self.extra_args)
+            self.bucket, self.key, self.filename, self.extra_args
+        )
 
         # The call to open a fifo will block until there is both a reader
         # and a writer, so we need to open it for reading after we've
@@ -345,7 +350,8 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         )
         with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.download(
-                s3_object_lambda_arn, self.key, self.filename, self.extra_args)
+                s3_object_lambda_arn, self.key, self.filename, self.extra_args
+            )
 
 
 class TestNonRangedDownload(BaseDownloadTest):
@@ -361,12 +367,13 @@ class TestNonRangedDownload(BaseDownloadTest):
         expected_params = {
             'Bucket': self.bucket,
             'Key': self.key,
-            'RequestPayer': 'requester'
+            'RequestPayer': 'requester',
         }
         self.add_head_object_response(expected_params)
         self.add_successful_get_object_responses(expected_params)
         future = self.manager.download(
-            self.bucket, self.key, self.filename, self.extra_args)
+            self.bucket, self.key, self.filename, self.extra_args
+        )
         future.result()
 
         # Ensure that the contents are correct
@@ -384,7 +391,8 @@ class TestNonRangedDownload(BaseDownloadTest):
         self.add_head_object_response()
         self.add_successful_get_object_responses()
         future = self.manager.download(
-            self.bucket, self.key, self.filename, self.extra_args)
+            self.bucket, self.key, self.filename, self.extra_args
+        )
         future.result()
 
         # Ensure that the empty file exists
@@ -395,7 +403,8 @@ class TestNonRangedDownload(BaseDownloadTest):
         self.content = b'a' * 1024 * 1024
         self.stream = BytesIO(self.content)
         self.config = TransferConfig(
-            max_request_concurrency=1, max_bandwidth=len(self.content)/2)
+            max_request_concurrency=1, max_bandwidth=len(self.content) / 2
+        )
         self._manager = TransferManager(self.client, self.config)
 
         self.add_head_object_response()
@@ -403,7 +412,8 @@ class TestNonRangedDownload(BaseDownloadTest):
 
         start = time.time()
         future = self.manager.download(
-            self.bucket, self.key, self.filename, self.extra_args)
+            self.bucket, self.key, self.filename, self.extra_args
+        )
         future.result()
         # This is just a smoke test to make sure that the limiter is
         # being used and not necessary its exactness. So we set the maximum
@@ -431,36 +441,30 @@ class TestRangedDownload(BaseDownloadTest):
     def setUp(self):
         super().setUp()
         self.config = TransferConfig(
-            max_request_concurrency=1, multipart_threshold=1,
-            multipart_chunksize=4)
+            max_request_concurrency=1,
+            multipart_threshold=1,
+            multipart_chunksize=4,
+        )
         self._manager = TransferManager(self.client, self.config)
 
     def create_stubbed_responses(self):
         return [
             {
                 'method': 'head_object',
-                'service_response': {
-                    'ContentLength': len(self.content)
-                }
+                'service_response': {'ContentLength': len(self.content)},
             },
             {
                 'method': 'get_object',
-                'service_response': {
-                    'Body': BytesIO(self.content[0:4])
-                }
+                'service_response': {'Body': BytesIO(self.content[0:4])},
             },
             {
                 'method': 'get_object',
-                'service_response': {
-                    'Body': BytesIO(self.content[4:8])
-                }
+                'service_response': {'Body': BytesIO(self.content[4:8])},
             },
             {
                 'method': 'get_object',
-                'service_response': {
-                    'Body': BytesIO(self.content[8:])
-                }
-            }
+                'service_response': {'Body': BytesIO(self.content[8:])},
+            },
         ]
 
     def create_expected_progress_callback_info(self):
@@ -475,15 +479,17 @@ class TestRangedDownload(BaseDownloadTest):
         expected_params = {
             'Bucket': self.bucket,
             'Key': self.key,
-            'RequestPayer': 'requester'
+            'RequestPayer': 'requester',
         }
         expected_ranges = ['bytes=0-3', 'bytes=4-7', 'bytes=8-']
         self.add_head_object_response(expected_params)
         self.add_successful_get_object_responses(
-            expected_params, expected_ranges)
+            expected_params, expected_ranges
+        )
 
         future = self.manager.download(
-            self.bucket, self.key, self.filename, self.extra_args)
+            self.bucket, self.key, self.filename, self.extra_args
+        )
         future.result()
 
         # Ensure that the contents are correct

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -11,27 +11,27 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import copy
+import glob
 import os
+import shutil
 import tempfile
 import time
-import shutil
-import glob
 
 from botocore.exceptions import ClientError
 
-from tests import StreamWithError
-from tests import FileSizeProvider
-from tests import RecordingSubscriber
-from tests import RecordingOSUtils
-from tests import NonSeekableWriter
-from tests import BaseGeneralInterfaceTest
-from tests import skip_if_windows
-from tests import skip_if_using_serial_implementation
-from s3transfer.compat import six
-from s3transfer.compat import SOCKET_ERROR
+from s3transfer.compat import SOCKET_ERROR, six
 from s3transfer.exceptions import RetriesExceededError
-from s3transfer.manager import TransferManager
-from s3transfer.manager import TransferConfig
+from s3transfer.manager import TransferConfig, TransferManager
+from tests import (
+    BaseGeneralInterfaceTest,
+    FileSizeProvider,
+    NonSeekableWriter,
+    RecordingOSUtils,
+    RecordingSubscriber,
+    StreamWithError,
+    skip_if_using_serial_implementation,
+    skip_if_windows,
+)
 
 
 class BaseDownloadTest(BaseGeneralInterfaceTest):

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -11,16 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from io import BytesIO
+
 from botocore.awsrequest import create_request_object
 
-from tests import mock
-from tests import skip_if_using_serial_implementation
-from tests import StubbedClientTest
-from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import FatalError
+from s3transfer.exceptions import CancelledError, FatalError
 from s3transfer.futures import BaseExecutor
-from s3transfer.manager import TransferManager
-from s3transfer.manager import TransferConfig
+from s3transfer.manager import TransferConfig, TransferManager
+from tests import StubbedClientTest, mock, skip_if_using_serial_implementation
 
 
 class ArbitraryException(Exception):

--- a/tests/functional/test_manager.py
+++ b/tests/functional/test_manager.py
@@ -27,7 +27,7 @@ class ArbitraryException(Exception):
 class SignalTransferringBody(BytesIO):
     """A mocked body with the ability to signal when transfers occur"""
     def __init__(self):
-        super(SignalTransferringBody, self).__init__()
+        super().__init__()
         self.signal_transferring_call_count = 0
         self.signal_not_transferring_call_count = 0
 
@@ -159,7 +159,7 @@ class TestTransferManager(StubbedClientTest):
     def test_unicode_exception_in_context_manager(self):
         with self.assertRaises(ArbitraryException):
             with TransferManager(self.client):
-                raise ArbitraryException(u'\u2713')
+                raise ArbitraryException('\u2713')
 
     def test_client_property(self):
         manager = TransferManager(self.client)

--- a/tests/functional/test_processpool.py
+++ b/tests/functional/test_processpool.py
@@ -12,19 +12,19 @@
 # language governing permissions and limitations under the License.
 import glob
 import os
+from io import BytesIO
 from multiprocessing.managers import BaseManager
 
 import botocore.exceptions
 import botocore.session
 from botocore.stub import Stubber
 
-from s3transfer.compat import six
 from s3transfer.exceptions import CancelledError
 from s3transfer.processpool import ProcessPoolDownloader, ProcessTransferConfig
 from tests import FileCreator, mock, unittest
 
 
-class StubbedClient(object):
+class StubbedClient:
     def __init__(self):
         self._client = botocore.session.get_session().create_client(
             's3', 'us-west-2', aws_access_key_id='foo',
@@ -56,7 +56,7 @@ StubbedClientManager.register('StubbedClient', StubbedClient)
 # Ideally a Mock would be used here. However, they cannot be pickled
 # for Windows. So instead we define a factory class at the module level that
 # can return a stubbed client we initialized in the setUp.
-class StubbedClientFactory(object):
+class StubbedClientFactory:
     def __init__(self, stubbed_client):
         self._stubbed_client = stubbed_client
 
@@ -95,7 +95,7 @@ class TestProcessPoolDownloader(unittest.TestCase):
         self.key = 'mykey'
         self.filename = self.files.full_path('filename')
         self.remote_contents = b'my content'
-        self.stream = six.BytesIO(self.remote_contents)
+        self.stream = BytesIO(self.remote_contents)
 
     def tearDown(self):
         self.manager.shutdown()
@@ -122,7 +122,7 @@ class TestProcessPoolDownloader(unittest.TestCase):
             'get_object', {'Body': self.stream}
         )
         self.stubbed_client.add_response(
-            'get_object', {'Body': six.BytesIO(self.remote_contents)}
+            'get_object', {'Body': BytesIO(self.remote_contents)}
         )
         with self.downloader:
             self.downloader.download_file(
@@ -141,12 +141,12 @@ class TestProcessPoolDownloader(unittest.TestCase):
             'head_object', {'ContentLength': len(self.remote_contents)})
         self.stubbed_client.add_response(
             'get_object', {
-                'Body': six.BytesIO(
+                'Body': BytesIO(
                     self.remote_contents[:half_of_content_length])}
         )
         self.stubbed_client.add_response(
             'get_object', {
-                'Body': six.BytesIO(
+                'Body': BytesIO(
                     self.remote_contents[half_of_content_length:])}
         )
         downloader = ProcessPoolDownloader(

--- a/tests/functional/test_processpool.py
+++ b/tests/functional/test_processpool.py
@@ -18,13 +18,10 @@ import botocore.exceptions
 import botocore.session
 from botocore.stub import Stubber
 
-from tests import mock
-from tests import unittest
-from tests import FileCreator
 from s3transfer.compat import six
 from s3transfer.exceptions import CancelledError
-from s3transfer.processpool import ProcessTransferConfig
-from s3transfer.processpool import ProcessPoolDownloader
+from s3transfer.processpool import ProcessPoolDownloader, ProcessTransferConfig
+from tests import FileCreator, mock, unittest
 
 
 class StubbedClient(object):

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -14,13 +14,13 @@ import os
 import shutil
 import tempfile
 import time
+from io import BytesIO
 
 from botocore.awsrequest import AWSRequest
 from botocore.client import Config
 from botocore.exceptions import ClientError
 from botocore.stub import ANY
 
-from s3transfer.compat import six
 from s3transfer.manager import TransferConfig, TransferManager
 from s3transfer.utils import ChunksizeAdjuster
 from tests import (
@@ -34,7 +34,7 @@ from tests import (
 
 class BaseUploadTest(BaseGeneralInterfaceTest):
     def setUp(self):
-        super(BaseUploadTest, self).setUp()
+        super().setUp()
         # TODO: We do not want to use the real MIN_UPLOAD_CHUNKSIZE
         # when we're adjusting parts.
         # This is really wasteful and fails CI builds because self.contents
@@ -72,7 +72,7 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
             'before-parameter-build.s3.*', self.collect_body)
 
     def tearDown(self):
-        super(BaseUploadTest, self).tearDown()
+        super().tearDown()
         shutil.rmtree(self.tempdir)
         self.adjuster_patch.stop()
 
@@ -175,7 +175,7 @@ class TestNonMultipartUpload(BaseUploadTest):
 
     def test_upload_for_seekable_filelike_obj(self):
         self.add_put_object_response_with_default_expected_params()
-        bytes_io = six.BytesIO(self.content)
+        bytes_io = BytesIO(self.content)
         future = self.manager.upload(
             bytes_io, self.bucket, self.key, self.extra_args)
         future.result()
@@ -184,7 +184,7 @@ class TestNonMultipartUpload(BaseUploadTest):
 
     def test_upload_for_seekable_filelike_obj_that_has_been_seeked(self):
         self.add_put_object_response_with_default_expected_params()
-        bytes_io = six.BytesIO(self.content)
+        bytes_io = BytesIO(self.content)
         seek_pos = 5
         bytes_io.seek(seek_pos)
         future = self.manager.upload(
@@ -280,7 +280,7 @@ class TestMultipartUpload(BaseUploadTest):
     __test__ = True
 
     def setUp(self):
-        super(TestMultipartUpload, self).setUp()
+        super().setUp()
         self.chunksize = 4
         self.config = TransferConfig(
             max_request_concurrency=1, multipart_threshold=1,
@@ -395,7 +395,7 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_create_multipart_response_with_default_expected_params()
         self.add_upload_part_responses_with_default_expected_params()
         self.add_complete_multipart_response_with_default_expected_params()
-        bytes_io = six.BytesIO(self.content)
+        bytes_io = BytesIO(self.content)
         future = self.manager.upload(
             bytes_io, self.bucket, self.key, self.extra_args)
         future.result()
@@ -406,7 +406,7 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_create_multipart_response_with_default_expected_params()
         self.add_upload_part_responses_with_default_expected_params()
         self.add_complete_multipart_response_with_default_expected_params()
-        bytes_io = six.BytesIO(self.content)
+        bytes_io = BytesIO(self.content)
         seek_pos = 1
         bytes_io.seek(seek_pos)
         future = self.manager.upload(

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -11,24 +11,25 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import time
-import tempfile
 import shutil
+import tempfile
+import time
 
+from botocore.awsrequest import AWSRequest
 from botocore.client import Config
 from botocore.exceptions import ClientError
-from botocore.awsrequest import AWSRequest
 from botocore.stub import ANY
 
-from tests import BaseGeneralInterfaceTest
-from tests import RecordingSubscriber
-from tests import RecordingOSUtils
-from tests import NonSeekableReader
-from tests import mock
 from s3transfer.compat import six
-from s3transfer.manager import TransferManager
-from s3transfer.manager import TransferConfig
+from s3transfer.manager import TransferConfig, TransferManager
 from s3transfer.utils import ChunksizeAdjuster
+from tests import (
+    BaseGeneralInterfaceTest,
+    NonSeekableReader,
+    RecordingOSUtils,
+    RecordingSubscriber,
+    mock,
+)
 
 
 class BaseUploadTest(BaseGeneralInterfaceTest):

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -46,7 +46,8 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
         # chunksize adjuster class.
         self.adjuster_patch = mock.patch(
             's3transfer.upload.ChunksizeAdjuster',
-            lambda: ChunksizeAdjuster(min_size=1))
+            lambda: ChunksizeAdjuster(min_size=1),
+        )
         self.adjuster_patch.start()
         self.config = TransferConfig(max_request_concurrency=1)
         self._manager = TransferManager(self.client, self.config)
@@ -69,7 +70,8 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
         # and their order.
         self.sent_bodies = []
         self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
+            'before-parameter-build.s3.*', self.collect_body
+        )
 
     def tearDown(self):
         super().tearDown()
@@ -85,12 +87,14 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
             # simulating reading of the request across the wire to trigger
             # progress callbacks
             request = AWSRequest(
-                method='PUT', url='https://s3.amazonaws.com',
-                data=params['Body']
+                method='PUT',
+                url='https://s3.amazonaws.com',
+                data=params['Body'],
             )
             self.client.meta.events.emit(
                 'request-created.s3.%s' % model.name,
-                request=request, operation_name=model.name
+                request=request,
+                operation_name=model.name,
             )
             self.sent_bodies.append(self._stream_body(params['Body']))
 
@@ -115,13 +119,11 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
         return {
             'fileobj': self.filename,
             'bucket': self.bucket,
-            'key': self.key
+            'key': self.key,
         }
 
     def create_invalid_extra_args(self):
-        return {
-            'Foo': 'bar'
-        }
+        return {'Foo': 'bar'}
 
     def create_stubbed_responses(self):
         return [{'method': 'put_object', 'service_response': {}}]
@@ -140,10 +142,9 @@ class TestNonMultipartUpload(BaseUploadTest):
     __test__ = True
 
     def add_put_object_response_with_default_expected_params(
-            self, extra_expected_params=None):
-        expected_params = {
-            'Body': ANY, 'Bucket': self.bucket, 'Key': self.key
-        }
+        self, extra_expected_params=None
+    ):
+        expected_params = {'Body': ANY, 'Bucket': self.bucket, 'Key': self.key}
         if extra_expected_params:
             expected_params.update(extra_expected_params)
         upload_response = self.create_stubbed_responses()[0]
@@ -159,7 +160,8 @@ class TestNonMultipartUpload(BaseUploadTest):
             extra_expected_params={'RequestPayer': 'requester'}
         )
         future = self.manager.upload(
-            self.filename, self.bucket, self.key, self.extra_args)
+            self.filename, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
@@ -168,7 +170,8 @@ class TestNonMultipartUpload(BaseUploadTest):
         self.add_put_object_response_with_default_expected_params()
         with open(self.filename, 'rb') as f:
             future = self.manager.upload(
-                f, self.bucket, self.key, self.extra_args)
+                f, self.bucket, self.key, self.extra_args
+            )
             future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
@@ -177,7 +180,8 @@ class TestNonMultipartUpload(BaseUploadTest):
         self.add_put_object_response_with_default_expected_params()
         bytes_io = BytesIO(self.content)
         future = self.manager.upload(
-            bytes_io, self.bucket, self.key, self.extra_args)
+            bytes_io, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
@@ -188,7 +192,8 @@ class TestNonMultipartUpload(BaseUploadTest):
         seek_pos = 5
         bytes_io.seek(seek_pos)
         future = self.manager.upload(
-            bytes_io, self.bucket, self.key, self.extra_args)
+            bytes_io, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assertEqual(b''.join(self.sent_bodies), self.content[seek_pos:])
@@ -197,7 +202,8 @@ class TestNonMultipartUpload(BaseUploadTest):
         self.add_put_object_response_with_default_expected_params()
         body = NonSeekableReader(self.content)
         future = self.manager.upload(
-            body, self.bucket, self.key, self.extra_args)
+            body, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
@@ -205,9 +211,11 @@ class TestNonMultipartUpload(BaseUploadTest):
     def test_sigv4_progress_callbacks_invoked_once(self):
         # Reset the client and manager to use sigv4
         self.reset_stubber_with_new_client(
-            {'config': Config(signature_version='s3v4')})
+            {'config': Config(signature_version='s3v4')}
+        )
         self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
+            'before-parameter-build.s3.*', self.collect_body
+        )
         self._manager = TransferManager(self.client, self.config)
 
         # Add the stubbed response.
@@ -215,7 +223,8 @@ class TestNonMultipartUpload(BaseUploadTest):
 
         subscriber = RecordingSubscriber()
         future = self.manager.upload(
-            self.filename, self.bucket, self.key, subscribers=[subscriber])
+            self.filename, self.bucket, self.key, subscribers=[subscriber]
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
 
@@ -247,7 +256,8 @@ class TestNonMultipartUpload(BaseUploadTest):
         with open(self.filename, 'wb') as f:
             f.write(self.content)
         self.config = TransferConfig(
-            max_request_concurrency=1, max_bandwidth=len(self.content)/2)
+            max_request_concurrency=1, max_bandwidth=len(self.content) / 2
+        )
         self._manager = TransferManager(self.client, self.config)
 
         self.add_put_object_response_with_default_expected_params()
@@ -283,29 +293,30 @@ class TestMultipartUpload(BaseUploadTest):
         super().setUp()
         self.chunksize = 4
         self.config = TransferConfig(
-            max_request_concurrency=1, multipart_threshold=1,
-            multipart_chunksize=self.chunksize)
+            max_request_concurrency=1,
+            multipart_threshold=1,
+            multipart_chunksize=self.chunksize,
+        )
         self._manager = TransferManager(self.client, self.config)
         self.multipart_id = 'my-upload-id'
 
     def create_stubbed_responses(self):
         return [
-            {'method': 'create_multipart_upload',
-             'service_response': {'UploadId': self.multipart_id}},
-            {'method': 'upload_part',
-             'service_response': {'ETag': 'etag-1'}},
-            {'method': 'upload_part',
-             'service_response': {'ETag': 'etag-2'}},
-            {'method': 'upload_part',
-             'service_response': {'ETag': 'etag-3'}},
-            {'method': 'complete_multipart_upload', 'service_response': {}}
+            {
+                'method': 'create_multipart_upload',
+                'service_response': {'UploadId': self.multipart_id},
+            },
+            {'method': 'upload_part', 'service_response': {'ETag': 'etag-1'}},
+            {'method': 'upload_part', 'service_response': {'ETag': 'etag-2'}},
+            {'method': 'upload_part', 'service_response': {'ETag': 'etag-3'}},
+            {'method': 'complete_multipart_upload', 'service_response': {}},
         ]
 
     def create_expected_progress_callback_info(self):
         return [
             {'bytes_transferred': 4},
             {'bytes_transferred': 4},
-            {'bytes_transferred': 2}
+            {'bytes_transferred': 2},
         ]
 
     def assert_upload_part_bodies_were_correct(self):
@@ -319,7 +330,8 @@ class TestMultipartUpload(BaseUploadTest):
         self.assertEqual(self.sent_bodies, expected_contents)
 
     def add_create_multipart_response_with_default_expected_params(
-            self, extra_expected_params=None):
+        self, extra_expected_params=None
+    ):
         expected_params = {'Bucket': self.bucket, 'Key': self.key}
         if extra_expected_params:
             expected_params.update(extra_expected_params)
@@ -328,7 +340,8 @@ class TestMultipartUpload(BaseUploadTest):
         self.stubber.add_response(**response)
 
     def add_upload_part_responses_with_default_expected_params(
-            self, extra_expected_params=None):
+        self, extra_expected_params=None
+    ):
         num_parts = 3
         upload_part_responses = self.create_stubbed_responses()[1:-1]
         for i in range(num_parts):
@@ -346,17 +359,19 @@ class TestMultipartUpload(BaseUploadTest):
             self.stubber.add_response(**upload_part_response)
 
     def add_complete_multipart_response_with_default_expected_params(
-            self, extra_expected_params=None):
+        self, extra_expected_params=None
+    ):
         expected_params = {
             'Bucket': self.bucket,
-            'Key': self.key, 'UploadId': self.multipart_id,
+            'Key': self.key,
+            'UploadId': self.multipart_id,
             'MultipartUpload': {
                 'Parts': [
                     {'ETag': 'etag-1', 'PartNumber': 1},
                     {'ETag': 'etag-2', 'PartNumber': 2},
-                    {'ETag': 'etag-3', 'PartNumber': 3}
+                    {'ETag': 'etag-3', 'PartNumber': 3},
                 ]
-            }
+            },
         }
         if extra_expected_params:
             expected_params.update(extra_expected_params)
@@ -369,14 +384,18 @@ class TestMultipartUpload(BaseUploadTest):
 
         # Add requester pays to the create multipart upload and upload parts.
         self.add_create_multipart_response_with_default_expected_params(
-            extra_expected_params={'RequestPayer': 'requester'})
+            extra_expected_params={'RequestPayer': 'requester'}
+        )
         self.add_upload_part_responses_with_default_expected_params(
-            extra_expected_params={'RequestPayer': 'requester'})
+            extra_expected_params={'RequestPayer': 'requester'}
+        )
         self.add_complete_multipart_response_with_default_expected_params(
-            extra_expected_params={'RequestPayer': 'requester'})
+            extra_expected_params={'RequestPayer': 'requester'}
+        )
 
         future = self.manager.upload(
-            self.filename, self.bucket, self.key, self.extra_args)
+            self.filename, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
 
@@ -386,7 +405,8 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_complete_multipart_response_with_default_expected_params()
         with open(self.filename, 'rb') as f:
             future = self.manager.upload(
-                f, self.bucket, self.key, self.extra_args)
+                f, self.bucket, self.key, self.extra_args
+            )
             future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_upload_part_bodies_were_correct()
@@ -397,7 +417,8 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_complete_multipart_response_with_default_expected_params()
         bytes_io = BytesIO(self.content)
         future = self.manager.upload(
-            bytes_io, self.bucket, self.key, self.extra_args)
+            bytes_io, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_upload_part_bodies_were_correct()
@@ -410,7 +431,8 @@ class TestMultipartUpload(BaseUploadTest):
         seek_pos = 1
         bytes_io.seek(seek_pos)
         future = self.manager.upload(
-            bytes_io, self.bucket, self.key, self.extra_args)
+            bytes_io, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assertEqual(b''.join(self.sent_bodies), self.content[seek_pos:])
@@ -421,7 +443,8 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_complete_multipart_response_with_default_expected_params()
         stream = NonSeekableReader(self.content)
         future = self.manager.upload(
-            stream, self.bucket, self.key, self.extra_args)
+            stream, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assert_upload_part_bodies_were_correct()
@@ -450,7 +473,8 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_complete_multipart_response_with_default_expected_params()
         with open(self.filename, 'rb') as f:
             future = self.manager.upload(
-                f, self.bucket, self.key, self.extra_args)
+                f, self.bucket, self.key, self.extra_args
+            )
             future.result()
 
         # Make sure that the stubber had all of its stubbed responses consumed.
@@ -462,24 +486,19 @@ class TestMultipartUpload(BaseUploadTest):
     def test_upload_failure_invokes_abort(self):
         self.stubber.add_response(
             method='create_multipart_upload',
-            service_response={
-                'UploadId': self.multipart_id
-            },
-            expected_params={
-                'Bucket': self.bucket,
-                'Key': self.key
-            }
+            service_response={'UploadId': self.multipart_id},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         self.stubber.add_response(
             method='upload_part',
-            service_response={
-                'ETag': 'etag-1'
-            },
+            service_response={'ETag': 'etag-1'},
             expected_params={
-                'Bucket': self.bucket, 'Body': ANY,
-                'Key': self.key, 'UploadId': self.multipart_id,
-                'PartNumber': 1
-            }
+                'Bucket': self.bucket,
+                'Body': ANY,
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+                'PartNumber': 1,
+            },
         )
         # With the upload part failing this should immediately initiate
         # an abort multipart with no more upload parts called.
@@ -490,8 +509,9 @@ class TestMultipartUpload(BaseUploadTest):
             service_response={},
             expected_params={
                 'Bucket': self.bucket,
-                'Key': self.key, 'UploadId': self.multipart_id
-            }
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+            },
         )
 
         future = self.manager.upload(self.filename, self.bucket, self.key)
@@ -506,11 +526,13 @@ class TestMultipartUpload(BaseUploadTest):
 
         # Add metadata to expected create multipart upload call
         self.add_create_multipart_response_with_default_expected_params(
-            extra_expected_params={'Metadata': {'foo': 'bar'}})
+            extra_expected_params={'Metadata': {'foo': 'bar'}}
+        )
         self.add_upload_part_responses_with_default_expected_params()
         self.add_complete_multipart_response_with_default_expected_params()
 
         future = self.manager.upload(
-            self.filename, self.bucket, self.key, self.extra_args)
+            self.filename, self.bucket, self.key, self.extra_args
+        )
         future.result()
         self.assert_expected_client_calls_were_correct()

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -15,9 +15,8 @@ import shutil
 import socket
 import tempfile
 
-from tests import unittest
-from tests import skip_if_windows
 from s3transfer.utils import OSUtils
+from tests import skip_if_windows, unittest
 
 
 @skip_if_windows('Windows does not support UNIX special files')

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -14,11 +14,9 @@ import botocore
 import botocore.session
 from botocore.exceptions import WaiterError
 
-from tests import unittest
-from tests import FileCreator
-from tests import random_bucket_name
 from s3transfer.manager import TransferManager
 from s3transfer.subscribers import BaseSubscriber
+from tests import FileCreator, random_bucket_name, unittest
 
 
 def recursive_delete(client, bucket_name):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -58,7 +58,8 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
         cls.bucket_name = random_bucket_name()
         cls.client.create_bucket(
             Bucket=cls.bucket_name,
-            CreateBucketConfiguration={'LocationConstraint': cls.region})
+            CreateBucketConfiguration={'LocationConstraint': cls.region},
+        )
 
     def setUp(self):
         self.files = FileCreator()
@@ -71,9 +72,7 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
         recursive_delete(cls.client, cls.bucket_name)
 
     def delete_object(self, key):
-        self.client.delete_object(
-            Bucket=self.bucket_name,
-            Key=key)
+        self.client.delete_object(Bucket=self.bucket_name, Key=key)
 
     def object_exists(self, key, extra_args=None):
         try:
@@ -87,9 +86,7 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
             extra_args = {}
         try:
             self.client.get_waiter('object_not_exists').wait(
-                Bucket=self.bucket_name,
-                Key=key,
-                **extra_args
+                Bucket=self.bucket_name, Key=key, **extra_args
             )
             return True
         except WaiterError:
@@ -100,9 +97,7 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
             extra_args = {}
         for _ in range(5):
             self.client.get_waiter('object_exists').wait(
-                Bucket=self.bucket_name,
-                Key=key,
-                **extra_args
+                Bucket=self.bucket_name, Key=key, **extra_args
             )
 
     def create_transfer_manager(self, config=None):

--- a/tests/integration/test_copy.py
+++ b/tests/integration/test_copy.py
@@ -17,7 +17,7 @@ from tests.integration import BaseTransferManagerIntegTest
 
 class TestCopy(BaseTransferManagerIntegTest):
     def setUp(self):
-        super(TestCopy, self).setUp()
+        super().setUp()
         self.multipart_threshold = 5 * 1024 * 1024
         self.config = TransferConfig(
             multipart_threshold=self.multipart_threshold)

--- a/tests/integration/test_copy.py
+++ b/tests/integration/test_copy.py
@@ -20,21 +20,21 @@ class TestCopy(BaseTransferManagerIntegTest):
         super().setUp()
         self.multipart_threshold = 5 * 1024 * 1024
         self.config = TransferConfig(
-            multipart_threshold=self.multipart_threshold)
+            multipart_threshold=self.multipart_threshold
+        )
 
     def test_copy_below_threshold(self):
         transfer_manager = self.create_transfer_manager(self.config)
         key = '1mb.txt'
         new_key = '1mb-copy.txt'
 
-        filename = self.files.create_file_with_size(
-            key, filesize=1024 * 1024)
+        filename = self.files.create_file_with_size(key, filesize=1024 * 1024)
         self.upload_file(filename, key)
 
         future = transfer_manager.copy(
             copy_source={'Bucket': self.bucket_name, 'Key': key},
             bucket=self.bucket_name,
-            key=new_key
+            key=new_key,
         )
 
         future.result()
@@ -46,13 +46,14 @@ class TestCopy(BaseTransferManagerIntegTest):
         new_key = '20mb-copy.txt'
 
         filename = self.files.create_file_with_size(
-            key, filesize=20 * 1024 * 1024)
+            key, filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, key)
 
         future = transfer_manager.copy(
             copy_source={'Bucket': self.bucket_name, 'Key': key},
             bucket=self.bucket_name,
-            key=new_key
+            key=new_key,
         )
 
         future.result()
@@ -65,14 +66,15 @@ class TestCopy(BaseTransferManagerIntegTest):
         new_key = '20mb-copy.txt'
 
         filename = self.files.create_file_with_size(
-            key, filesize=20 * 1024 * 1024)
+            key, filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, key)
 
         future = transfer_manager.copy(
             copy_source={'Bucket': self.bucket_name, 'Key': key},
             bucket=self.bucket_name,
             key=new_key,
-            subscribers=[subscriber]
+            subscribers=[subscriber],
         )
 
         future.result()

--- a/tests/integration/test_copy.py
+++ b/tests/integration/test_copy.py
@@ -10,9 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from s3transfer.manager import TransferConfig
 from tests import RecordingSubscriber
 from tests.integration import BaseTransferManagerIntegTest
-from s3transfer.manager import TransferConfig
 
 
 class TestCopy(BaseTransferManagerIntegTest):

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -10,19 +10,18 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
 import glob
-from s3transfer.utils import OSUtils
-
-from tests.integration import BaseTransferManagerIntegTest
-from tests import assert_files_equal
+import os
 
 from s3transfer.subscribers import BaseSubscriber
-from tests import requires_crt, HAS_CRT
+from s3transfer.utils import OSUtils
+from tests import HAS_CRT, assert_files_equal, requires_crt
+from tests.integration import BaseTransferManagerIntegTest
 
 if HAS_CRT:
-    import s3transfer.crt
     from awscrt.exceptions import AwsCrtError
+
+    import s3transfer.crt
 
 
 class RecordingSubscriber(BaseSubscriber):

--- a/tests/integration/test_delete.py
+++ b/tests/integration/test_delete.py
@@ -14,16 +14,15 @@ from tests.integration import BaseTransferManagerIntegTest
 
 
 class TestDeleteObject(BaseTransferManagerIntegTest):
-
     def test_can_delete_object(self):
         key_name = 'mykey'
-        self.client.put_object(Bucket=self.bucket_name,
-                               Key=key_name, Body=b'hello world')
+        self.client.put_object(
+            Bucket=self.bucket_name, Key=key_name, Body=b'hello world'
+        )
         self.assertTrue(self.object_exists(key_name))
 
         transfer_manager = self.create_transfer_manager()
-        future = transfer_manager.delete(bucket=self.bucket_name,
-                                         key=key_name)
+        future = transfer_manager.delete(bucket=self.bucket_name, key=key_name)
         future.result()
 
         self.assertTrue(self.object_not_exists(key_name))

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -12,19 +12,22 @@
 # language governing permissions and limitations under the License.
 import glob
 import os
-import time
 import threading
-
+import time
 from concurrent.futures import CancelledError
 
-from tests import assert_files_equal
-from tests import skip_if_windows
-from tests import skip_if_using_serial_implementation
-from tests import RecordingSubscriber
-from tests import NonSeekableWriter
-from tests.integration import BaseTransferManagerIntegTest
-from tests.integration import WaitForTransferStart
 from s3transfer.manager import TransferConfig
+from tests import (
+    NonSeekableWriter,
+    RecordingSubscriber,
+    assert_files_equal,
+    skip_if_using_serial_implementation,
+    skip_if_windows,
+)
+from tests.integration import (
+    BaseTransferManagerIntegTest,
+    WaitForTransferStart,
+)
 
 
 class TestDownload(BaseTransferManagerIntegTest):

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -32,7 +32,7 @@ from tests.integration import (
 
 class TestDownload(BaseTransferManagerIntegTest):
     def setUp(self):
-        super(TestDownload, self).setUp()
+        super().setUp()
         self.multipart_threshold = 5 * 1024 * 1024
         self.config = TransferConfig(
             multipart_threshold=self.multipart_threshold
@@ -106,7 +106,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         actual_time_to_exit = end_time - start_time
         self.assertLess(
             actual_time_to_exit, max_allowed_exit_time,
-            "Failed to exit under %s. Instead exited in %s." % (
+            "Failed to exit under {}. Instead exited in {}.".format(
                 max_allowed_exit_time, actual_time_to_exit)
         )
 
@@ -160,7 +160,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         max_allowed_exit_time = 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
-            "Failed to exit under %s. Instead exited in %s." % (
+            "Failed to exit under {}. Instead exited in {}.".format(
                 max_allowed_exit_time, end_time - start_time)
         )
 

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -42,12 +42,14 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '1mb.txt')
         future = transfer_manager.download(
-            self.bucket_name, '1mb.txt', download_path)
+            self.bucket_name, '1mb.txt', download_path
+        )
         future.result()
         assert_files_equal(filename, download_path)
 
@@ -55,12 +57,14 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, '20mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '20mb.txt')
         future = transfer_manager.download(
-            self.bucket_name, '20mb.txt', download_path)
+            self.bucket_name, '20mb.txt', download_path
+        )
         future.result()
         assert_files_equal(filename, download_path)
 
@@ -74,7 +78,8 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=60 * 1024 * 1024)
+            'foo.txt', filesize=60 * 1024 * 1024
+        )
         self.upload_file(filename, '60mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '60mb.txt')
@@ -84,14 +89,17 @@ class TestDownload(BaseTransferManagerIntegTest):
         try:
             with transfer_manager:
                 future = transfer_manager.download(
-                    self.bucket_name, '60mb.txt', download_path,
-                    subscribers=[subscriber]
+                    self.bucket_name,
+                    '60mb.txt',
+                    download_path,
+                    subscribers=[subscriber],
                 )
                 if not bytes_transferring.wait(timeout):
                     future.cancel()
                     raise RuntimeError(
                         "Download transfer did not start after waiting for "
-                        "%s seconds." % timeout)
+                        "%s seconds." % timeout
+                    )
                 # Raise an exception which should cause the preceding
                 # download to cancel and exit quickly
                 start_time = time.time()
@@ -105,9 +113,11 @@ class TestDownload(BaseTransferManagerIntegTest):
         max_allowed_exit_time = 5
         actual_time_to_exit = end_time - start_time
         self.assertLess(
-            actual_time_to_exit, max_allowed_exit_time,
+            actual_time_to_exit,
+            max_allowed_exit_time,
             "Failed to exit under {}. Instead exited in {}.".format(
-                max_allowed_exit_time, actual_time_to_exit)
+                max_allowed_exit_time, actual_time_to_exit
+            ),
         )
 
         # Make sure the future was cancelled because of the KeyboardInterrupt
@@ -134,21 +144,24 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
 
         filenames = []
         futures = []
         for i in range(10):
-            filenames.append(
-                os.path.join(self.files.rootdir, 'file'+str(i)))
+            filenames.append(os.path.join(self.files.rootdir, 'file' + str(i)))
 
         try:
             with transfer_manager:
                 start_time = time.time()
                 for filename in filenames:
-                    futures.append(transfer_manager.download(
-                        self.bucket_name, '1mb.txt', filename))
+                    futures.append(
+                        transfer_manager.download(
+                            self.bucket_name, '1mb.txt', filename
+                        )
+                    )
                 # Raise an exception which should cause the preceding
                 # transfer to cancel and exit quickly
                 raise KeyboardInterrupt()
@@ -159,9 +172,11 @@ class TestDownload(BaseTransferManagerIntegTest):
         # This means that it should take less than a couple seconds to exit.
         max_allowed_exit_time = 5
         self.assertLess(
-            end_time - start_time, max_allowed_exit_time,
+            end_time - start_time,
+            max_allowed_exit_time,
             "Failed to exit under {}. Instead exited in {}.".format(
-                max_allowed_exit_time, end_time - start_time)
+                max_allowed_exit_time, end_time - start_time
+            ),
         )
 
         # Make sure at least one of the futures got cancelled
@@ -179,14 +194,18 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, '20mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '20mb.txt')
 
         future = transfer_manager.download(
-            self.bucket_name, '20mb.txt', download_path,
-            subscribers=[subscriber])
+            self.bucket_name,
+            '20mb.txt',
+            download_path,
+            subscribers=[subscriber],
+        )
         future.result()
         self.assertEqual(subscriber.calculate_bytes_seen(), 20 * 1024 * 1024)
 
@@ -194,13 +213,13 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '1mb.txt')
         with open(download_path, 'wb') as f:
-            future = transfer_manager.download(
-                self.bucket_name, '1mb.txt', f)
+            future = transfer_manager.download(self.bucket_name, '1mb.txt', f)
             future.result()
         assert_files_equal(filename, download_path)
 
@@ -208,13 +227,13 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, '20mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '20mb.txt')
         with open(download_path, 'wb') as f:
-            future = transfer_manager.download(
-                self.bucket_name, '20mb.txt', f)
+            future = transfer_manager.download(self.bucket_name, '20mb.txt', f)
             future.result()
         assert_files_equal(filename, download_path)
 
@@ -222,13 +241,15 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '1mb.txt')
         with open(download_path, 'wb') as f:
             future = transfer_manager.download(
-                self.bucket_name, '1mb.txt', NonSeekableWriter(f))
+                self.bucket_name, '1mb.txt', NonSeekableWriter(f)
+            )
             future.result()
         assert_files_equal(filename, download_path)
 
@@ -236,13 +257,15 @@ class TestDownload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, '20mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '20mb.txt')
         with open(download_path, 'wb') as f:
             future = transfer_manager.download(
-                self.bucket_name, '20mb.txt', NonSeekableWriter(f))
+                self.bucket_name, '20mb.txt', NonSeekableWriter(f)
+            )
             future.result()
         assert_files_equal(filename, download_path)
 
@@ -250,13 +273,16 @@ class TestDownload(BaseTransferManagerIntegTest):
     def test_download_to_special_file(self):
         transfer_manager = self.create_transfer_manager(self.config)
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
         future = transfer_manager.download(
-            self.bucket_name, '1mb.txt', '/dev/null')
+            self.bucket_name, '1mb.txt', '/dev/null'
+        )
         try:
             future.result()
         except Exception as e:
             self.fail(
                 'Should have been able to download to /dev/null but received '
-                'following exception %s' % e)
+                'following exception %s' % e
+            )

--- a/tests/integration/test_processpool.py
+++ b/tests/integration/test_processpool.py
@@ -34,37 +34,43 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         if config is None:
             config = self.config
         return ProcessPoolDownloader(
-            client_kwargs=client_kwargs, config=config)
+            client_kwargs=client_kwargs, config=config
+        )
 
     def test_below_threshold(self):
         downloader = self.create_process_pool_downloader()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '1mb.txt')
         with downloader:
             downloader.download_file(
-                self.bucket_name, '1mb.txt', download_path)
+                self.bucket_name, '1mb.txt', download_path
+            )
         assert_files_equal(filename, download_path)
 
     def test_above_threshold(self):
         downloader = self.create_process_pool_downloader()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, '20mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '20mb.txt')
         with downloader:
             downloader.download_file(
-                self.bucket_name, '20mb.txt', download_path)
+                self.bucket_name, '20mb.txt', download_path
+            )
         assert_files_equal(filename, download_path)
 
     def test_large_download_exits_quickly_on_exception(self):
         downloader = self.create_process_pool_downloader()
 
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=60 * 1024 * 1024)
+            'foo.txt', filesize=60 * 1024 * 1024
+        )
         self.upload_file(filename, '60mb.txt')
 
         download_path = os.path.join(self.files.rootdir, '60mb.txt')
@@ -72,7 +78,8 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         try:
             with downloader:
                 downloader.download_file(
-                    self.bucket_name, '60mb.txt', download_path)
+                    self.bucket_name, '60mb.txt', download_path
+                )
                 # Sleep for a little to get the transfer process going
                 time.sleep(sleep_time)
                 # Raise an exception which should cause the preceding
@@ -87,9 +94,11 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         # sleeping to exit.
         max_allowed_exit_time = 5
         self.assertLess(
-            end_time - start_time, max_allowed_exit_time,
+            end_time - start_time,
+            max_allowed_exit_time,
             "Failed to exit under {}. Instead exited in {}.".format(
-                max_allowed_exit_time, end_time - start_time)
+                max_allowed_exit_time, end_time - start_time
+            ),
         )
 
         # Make sure the actual file and the temporary do not exist
@@ -101,7 +110,8 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         downloader = self.create_process_pool_downloader()
 
         filename = self.files.create_file_with_size(
-            '1mb.txt', filesize=1024 * 1024)
+            '1mb.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
 
         filenames = []
@@ -114,7 +124,8 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
                 start_time = time.time()
                 for filename in filenames:
                     downloader.download_file(
-                        self.bucket_name, '1mb.txt', filename)
+                        self.bucket_name, '1mb.txt', filename
+                    )
                 # Raise an exception which should cause the preceding
                 # transfer to cancel and exit quickly
                 raise KeyboardInterrupt()
@@ -125,9 +136,11 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         # This means that it should take less than a couple seconds to exit.
         max_allowed_exit_time = 5
         self.assertLess(
-            end_time - start_time, max_allowed_exit_time,
+            end_time - start_time,
+            max_allowed_exit_time,
             "Failed to exit under {}. Instead exited in {}.".format(
-                max_allowed_exit_time, end_time - start_time)
+                max_allowed_exit_time, end_time - start_time
+            ),
         )
 
         # For the transfer that did get cancelled, make sure the temporary

--- a/tests/integration/test_processpool.py
+++ b/tests/integration/test_processpool.py
@@ -14,10 +14,9 @@ import glob
 import os
 import time
 
+from s3transfer.processpool import ProcessPoolDownloader, ProcessTransferConfig
 from tests import assert_files_equal
 from tests.integration import BaseTransferManagerIntegTest
-from s3transfer.processpool import ProcessTransferConfig
-from s3transfer.processpool import ProcessPoolDownloader
 
 
 class TestProcessPoolDownloader(BaseTransferManagerIntegTest):

--- a/tests/integration/test_processpool.py
+++ b/tests/integration/test_processpool.py
@@ -21,7 +21,7 @@ from tests.integration import BaseTransferManagerIntegTest
 
 class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
     def setUp(self):
-        super(TestProcessPoolDownloader, self).setUp()
+        super().setUp()
         self.multipart_threshold = 5 * 1024 * 1024
         self.config = ProcessTransferConfig(
             multipart_threshold=self.multipart_threshold
@@ -88,7 +88,7 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         max_allowed_exit_time = 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
-            "Failed to exit under %s. Instead exited in %s." % (
+            "Failed to exit under {}. Instead exited in {}.".format(
                 max_allowed_exit_time, end_time - start_time)
         )
 
@@ -126,7 +126,7 @@ class TestProcessPoolDownloader(BaseTransferManagerIntegTest):
         max_allowed_exit_time = 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
-            "Failed to exit under %s. Instead exited in %s." % (
+            "Failed to exit under {}. Instead exited in {}.".format(
                 max_allowed_exit_time, end_time - start_time)
         )
 

--- a/tests/integration/test_s3transfer.py
+++ b/tests/integration/test_s3transfer.py
@@ -10,20 +10,19 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
-import threading
-import math
-import tempfile
-import shutil
 import hashlib
+import math
+import os
+import shutil
 import string
+import tempfile
+import threading
 
-from tests.integration import BaseTransferManagerIntegTest
-from botocore.compat import six
 from botocore.client import Config
+from botocore.compat import six
 
 import s3transfer
-
+from tests.integration import BaseTransferManagerIntegTest
 
 urlopen = six.moves.urllib.request.urlopen
 

--- a/tests/integration/test_s3transfer.py
+++ b/tests/integration/test_s3transfer.py
@@ -19,22 +19,19 @@ import tempfile
 import threading
 
 from botocore.client import Config
-from botocore.compat import six
 
 import s3transfer
 from tests.integration import BaseTransferManagerIntegTest
 
-urlopen = six.moves.urllib.request.urlopen
-
 
 def assert_files_equal(first, second):
     if os.path.getsize(first) != os.path.getsize(second):
-        raise AssertionError("Files are not equal: %s, %s" % (first, second))
+        raise AssertionError(f"Files are not equal: {first}, {second}")
     first_md5 = md5_checksum(first)
     second_md5 = md5_checksum(second)
     if first_md5 != second_md5:
         raise AssertionError(
-            "Files are not equal: %s(md5=%s) != %s(md5=%s)" % (
+            "Files are not equal: {}(md5={}) != {}(md5={})".format(
                 first, first_md5, second, second_md5))
 
 
@@ -52,7 +49,7 @@ def random_bucket_name(prefix='boto3-transfer', num_chars=10):
     return prefix + ''.join([base[b % len(base)] for b in random_bytes])
 
 
-class FileCreator(object):
+class FileCreator:
     def __init__(self):
         self.rootdir = tempfile.mkdtemp()
 

--- a/tests/integration/test_s3transfer.py
+++ b/tests/integration/test_s3transfer.py
@@ -32,7 +32,9 @@ def assert_files_equal(first, second):
     if first_md5 != second_md5:
         raise AssertionError(
             "Files are not equal: {}(md5={}) != {}(md5={})".format(
-                first, first_md5, second, second_md5))
+                first, first_md5, second, second_md5
+            )
+        )
 
 
 def md5_checksum(filename):
@@ -103,53 +105,54 @@ class TestS3Transfers(BaseTransferManagerIntegTest):
     """Tests for the high level s3transfer module."""
 
     def create_s3_transfer(self, config=None):
-        return s3transfer.S3Transfer(
-            self.client, config=config
-        )
+        return s3transfer.S3Transfer(self.client, config=config)
 
     def assert_has_public_read_acl(self, response):
         grants = response['Grants']
-        public_read = [g['Grantee'].get('URI', '') for g in grants
-                       if g['Permission'] == 'READ']
+        public_read = [
+            g['Grantee'].get('URI', '')
+            for g in grants
+            if g['Permission'] == 'READ'
+        ]
         self.assertIn('groups/global/AllUsers', public_read[0])
 
     def test_upload_below_threshold(self):
-        config = s3transfer.TransferConfig(
-            multipart_threshold=2 * 1024 * 1024)
+        config = s3transfer.TransferConfig(multipart_threshold=2 * 1024 * 1024)
         transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
-        transfer.upload_file(filename, self.bucket_name,
-                             'foo.txt')
+            'foo.txt', filesize=1024 * 1024
+        )
+        transfer.upload_file(filename, self.bucket_name, 'foo.txt')
         self.addCleanup(self.delete_object, 'foo.txt')
 
         self.assertTrue(self.object_exists('foo.txt'))
 
     def test_upload_above_threshold(self):
-        config = s3transfer.TransferConfig(
-            multipart_threshold=2 * 1024 * 1024)
+        config = s3transfer.TransferConfig(multipart_threshold=2 * 1024 * 1024)
         transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=20 * 1024 * 1024)
-        transfer.upload_file(filename, self.bucket_name,
-                             '20mb.txt')
+            '20mb.txt', filesize=20 * 1024 * 1024
+        )
+        transfer.upload_file(filename, self.bucket_name, '20mb.txt')
         self.addCleanup(self.delete_object, '20mb.txt')
         self.assertTrue(self.object_exists('20mb.txt'))
 
     def test_upload_file_above_threshold_with_acl(self):
-        config = s3transfer.TransferConfig(
-            multipart_threshold=5 * 1024 * 1024)
+        config = s3transfer.TransferConfig(multipart_threshold=5 * 1024 * 1024)
         transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
-            '6mb.txt', filesize=6 * 1024 * 1024)
+            '6mb.txt', filesize=6 * 1024 * 1024
+        )
         extra_args = {'ACL': 'public-read'}
-        transfer.upload_file(filename, self.bucket_name,
-                             '6mb.txt', extra_args=extra_args)
+        transfer.upload_file(
+            filename, self.bucket_name, '6mb.txt', extra_args=extra_args
+        )
         self.addCleanup(self.delete_object, '6mb.txt')
 
         self.assertTrue(self.object_exists('6mb.txt'))
         response = self.client.get_object_acl(
-            Bucket=self.bucket_name, Key='6mb.txt')
+            Bucket=self.bucket_name, Key='6mb.txt'
+        )
         self.assert_has_public_read_acl(response)
 
     def test_upload_file_above_threshold_with_ssec(self):
@@ -158,21 +161,22 @@ class TestS3Transfers(BaseTransferManagerIntegTest):
             'SSECustomerKey': key_bytes,
             'SSECustomerAlgorithm': 'AES256',
         }
-        config = s3transfer.TransferConfig(
-            multipart_threshold=5 * 1024 * 1024)
+        config = s3transfer.TransferConfig(multipart_threshold=5 * 1024 * 1024)
         transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
-            '6mb.txt', filesize=6 * 1024 * 1024)
-        transfer.upload_file(filename, self.bucket_name,
-                             '6mb.txt', extra_args=extra_args)
+            '6mb.txt', filesize=6 * 1024 * 1024
+        )
+        transfer.upload_file(
+            filename, self.bucket_name, '6mb.txt', extra_args=extra_args
+        )
         self.addCleanup(self.delete_object, '6mb.txt')
         self.wait_object_exists('6mb.txt', extra_args)
         # A head object will fail if it has a customer key
         # associated with it and it's not provided in the HeadObject
         # request so we can use this to verify our functionality.
         response = self.client.head_object(
-            Bucket=self.bucket_name,
-            Key='6mb.txt', **extra_args)
+            Bucket=self.bucket_name, Key='6mb.txt', **extra_args
+        )
         self.assertEqual(response['SSECustomerAlgorithm'], 'AES256')
 
     def test_progress_callback_on_upload(self):
@@ -185,9 +189,11 @@ class TestS3Transfers(BaseTransferManagerIntegTest):
 
         transfer = self.create_s3_transfer()
         filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=20 * 1024 * 1024)
-        transfer.upload_file(filename, self.bucket_name,
-                             '20mb.txt', callback=progress_callback)
+            '20mb.txt', filesize=20 * 1024 * 1024
+        )
+        transfer.upload_file(
+            filename, self.bucket_name, '20mb.txt', callback=progress_callback
+        )
         self.addCleanup(self.delete_object, '20mb.txt')
 
         # The callback should have been called enough times such that
@@ -207,13 +213,15 @@ class TestS3Transfers(BaseTransferManagerIntegTest):
                 self.amount_seen += amount
 
         client = self.session.create_client(
-            's3', self.region,
-            config=Config(signature_version='s3v4'))
+            's3', self.region, config=Config(signature_version='s3v4')
+        )
         transfer = s3transfer.S3Transfer(client)
         filename = self.files.create_file_with_size(
-            '10mb.txt', filesize=10 * 1024 * 1024)
-        transfer.upload_file(filename, self.bucket_name,
-                             '10mb.txt', callback=progress_callback)
+            '10mb.txt', filesize=10 * 1024 * 1024
+        )
+        transfer.upload_file(
+            filename, self.bucket_name, '10mb.txt', callback=progress_callback
+        )
         self.addCleanup(self.delete_object, '10mb.txt')
 
         self.assertEqual(self.amount_seen, 10 * 1024 * 1024)
@@ -221,24 +229,27 @@ class TestS3Transfers(BaseTransferManagerIntegTest):
     def test_can_send_extra_params_on_upload(self):
         transfer = self.create_s3_transfer()
         filename = self.files.create_file_with_size('foo.txt', filesize=1024)
-        transfer.upload_file(filename, self.bucket_name,
-                             'foo.txt', extra_args={'ACL': 'public-read'})
+        transfer.upload_file(
+            filename,
+            self.bucket_name,
+            'foo.txt',
+            extra_args={'ACL': 'public-read'},
+        )
         self.addCleanup(self.delete_object, 'foo.txt')
 
         self.wait_object_exists('foo.txt')
         response = self.client.get_object_acl(
-            Bucket=self.bucket_name, Key='foo.txt')
+            Bucket=self.bucket_name, Key='foo.txt'
+        )
         self.assert_has_public_read_acl(response)
 
     def test_can_configure_threshold(self):
-        config = s3transfer.TransferConfig(
-            multipart_threshold=6 * 1024 * 1024
-        )
+        config = s3transfer.TransferConfig(multipart_threshold=6 * 1024 * 1024)
         transfer = self.create_s3_transfer(config)
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=8 * 1024 * 1024)
-        transfer.upload_file(filename, self.bucket_name,
-                             'foo.txt')
+            'foo.txt', filesize=8 * 1024 * 1024
+        )
+        transfer.upload_file(filename, self.bucket_name, 'foo.txt')
         self.addCleanup(self.delete_object, 'foo.txt')
 
         self.assertTrue(self.object_exists('foo.txt'))
@@ -257,8 +268,9 @@ class TestS3Transfers(BaseTransferManagerIntegTest):
         transfer = self.create_s3_transfer()
 
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
-        transfer.download_file(self.bucket_name, 'foo.txt',
-                               download_path, extra_args=extra_args)
+        transfer.download_file(
+            self.bucket_name, 'foo.txt', download_path, extra_args=extra_args
+        )
         with open(download_path, 'rb') as f:
             self.assertEqual(f.read(), b'hello world')
 
@@ -272,33 +284,38 @@ class TestS3Transfers(BaseTransferManagerIntegTest):
 
         transfer = self.create_s3_transfer()
         filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=20 * 1024 * 1024)
+            '20mb.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, '20mb.txt')
 
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
-        transfer.download_file(self.bucket_name, '20mb.txt',
-                               download_path, callback=progress_callback)
+        transfer.download_file(
+            self.bucket_name,
+            '20mb.txt',
+            download_path,
+            callback=progress_callback,
+        )
 
         self.assertEqual(self.amount_seen, 20 * 1024 * 1024)
 
     def test_download_below_threshold(self):
         transfer = self.create_s3_transfer()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, 'foo.txt')
 
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
-        transfer.download_file(self.bucket_name, 'foo.txt',
-                               download_path)
+        transfer.download_file(self.bucket_name, 'foo.txt', download_path)
         assert_files_equal(filename, download_path)
 
     def test_download_above_threshold(self):
         transfer = self.create_s3_transfer()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, 'foo.txt')
 
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
-        transfer.download_file(self.bucket_name, 'foo.txt',
-                               download_path)
+        transfer.download_file(self.bucket_name, 'foo.txt', download_path)
         assert_files_equal(filename, download_path)

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -32,7 +32,8 @@ class TestUpload(BaseTransferManagerIntegTest):
         super().setUp()
         self.multipart_threshold = 5 * 1024 * 1024
         self.config = TransferConfig(
-            multipart_threshold=self.multipart_threshold)
+            multipart_threshold=self.multipart_threshold
+        )
 
     def get_input_fileobj(self, size, name=''):
         return self.files.create_file_with_size(name, size)
@@ -49,8 +50,7 @@ class TestUpload(BaseTransferManagerIntegTest):
     def test_upload_above_threshold(self):
         transfer_manager = self.create_transfer_manager(self.config)
         file = self.get_input_fileobj(size=20 * 1024 * 1024, name='20mb.txt')
-        future = transfer_manager.upload(
-            file, self.bucket_name, '20mb.txt')
+        future = transfer_manager.upload(file, self.bucket_name, '20mb.txt')
         self.addCleanup(self.delete_object, '20mb.txt')
 
         future.result()
@@ -66,7 +66,8 @@ class TestUpload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
 
         filename = self.get_input_fileobj(
-            name='foo.txt', size=20 * 1024 * 1024)
+            name='foo.txt', size=20 * 1024 * 1024
+        )
 
         timeout = 10
         bytes_transferring = threading.Event()
@@ -74,14 +75,17 @@ class TestUpload(BaseTransferManagerIntegTest):
         try:
             with transfer_manager:
                 future = transfer_manager.upload(
-                    filename, self.bucket_name, '20mb.txt',
-                    subscribers=[subscriber]
+                    filename,
+                    self.bucket_name,
+                    '20mb.txt',
+                    subscribers=[subscriber],
                 )
                 if not bytes_transferring.wait(timeout):
                     future.cancel()
                     raise RuntimeError(
                         "Download transfer did not start after waiting for "
-                        "%s seconds." % timeout)
+                        "%s seconds." % timeout
+                    )
                 # Raise an exception which should cause the preceding
                 # download to cancel and exit quickly
                 start_time = time.time()
@@ -95,16 +99,19 @@ class TestUpload(BaseTransferManagerIntegTest):
         max_allowed_exit_time = 5
         actual_time_to_exit = end_time - start_time
         self.assertLess(
-            actual_time_to_exit, max_allowed_exit_time,
+            actual_time_to_exit,
+            max_allowed_exit_time,
             "Failed to exit under {}. Instead exited in {}.".format(
-                max_allowed_exit_time, actual_time_to_exit)
+                max_allowed_exit_time, actual_time_to_exit
+            ),
         )
 
         try:
             future.result()
             self.skipTest(
                 'Upload completed before interrupted and therefore '
-                'could not cancel the upload')
+                'could not cancel the upload'
+            )
         except CancelledError as e:
             self.assertEqual(str(e), 'KeyboardInterrupt()')
             # If the transfer did get cancelled,
@@ -132,13 +139,17 @@ class TestUpload(BaseTransferManagerIntegTest):
             filename = 'file' + str(i)
             keynames.append(filename)
             fileobjs.append(
-                self.get_input_fileobj(name=filename, size=1024 * 1024))
+                self.get_input_fileobj(name=filename, size=1024 * 1024)
+            )
 
         try:
             with transfer_manager:
                 for i, fileobj in enumerate(fileobjs):
-                    futures.append(transfer_manager.upload(
-                        fileobj, self.bucket_name, keynames[i]))
+                    futures.append(
+                        transfer_manager.upload(
+                            fileobj, self.bucket_name, keynames[i]
+                        )
+                    )
                 # Raise an exception which should cause the preceding
                 # transfer to cancel and exit quickly
                 start_time = time.time()
@@ -150,9 +161,11 @@ class TestUpload(BaseTransferManagerIntegTest):
         # This means that it should take less than a couple seconds to exit.
         max_allowed_exit_time = 5
         self.assertLess(
-            end_time - start_time, max_allowed_exit_time,
+            end_time - start_time,
+            max_allowed_exit_time,
             "Failed to exit under {}. Instead exited in {}.".format(
-                max_allowed_exit_time, end_time - start_time)
+                max_allowed_exit_time, end_time - start_time
+            ),
         )
 
         # Make sure at least one of the futures got cancelled
@@ -168,8 +181,8 @@ class TestUpload(BaseTransferManagerIntegTest):
         transfer_manager = self.create_transfer_manager(self.config)
         file = self.get_input_fileobj(size=20 * 1024 * 1024, name='20mb.txt')
         future = transfer_manager.upload(
-            file, self.bucket_name, '20mb.txt',
-            subscribers=[subscriber])
+            file, self.bucket_name, '20mb.txt', subscribers=[subscriber]
+        )
         self.addCleanup(self.delete_object, '20mb.txt')
 
         future.result()

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -10,17 +10,22 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import time
 import threading
-
+import time
 from concurrent.futures import CancelledError
 
 from botocore.compat import six
-from tests import skip_if_using_serial_implementation
-from tests import RecordingSubscriber, NonSeekableReader
-from tests.integration import BaseTransferManagerIntegTest
-from tests.integration import WaitForTransferStart
+
 from s3transfer.manager import TransferConfig
+from tests import (
+    NonSeekableReader,
+    RecordingSubscriber,
+    skip_if_using_serial_implementation,
+)
+from tests.integration import (
+    BaseTransferManagerIntegTest,
+    WaitForTransferStart,
+)
 
 
 class TestUpload(BaseTransferManagerIntegTest):

--- a/tests/integration/test_upload.py
+++ b/tests/integration/test_upload.py
@@ -13,8 +13,7 @@
 import threading
 import time
 from concurrent.futures import CancelledError
-
-from botocore.compat import six
+from io import BytesIO
 
 from s3transfer.manager import TransferConfig
 from tests import (
@@ -30,7 +29,7 @@ from tests.integration import (
 
 class TestUpload(BaseTransferManagerIntegTest):
     def setUp(self):
-        super(TestUpload, self).setUp()
+        super().setUp()
         self.multipart_threshold = 5 * 1024 * 1024
         self.config = TransferConfig(
             multipart_threshold=self.multipart_threshold)
@@ -97,7 +96,7 @@ class TestUpload(BaseTransferManagerIntegTest):
         actual_time_to_exit = end_time - start_time
         self.assertLess(
             actual_time_to_exit, max_allowed_exit_time,
-            "Failed to exit under %s. Instead exited in %s." % (
+            "Failed to exit under {}. Instead exited in {}.".format(
                 max_allowed_exit_time, actual_time_to_exit)
         )
 
@@ -152,7 +151,7 @@ class TestUpload(BaseTransferManagerIntegTest):
         max_allowed_exit_time = 5
         self.assertLess(
             end_time - start_time, max_allowed_exit_time,
-            "Failed to exit under %s. Instead exited in %s." % (
+            "Failed to exit under {}. Instead exited in {}.".format(
                 max_allowed_exit_time, end_time - start_time)
         )
 
@@ -183,7 +182,7 @@ class TestUpload(BaseTransferManagerIntegTest):
 
 class TestUploadSeekableStream(TestUpload):
     def get_input_fileobj(self, size, name=''):
-        return six.BytesIO(b'0' * size)
+        return BytesIO(b'0' * size)
 
 
 class TestUploadNonSeekableStream(TestUpload):

--- a/tests/unit/test_bandwidth.py
+++ b/tests/unit/test_bandwidth.py
@@ -51,10 +51,7 @@ class TestTimeUtils(unittest.TestCase):
     def test_sleep(self, mock_sleep):
         time_utils = TimeUtils()
         time_utils.sleep(1)
-        self.assertEqual(
-            mock_sleep.call_args_list,
-            [mock.call(1)]
-        )
+        self.assertEqual(mock_sleep.call_args_list, [mock.call(1)])
 
 
 class BaseBandwidthLimitTest(unittest.TestCase):
@@ -72,12 +69,9 @@ class BaseBandwidthLimitTest(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
     def assert_consume_calls(self, amts):
-        expected_consume_args = [
-            mock.call(amt, mock.ANY) for amt in amts
-        ]
+        expected_consume_args = [mock.call(amt, mock.ANY) for amt in amts]
         self.assertEqual(
-            self.leaky_bucket.consume.call_args_list,
-            expected_consume_args
+            self.leaky_bucket.consume.call_args_list, expected_consume_args
         )
 
 
@@ -89,7 +83,8 @@ class TestBandwidthLimiter(BaseBandwidthLimitTest):
     def test_get_bandwidth_limited_stream(self):
         with open(self.filename, 'rb') as f:
             stream = self.bandwidth_limiter.get_bandwith_limited_stream(
-                f, self.coordinator)
+                f, self.coordinator
+            )
             self.assertIsInstance(stream, BandwidthLimitedStream)
             self.assertEqual(stream.read(len(self.content)), self.content)
             self.assert_consume_calls(amts=[len(self.content)])
@@ -97,7 +92,8 @@ class TestBandwidthLimiter(BaseBandwidthLimitTest):
     def test_get_disabled_bandwidth_limited_stream(self):
         with open(self.filename, 'rb') as f:
             stream = self.bandwidth_limiter.get_bandwith_limited_stream(
-                f, self.coordinator, enabled=False)
+                f, self.coordinator, enabled=False
+            )
             self.assertIsInstance(stream, BandwidthLimitedStream)
             self.assertEqual(stream.read(len(self.content)), self.content)
             self.leaky_bucket.consume.assert_not_called()
@@ -113,22 +109,23 @@ class TestBandwidthLimitedStream(BaseBandwidthLimitTest):
 
     def get_bandwidth_limited_stream(self, f):
         return BandwidthLimitedStream(
-            f, self.leaky_bucket, self.coordinator, self.time_utils,
-            self.bytes_threshold)
+            f,
+            self.leaky_bucket,
+            self.coordinator,
+            self.time_utils,
+            self.bytes_threshold,
+        )
 
     def assert_sleep_calls(self, amts):
-        expected_sleep_args_list = [
-            mock.call(amt) for amt in amts
-        ]
+        expected_sleep_args_list = [mock.call(amt) for amt in amts]
         self.assertEqual(
-            self.time_utils.sleep.call_args_list,
-            expected_sleep_args_list
+            self.time_utils.sleep.call_args_list, expected_sleep_args_list
         )
 
     def get_unique_consume_request_tokens(self):
         return {
-            call_args[0][1] for call_args in
-            self.leaky_bucket.consume.call_args_list
+            call_args[0][1]
+            for call_args in self.leaky_bucket.consume.call_args_list
         }
 
     def test_read(self):
@@ -146,7 +143,7 @@ class TestBandwidthLimitedStream(BaseBandwidthLimitTest):
             amt_requested = len(self.content)
             self.leaky_bucket.consume.side_effect = [
                 RequestExceededException(amt_requested, retry_time),
-                len(self.content)
+                len(self.content),
             ]
             data = stream.read(len(self.content))
             self.assertEqual(self.content, data)
@@ -184,38 +181,26 @@ class TestBandwidthLimitedStream(BaseBandwidthLimitTest):
         mock_fileobj = mock.Mock()
         stream = self.get_bandwidth_limited_stream(mock_fileobj)
         stream.seek(1)
-        self.assertEqual(
-            mock_fileobj.seek.call_args_list,
-            [mock.call(1, 0)]
-        )
+        self.assertEqual(mock_fileobj.seek.call_args_list, [mock.call(1, 0)])
 
     def test_tell(self):
         mock_fileobj = mock.Mock()
         stream = self.get_bandwidth_limited_stream(mock_fileobj)
         stream.tell()
-        self.assertEqual(
-            mock_fileobj.tell.call_args_list,
-            [mock.call()]
-        )
+        self.assertEqual(mock_fileobj.tell.call_args_list, [mock.call()])
 
     def test_close(self):
         mock_fileobj = mock.Mock()
         stream = self.get_bandwidth_limited_stream(mock_fileobj)
         stream.close()
-        self.assertEqual(
-            mock_fileobj.close.call_args_list,
-            [mock.call()]
-        )
+        self.assertEqual(mock_fileobj.close.call_args_list, [mock.call()])
 
     def test_context_manager(self):
         mock_fileobj = mock.Mock()
         stream = self.get_bandwidth_limited_stream(mock_fileobj)
         with stream as stream_handle:
             self.assertIs(stream_handle, stream)
-        self.assertEqual(
-            mock_fileobj.close.call_args_list,
-            [mock.call()]
-        )
+        self.assertEqual(mock_fileobj.close.call_args_list, [mock.call()])
 
     def test_reuses_request_token(self):
         with open(self.filename, 'rb') as f:
@@ -305,8 +290,7 @@ class TestLeakyBucket(unittest.TestCase):
         self.scheduler.is_scheduled.return_value = False
         self.rate_tracker = mock.Mock(BandwidthRateTracker)
         self.leaky_bucket = LeakyBucket(
-            self.max_rate, self.time_utils, self.rate_tracker,
-            self.scheduler
+            self.max_rate, self.time_utils, self.rate_tracker, self.scheduler
         )
 
     def set_projected_rate(self, rate):
@@ -318,12 +302,13 @@ class TestLeakyBucket(unittest.TestCase):
     def assert_recorded_consumed_amt(self, expected_amt):
         self.assertEqual(
             self.rate_tracker.record_consumption_rate.call_args,
-            mock.call(expected_amt, self.time_utils.time.return_value))
+            mock.call(expected_amt, self.time_utils.time.return_value),
+        )
 
     def assert_was_scheduled(self, amt, token):
         self.assertEqual(
             self.scheduler.schedule_consumption.call_args,
-            mock.call(amt, token, amt/(self.max_rate))
+            mock.call(amt, token, amt / (self.max_rate)),
         )
 
     def assert_nothing_scheduled(self):
@@ -332,12 +317,12 @@ class TestLeakyBucket(unittest.TestCase):
     def assert_processed_request_token(self, request_token):
         self.assertEqual(
             self.scheduler.process_scheduled_consumption.call_args,
-            mock.call(request_token)
+            mock.call(request_token),
         )
 
     def test_consume_under_max_rate(self):
         amt = 1
-        self.set_projected_rate(self.max_rate/2)
+        self.set_projected_rate(self.max_rate / 2)
         self.assertEqual(self.leaky_bucket.consume(amt, RequestToken()), amt)
         self.assert_recorded_consumed_amt(amt)
         self.assert_nothing_scheduled()
@@ -383,20 +368,23 @@ class TestConsumptionScheduler(unittest.TestCase):
         token = RequestToken()
         consume_time = 5
         actual_wait_time = self.scheduler.schedule_consumption(
-            1, token, consume_time)
+            1, token, consume_time
+        )
         self.assertEqual(consume_time, actual_wait_time)
 
     def test_schedule_consumption_for_multiple_requests(self):
         token = RequestToken()
         consume_time = 5
         actual_wait_time = self.scheduler.schedule_consumption(
-            1, token, consume_time)
+            1, token, consume_time
+        )
         self.assertEqual(consume_time, actual_wait_time)
 
         other_consume_time = 3
         other_token = RequestToken()
         next_wait_time = self.scheduler.schedule_consumption(
-            1, other_token, other_consume_time)
+            1, other_token, other_consume_time
+        )
 
         # This wait time should be the previous time plus its desired
         # wait time
@@ -422,7 +410,7 @@ class TestConsumptionScheduler(unittest.TestCase):
         # as it has been completed.
         self.assertEqual(
             self.scheduler.schedule_consumption(1, token, different_time),
-            different_time
+            different_time,
         )
 
 
@@ -460,6 +448,5 @@ class TestBandwidthRateTracker(unittest.TestCase):
     def test_get_projected_rate_for_same_timestamp(self):
         self.rate_tracker.record_consumption_rate(1, 1)
         self.assertEqual(
-            self.rate_tracker.get_projected_rate(1, 1),
-            float('inf')
+            self.rate_tracker.get_projected_rate(1, 1), float('inf')
         )

--- a/tests/unit/test_bandwidth.py
+++ b/tests/unit/test_bandwidth.py
@@ -14,16 +14,18 @@ import os
 import shutil
 import tempfile
 
-from tests import mock, unittest
-from s3transfer.bandwidth import RequestExceededException
-from s3transfer.bandwidth import RequestToken
-from s3transfer.bandwidth import TimeUtils
-from s3transfer.bandwidth import BandwidthLimiter
-from s3transfer.bandwidth import BandwidthLimitedStream
-from s3transfer.bandwidth import LeakyBucket
-from s3transfer.bandwidth import ConsumptionScheduler
-from s3transfer.bandwidth import BandwidthRateTracker
+from s3transfer.bandwidth import (
+    BandwidthLimitedStream,
+    BandwidthLimiter,
+    BandwidthRateTracker,
+    ConsumptionScheduler,
+    LeakyBucket,
+    RequestExceededException,
+    RequestToken,
+    TimeUtils,
+)
 from s3transfer.futures import TransferCoordinator
+from tests import mock, unittest
 
 
 class FixedIncrementalTickTimeUtils(TimeUtils):

--- a/tests/unit/test_bandwidth.py
+++ b/tests/unit/test_bandwidth.py
@@ -83,7 +83,7 @@ class BaseBandwidthLimitTest(unittest.TestCase):
 
 class TestBandwidthLimiter(BaseBandwidthLimitTest):
     def setUp(self):
-        super(TestBandwidthLimiter, self).setUp()
+        super().setUp()
         self.bandwidth_limiter = BandwidthLimiter(self.leaky_bucket)
 
     def test_get_bandwidth_limited_stream(self):
@@ -105,7 +105,7 @@ class TestBandwidthLimiter(BaseBandwidthLimitTest):
 
 class TestBandwidthLimitedStream(BaseBandwidthLimitTest):
     def setUp(self):
-        super(TestBandwidthLimitedStream, self).setUp()
+        super().setUp()
         self.bytes_threshold = 1
 
     def tearDown(self):
@@ -126,10 +126,10 @@ class TestBandwidthLimitedStream(BaseBandwidthLimitTest):
         )
 
     def get_unique_consume_request_tokens(self):
-        return set(
+        return {
             call_args[0][1] for call_args in
             self.leaky_bucket.consume.call_args_list
-        )
+        }
 
     def test_read(self):
         with open(self.filename, 'rb') as f:

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -14,14 +14,13 @@ import os
 import shutil
 import signal
 import tempfile
-
-from botocore.compat import six
+from io import BytesIO
 
 from s3transfer.compat import BaseManager, readable, seekable
 from tests import skip_if_windows, unittest
 
 
-class ErrorRaisingSeekWrapper(object):
+class ErrorRaisingSeekWrapper:
     """An object wrapper that throws an error when seeked on
 
     :param fileobj: The fileobj that it wraps
@@ -71,7 +70,7 @@ class TestReadable(unittest.TestCase):
             self.assertTrue(readable(f))
 
     def test_readable_file_like_obj(self):
-        self.assertTrue(readable(six.BytesIO()))
+        self.assertTrue(readable(BytesIO()))
 
     def test_non_file_like_obj(self):
         self.assertFalse(readable(object()))

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -11,16 +11,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import tempfile
 import shutil
 import signal
+import tempfile
 
 from botocore.compat import six
 
-from tests import unittest
-from tests import skip_if_windows
-from s3transfer.compat import seekable, readable
-from s3transfer.compat import BaseManager
+from s3transfer.compat import BaseManager, readable, seekable
+from tests import skip_if_windows, unittest
 
 
 class ErrorRaisingSeekWrapper(object):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -26,6 +26,7 @@ class ErrorRaisingSeekWrapper:
     :param fileobj: The fileobj that it wraps
     :param exception: The exception to raise when seeked on.
     """
+
     def __init__(self, fileobj, exception):
         self._fileobj = fileobj
         self._exception = exception

--- a/tests/unit/test_copies.py
+++ b/tests/unit/test_copies.py
@@ -10,10 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import BaseTaskTest
-from tests import RecordingSubscriber
-from s3transfer.copies import CopyObjectTask
-from s3transfer.copies import CopyPartTask
+from s3transfer.copies import CopyObjectTask, CopyPartTask
+from tests import BaseTaskTest, RecordingSubscriber
 
 
 class BaseCopyTaskTest(BaseTaskTest):

--- a/tests/unit/test_copies.py
+++ b/tests/unit/test_copies.py
@@ -16,7 +16,7 @@ from tests import BaseTaskTest, RecordingSubscriber
 
 class BaseCopyTaskTest(BaseTaskTest):
     def setUp(self):
-        super(BaseCopyTaskTest, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'mykey'
         self.copy_source = {
@@ -85,7 +85,7 @@ class TestCopyObjectTask(BaseCopyTaskTest):
 
 class TestCopyPartTask(BaseCopyTaskTest):
     def setUp(self):
-        super(TestCopyPartTask, self).setUp()
+        super().setUp()
         self.copy_source_range = 'bytes=5-9'
         self.extra_args['CopySourceRange'] = self.copy_source_range
         self.upload_id = 'myuploadid'

--- a/tests/unit/test_copies.py
+++ b/tests/unit/test_copies.py
@@ -19,10 +19,7 @@ class BaseCopyTaskTest(BaseTaskTest):
         super().setUp()
         self.bucket = 'mybucket'
         self.key = 'mykey'
-        self.copy_source = {
-            'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
-        }
+        self.copy_source = {'Bucket': 'mysourcebucket', 'Key': 'mysourcekey'}
         self.extra_args = {}
         self.callbacks = []
         self.size = 5
@@ -31,21 +28,26 @@ class BaseCopyTaskTest(BaseTaskTest):
 class TestCopyObjectTask(BaseCopyTaskTest):
     def get_copy_task(self, **kwargs):
         default_kwargs = {
-            'client': self.client, 'copy_source': self.copy_source,
-            'bucket': self.bucket, 'key': self.key,
-            'extra_args': self.extra_args, 'callbacks': self.callbacks,
-            'size': self.size
+            'client': self.client,
+            'copy_source': self.copy_source,
+            'bucket': self.bucket,
+            'key': self.key,
+            'extra_args': self.extra_args,
+            'callbacks': self.callbacks,
+            'size': self.size,
         }
         default_kwargs.update(kwargs)
         return self.get_task(CopyObjectTask, main_kwargs=default_kwargs)
 
     def test_main(self):
         self.stubber.add_response(
-            'copy_object', service_response={},
+            'copy_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+            },
         )
         task = self.get_copy_task()
         task()
@@ -55,11 +57,14 @@ class TestCopyObjectTask(BaseCopyTaskTest):
     def test_extra_args(self):
         self.extra_args['ACL'] = 'private'
         self.stubber.add_response(
-            'copy_object', service_response={},
+            'copy_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'ACL': 'private'
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'ACL': 'private',
+            },
         )
         task = self.get_copy_task()
         task()
@@ -70,11 +75,13 @@ class TestCopyObjectTask(BaseCopyTaskTest):
         subscriber = RecordingSubscriber()
         self.callbacks.append(subscriber.on_progress)
         self.stubber.add_response(
-            'copy_object', service_response={},
+            'copy_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+            },
         )
         task = self.get_copy_task()
         task()
@@ -94,73 +101,77 @@ class TestCopyPartTask(BaseCopyTaskTest):
 
     def get_copy_task(self, **kwargs):
         default_kwargs = {
-            'client': self.client, 'copy_source': self.copy_source,
-            'bucket': self.bucket, 'key': self.key,
-            'upload_id': self.upload_id, 'part_number': self.part_number,
-            'extra_args': self.extra_args, 'callbacks': self.callbacks,
-            'size': self.size
+            'client': self.client,
+            'copy_source': self.copy_source,
+            'bucket': self.bucket,
+            'key': self.key,
+            'upload_id': self.upload_id,
+            'part_number': self.part_number,
+            'extra_args': self.extra_args,
+            'callbacks': self.callbacks,
+            'size': self.size,
         }
         default_kwargs.update(kwargs)
         return self.get_task(CopyPartTask, main_kwargs=default_kwargs)
 
     def test_main(self):
         self.stubber.add_response(
-            'upload_part_copy', service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag
-                }
-            },
+            'upload_part_copy',
+            service_response={'CopyPartResult': {'ETag': self.result_etag}},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'UploadId': self.upload_id,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
                 'PartNumber': self.part_number,
-                'CopySourceRange': self.copy_source_range
-            }
+                'CopySourceRange': self.copy_source_range,
+            },
         )
         task = self.get_copy_task()
         self.assertEqual(
-            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag})
+            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag}
+        )
         self.stubber.assert_no_pending_responses()
 
     def test_extra_args(self):
         self.extra_args['RequestPayer'] = 'requester'
         self.stubber.add_response(
-            'upload_part_copy', service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag
-                }
-            },
+            'upload_part_copy',
+            service_response={'CopyPartResult': {'ETag': self.result_etag}},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'UploadId': self.upload_id,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
                 'PartNumber': self.part_number,
                 'CopySourceRange': self.copy_source_range,
-                'RequestPayer': 'requester'
-            }
+                'RequestPayer': 'requester',
+            },
         )
         task = self.get_copy_task()
         self.assertEqual(
-            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag})
+            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag}
+        )
         self.stubber.assert_no_pending_responses()
 
     def test_callbacks_invoked(self):
         subscriber = RecordingSubscriber()
         self.callbacks.append(subscriber.on_progress)
         self.stubber.add_response(
-            'upload_part_copy', service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag
-                }
-            },
+            'upload_part_copy',
+            service_response={'CopyPartResult': {'ETag': self.result_etag}},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'UploadId': self.upload_id,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
                 'PartNumber': self.part_number,
-                'CopySourceRange': self.copy_source_range
-            }
+                'CopySourceRange': self.copy_source_range,
+            },
         )
         task = self.get_copy_task()
         self.assertEqual(
-            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag})
+            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag}
+        )
         self.stubber.assert_no_pending_responses()
         self.assertEqual(subscriber.calculate_bytes_seen(), self.size)

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -10,17 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.session import Session
 from botocore.credentials import CredentialResolver, ReadOnlyCredentials
+from botocore.session import Session
+
 from s3transfer.exceptions import TransferNotDoneError
 from s3transfer.utils import CallArgs
-
-from tests import (
-    FileCreator, requires_crt, HAS_CRT, mock, unittest
-)
+from tests import HAS_CRT, FileCreator, mock, requires_crt, unittest
 
 if HAS_CRT:
     import awscrt.s3
+
     import s3transfer.crt
 
 

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -34,7 +34,8 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         self.session = Session()
         self.session.set_config_variable('region', self.region)
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
-            self.session)
+            self.session
+        )
         self.bucket = "test_bucket"
         self.key = "test_key"
         self.files = FileCreator()
@@ -47,14 +48,19 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
     def test_upload_request(self):
         callargs = CallArgs(
-            bucket=self.bucket, key=self.key, fileobj=self.filename,
-            extra_args={}, subscribers=[])
+            bucket=self.bucket,
+            key=self.key,
+            fileobj=self.filename,
+            extra_args={},
+            subscribers=[],
+        )
         coordinator = s3transfer.crt.CRTTransferCoordinator()
         future = s3transfer.crt.CRTTransferFuture(
-            s3transfer.crt.CRTTransferMeta(call_args=callargs),
-            coordinator)
+            s3transfer.crt.CRTTransferMeta(call_args=callargs), coordinator
+        )
         crt_request = self.request_serializer.serialize_http_request(
-            "put_object", future)
+            "put_object", future
+        )
         self.assertEqual("PUT", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
@@ -62,14 +68,19 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
     def test_download_request(self):
         callargs = CallArgs(
-            bucket=self.bucket, key=self.key, fileobj=self.filename,
-            extra_args={}, subscribers=[])
+            bucket=self.bucket,
+            key=self.key,
+            fileobj=self.filename,
+            extra_args={},
+            subscribers=[],
+        )
         coordinator = s3transfer.crt.CRTTransferCoordinator()
         future = s3transfer.crt.CRTTransferFuture(
-            s3transfer.crt.CRTTransferMeta(call_args=callargs),
-            coordinator)
+            s3transfer.crt.CRTTransferMeta(call_args=callargs), coordinator
+        )
         crt_request = self.request_serializer.serialize_http_request(
-            "get_object", future)
+            "get_object", future
+        )
         self.assertEqual("GET", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
@@ -77,14 +88,15 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
     def test_delete_request(self):
         callargs = CallArgs(
-            bucket=self.bucket, key=self.key,
-            extra_args={}, subscribers=[])
+            bucket=self.bucket, key=self.key, extra_args={}, subscribers=[]
+        )
         coordinator = s3transfer.crt.CRTTransferCoordinator()
         future = s3transfer.crt.CRTTransferFuture(
-            s3transfer.crt.CRTTransferMeta(call_args=callargs),
-            coordinator)
+            s3transfer.crt.CRTTransferMeta(call_args=callargs), coordinator
+        )
         crt_request = self.request_serializer.serialize_http_request(
-            "delete_object", future)
+            "delete_object", future
+        )
         self.assertEqual("DELETE", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
@@ -93,15 +105,14 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
 @requires_crt
 class TestCRTCredentialProviderAdapter(unittest.TestCase):
-
     def setUp(self):
         self.botocore_credential_provider = mock.Mock(CredentialResolver)
         self.access_key = "access_key"
         self.secret_key = "secret_key"
         self.token = "token"
-        self.botocore_credential_provider.load_credentials.return_value.\
-            get_frozen_credentials.return_value = ReadOnlyCredentials(
-                self.access_key, self.secret_key, self.token)
+        self.botocore_credential_provider.load_credentials.return_value.get_frozen_credentials.return_value = ReadOnlyCredentials(
+            self.access_key, self.secret_key, self.token
+        )
 
     def _call_adapter_and_check(self, credentails_provider_adapter):
         credentials = credentails_provider_adapter()
@@ -110,22 +121,27 @@ class TestCRTCredentialProviderAdapter(unittest.TestCase):
         self.assertEqual(credentials.session_token, self.token)
 
     def test_fetch_crt_credentials_successfully(self):
-        credentails_provider_adapter = \
+        credentails_provider_adapter = (
             s3transfer.crt.CRTCredentialProviderAdapter(
-                self.botocore_credential_provider)
+                self.botocore_credential_provider
+            )
+        )
         self._call_adapter_and_check(credentails_provider_adapter)
 
     def test_load_credentials_once(self):
-        credentails_provider_adapter = \
+        credentails_provider_adapter = (
             s3transfer.crt.CRTCredentialProviderAdapter(
-                self.botocore_credential_provider)
+                self.botocore_credential_provider
+            )
+        )
         called_times = 5
         for i in range(called_times):
             self._call_adapter_and_check(credentails_provider_adapter)
         # Assert that the load_credentails of botocore credential provider
         # will only be called once
         self.assertEqual(
-            self.botocore_credential_provider.load_credentials.call_count, 1)
+            self.botocore_credential_provider.load_credentials.call_count, 1
+        )
 
 
 @requires_crt
@@ -137,7 +153,8 @@ class TestCRTTransferFuture(unittest.TestCase):
         self.coordinator = s3transfer.crt.CRTTransferCoordinator()
         self.coordinator.set_s3_request(self.mock_s3_request)
         self.future = s3transfer.crt.CRTTransferFuture(
-            coordinator=self.coordinator)
+            coordinator=self.coordinator
+        )
 
     def test_set_exception(self):
         self.future.set_exception(CustomFutureException())

--- a/tests/unit/test_delete.py
+++ b/tests/unit/test_delete.py
@@ -16,7 +16,7 @@ from tests import BaseTaskTest
 
 class TestDeleteObjectTask(BaseTaskTest):
     def setUp(self):
-        super(TestDeleteObjectTask, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'mykey'
         self.extra_args = {}

--- a/tests/unit/test_delete.py
+++ b/tests/unit/test_delete.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import BaseTaskTest
 from s3transfer.delete import DeleteObjectTask
+from tests import BaseTaskTest
 
 
 class TestDeleteObjectTask(BaseTaskTest):

--- a/tests/unit/test_delete.py
+++ b/tests/unit/test_delete.py
@@ -24,7 +24,9 @@ class TestDeleteObjectTask(BaseTaskTest):
 
     def get_delete_task(self, **kwargs):
         default_kwargs = {
-            'client': self.client, 'bucket': self.bucket, 'key': self.key,
+            'client': self.client,
+            'bucket': self.bucket,
+            'key': self.key,
             'extra_args': self.extra_args,
         }
         default_kwargs.update(kwargs)
@@ -32,10 +34,12 @@ class TestDeleteObjectTask(BaseTaskTest):
 
     def test_main(self):
         self.stubber.add_response(
-            'delete_object', service_response={},
+            'delete_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+            },
         )
         task = self.get_delete_task()
         task()
@@ -46,14 +50,16 @@ class TestDeleteObjectTask(BaseTaskTest):
         self.extra_args['MFA'] = 'mfa-code'
         self.extra_args['VersionId'] = '12345'
         self.stubber.add_response(
-            'delete_object', service_response={},
+            'delete_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
+                'Bucket': self.bucket,
+                'Key': self.key,
                 # These extra_args should be injected into the
                 # expected params for the delete_object call.
                 'MFA': 'mfa-code',
                 'VersionId': '12345',
-            }
+            },
         )
         task = self.get_delete_task()
         task()

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -15,36 +15,37 @@ import os
 import shutil
 import tempfile
 
-from tests import BaseTaskTest
-from tests import BaseSubmissionTaskTest
-from tests import StreamWithError
-from tests import FileCreator
-from tests import mock
-from tests import unittest
-from tests import RecordingExecutor
-from tests import NonSeekableWriter
-from s3transfer.compat import six
-from s3transfer.compat import SOCKET_ERROR
-from s3transfer.exceptions import RetriesExceededError
 from s3transfer.bandwidth import BandwidthLimiter
-from s3transfer.download import DownloadFilenameOutputManager
-from s3transfer.download import DownloadSpecialFilenameOutputManager
-from s3transfer.download import DownloadSeekableOutputManager
-from s3transfer.download import DownloadNonSeekableOutputManager
-from s3transfer.download import DownloadSubmissionTask
-from s3transfer.download import GetObjectTask
-from s3transfer.download import ImmediatelyWriteIOGetObjectTask
-from s3transfer.download import IOWriteTask
-from s3transfer.download import IOStreamingWriteTask
-from s3transfer.download import IORenameFileTask
-from s3transfer.download import IOCloseTask
-from s3transfer.download import CompleteDownloadNOOPTask
-from s3transfer.download import DownloadChunkIterator
-from s3transfer.download import DeferQueue
-from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
-from s3transfer.futures import BoundedExecutor
-from s3transfer.utils import OSUtils
-from s3transfer.utils import CallArgs
+from s3transfer.compat import SOCKET_ERROR, six
+from s3transfer.download import (
+    CompleteDownloadNOOPTask,
+    DeferQueue,
+    DownloadChunkIterator,
+    DownloadFilenameOutputManager,
+    DownloadNonSeekableOutputManager,
+    DownloadSeekableOutputManager,
+    DownloadSpecialFilenameOutputManager,
+    DownloadSubmissionTask,
+    GetObjectTask,
+    ImmediatelyWriteIOGetObjectTask,
+    IOCloseTask,
+    IORenameFileTask,
+    IOStreamingWriteTask,
+    IOWriteTask,
+)
+from s3transfer.exceptions import RetriesExceededError
+from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG, BoundedExecutor
+from s3transfer.utils import CallArgs, OSUtils
+from tests import (
+    BaseSubmissionTaskTest,
+    BaseTaskTest,
+    FileCreator,
+    NonSeekableWriter,
+    RecordingExecutor,
+    StreamWithError,
+    mock,
+    unittest,
+)
 
 
 class DownloadException(Exception):

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -55,6 +55,7 @@ class DownloadException(Exception):
 
 class WriteCollector:
     """A utility to collect information about writes and seeks"""
+
     def __init__(self):
         self._pos = 0
         self.writes = []
@@ -69,6 +70,7 @@ class WriteCollector:
 
 class AlwaysIndicatesSpecialFileOSUtils(OSUtils):
     """OSUtil that always returns True for is_special_file"""
+
     def is_special_file(self, filename):
         return True
 
@@ -82,6 +84,7 @@ class CancelledStreamWrapper:
     :param num_reads: On which read to signal a cancellation. 0 is the first
         read.
     """
+
     def __init__(self, stream, transfer_coordinator, num_reads=0):
         self._stream = stream
         self._transfer_coordinator = transfer_coordinator
@@ -117,13 +120,16 @@ class TestDownloadFilenameOutputManager(BaseDownloadOutputManagerTest):
     def setUp(self):
         super().setUp()
         self.download_output_manager = DownloadFilenameOutputManager(
-            self.osutil, self.transfer_coordinator,
-            io_executor=self.io_executor)
+            self.osutil,
+            self.transfer_coordinator,
+            io_executor=self.io_executor,
+        )
 
     def test_is_compatible(self):
         self.assertTrue(
             self.download_output_manager.is_compatible(
-                self.filename, self.osutil)
+                self.filename, self.osutil
+            )
         )
 
     def test_get_download_task_tag(self):
@@ -131,7 +137,8 @@ class TestDownloadFilenameOutputManager(BaseDownloadOutputManagerTest):
 
     def test_get_fileobj_for_io_writes(self):
         with self.download_output_manager.get_fileobj_for_io_writes(
-                self.future) as f:
+            self.future
+        ) as f:
             # Ensure it is a file like object returned
             self.assertTrue(hasattr(f, 'read'))
             self.assertTrue(hasattr(f, 'seek'))
@@ -142,7 +149,8 @@ class TestDownloadFilenameOutputManager(BaseDownloadOutputManagerTest):
     def test_get_final_io_task(self):
         ref_contents = b'my_contents'
         with self.download_output_manager.get_fileobj_for_io_writes(
-                self.future) as f:
+            self.future
+        ) as f:
             temp_filename = f.name
             # Write some data to test that the data gets moved over to the
             # final location.
@@ -161,16 +169,19 @@ class TestDownloadFilenameOutputManager(BaseDownloadOutputManagerTest):
     def test_can_queue_file_io_task(self):
         fileobj = WriteCollector()
         self.download_output_manager.queue_file_io_task(
-            fileobj=fileobj, data='foo', offset=0)
+            fileobj=fileobj, data='foo', offset=0
+        )
         self.download_output_manager.queue_file_io_task(
-            fileobj=fileobj, data='bar', offset=3)
+            fileobj=fileobj, data='bar', offset=3
+        )
         self.io_executor.shutdown()
         self.assertEqual(fileobj.writes, [(0, 'foo'), (3, 'bar')])
 
     def test_get_file_io_write_task(self):
         fileobj = WriteCollector()
         io_write_task = self.download_output_manager.get_io_write_task(
-            fileobj=fileobj, data='foo', offset=3)
+            fileobj=fileobj, data='foo', offset=3
+        )
         self.assertIsInstance(io_write_task, IOWriteTask)
 
         io_write_task()
@@ -182,22 +193,29 @@ class TestDownloadSpecialFilenameOutputManager(BaseDownloadOutputManagerTest):
         super().setUp()
         self.osutil = AlwaysIndicatesSpecialFileOSUtils()
         self.download_output_manager = DownloadSpecialFilenameOutputManager(
-            self.osutil, self.transfer_coordinator,
-            io_executor=self.io_executor)
+            self.osutil,
+            self.transfer_coordinator,
+            io_executor=self.io_executor,
+        )
 
     def test_is_compatible_for_special_file(self):
         self.assertTrue(
             self.download_output_manager.is_compatible(
-                self.filename, AlwaysIndicatesSpecialFileOSUtils()))
+                self.filename, AlwaysIndicatesSpecialFileOSUtils()
+            )
+        )
 
     def test_is_not_compatible_for_non_special_file(self):
         self.assertFalse(
             self.download_output_manager.is_compatible(
-                self.filename, OSUtils()))
+                self.filename, OSUtils()
+            )
+        )
 
     def test_get_fileobj_for_io_writes(self):
         with self.download_output_manager.get_fileobj_for_io_writes(
-                self.future) as f:
+            self.future
+        ) as f:
             # Ensure it is a file like object returned
             self.assertTrue(hasattr(f, 'read'))
             # Make sure the name of the file returned is the same as the
@@ -206,14 +224,17 @@ class TestDownloadSpecialFilenameOutputManager(BaseDownloadOutputManagerTest):
 
     def test_get_final_io_task(self):
         self.assertIsInstance(
-            self.download_output_manager.get_final_io_task(), IOCloseTask)
+            self.download_output_manager.get_final_io_task(), IOCloseTask
+        )
 
     def test_can_queue_file_io_task(self):
         fileobj = WriteCollector()
         self.download_output_manager.queue_file_io_task(
-            fileobj=fileobj, data='foo', offset=0)
+            fileobj=fileobj, data='foo', offset=0
+        )
         self.download_output_manager.queue_file_io_task(
-            fileobj=fileobj, data='bar', offset=3)
+            fileobj=fileobj, data='bar', offset=3
+        )
         self.io_executor.shutdown()
         self.assertEqual(fileobj.writes, [(0, 'foo'), (3, 'bar')])
 
@@ -222,8 +243,10 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
     def setUp(self):
         super().setUp()
         self.download_output_manager = DownloadSeekableOutputManager(
-            self.osutil, self.transfer_coordinator,
-            io_executor=self.io_executor)
+            self.osutil,
+            self.transfer_coordinator,
+            io_executor=self.io_executor,
+        )
 
         # Create a fileobj to write to
         self.fileobj = open(self.filename, 'wb')
@@ -238,18 +261,18 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
     def test_is_compatible(self):
         self.assertTrue(
             self.download_output_manager.is_compatible(
-                self.fileobj, self.osutil)
+                self.fileobj, self.osutil
+            )
         )
 
     def test_is_compatible_bytes_io(self):
         self.assertTrue(
-            self.download_output_manager.is_compatible(
-                BytesIO(), self.osutil)
+            self.download_output_manager.is_compatible(BytesIO(), self.osutil)
         )
 
     def test_not_compatible_for_non_filelike_obj(self):
-        self.assertFalse(self.download_output_manager.is_compatible(
-            object(), self.osutil)
+        self.assertFalse(
+            self.download_output_manager.is_compatible(object(), self.osutil)
         )
 
     def test_get_download_task_tag(self):
@@ -258,29 +281,33 @@ class TestDownloadSeekableOutputManager(BaseDownloadOutputManagerTest):
     def test_get_fileobj_for_io_writes(self):
         self.assertIs(
             self.download_output_manager.get_fileobj_for_io_writes(
-                self.future),
-            self.fileobj
+                self.future
+            ),
+            self.fileobj,
         )
 
     def test_get_final_io_task(self):
         self.assertIsInstance(
             self.download_output_manager.get_final_io_task(),
-            CompleteDownloadNOOPTask
+            CompleteDownloadNOOPTask,
         )
 
     def test_can_queue_file_io_task(self):
         fileobj = WriteCollector()
         self.download_output_manager.queue_file_io_task(
-            fileobj=fileobj, data='foo', offset=0)
+            fileobj=fileobj, data='foo', offset=0
+        )
         self.download_output_manager.queue_file_io_task(
-            fileobj=fileobj, data='bar', offset=3)
+            fileobj=fileobj, data='bar', offset=3
+        )
         self.io_executor.shutdown()
         self.assertEqual(fileobj.writes, [(0, 'foo'), (3, 'bar')])
 
     def test_get_file_io_write_task(self):
         fileobj = WriteCollector()
         io_write_task = self.download_output_manager.get_io_write_task(
-            fileobj=fileobj, data='foo', offset=3)
+            fileobj=fileobj, data='foo', offset=3
+        )
         self.assertIsInstance(io_write_task, IOWriteTask)
 
         io_write_task()
@@ -291,17 +318,21 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
     def setUp(self):
         super().setUp()
         self.download_output_manager = DownloadNonSeekableOutputManager(
-            self.osutil, self.transfer_coordinator, io_executor=None)
+            self.osutil, self.transfer_coordinator, io_executor=None
+        )
 
     def test_is_compatible_with_seekable_stream(self):
         with open(self.filename, 'wb') as f:
-            self.assertTrue(self.download_output_manager.is_compatible(
-                f, self.osutil)
+            self.assertTrue(
+                self.download_output_manager.is_compatible(f, self.osutil)
             )
 
     def test_not_compatible_with_filename(self):
-        self.assertFalse(self.download_output_manager.is_compatible(
-            self.filename, self.osutil))
+        self.assertFalse(
+            self.download_output_manager.is_compatible(
+                self.filename, self.osutil
+            )
+        )
 
     def test_compatible_with_non_seekable_stream(self):
         class NonSeekable:
@@ -309,20 +340,20 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
                 pass
 
         f = NonSeekable()
-        self.assertTrue(self.download_output_manager.is_compatible(
-            f, self.osutil)
+        self.assertTrue(
+            self.download_output_manager.is_compatible(f, self.osutil)
         )
 
     def test_is_compatible_with_bytesio(self):
         self.assertTrue(
-            self.download_output_manager.is_compatible(
-                BytesIO(), self.osutil)
+            self.download_output_manager.is_compatible(BytesIO(), self.osutil)
         )
 
     def test_get_download_task_tag(self):
         self.assertIs(
             self.download_output_manager.get_download_task_tag(),
-            IN_MEMORY_DOWNLOAD_TAG)
+            IN_MEMORY_DOWNLOAD_TAG,
+        )
 
     def test_submit_writes_from_internal_queue(self):
         class FakeQueue:
@@ -335,18 +366,21 @@ class TestDownloadNonSeekableOutputManager(BaseDownloadOutputManagerTest):
         q = FakeQueue()
         io_executor = BoundedExecutor(1000, 1)
         manager = DownloadNonSeekableOutputManager(
-            self.osutil, self.transfer_coordinator, io_executor=io_executor,
-            defer_queue=q)
+            self.osutil,
+            self.transfer_coordinator,
+            io_executor=io_executor,
+            defer_queue=q,
+        )
         fileobj = WriteCollector()
-        manager.queue_file_io_task(
-            fileobj=fileobj, data='foo', offset=1)
+        manager.queue_file_io_task(fileobj=fileobj, data='foo', offset=1)
         io_executor.shutdown()
         self.assertEqual(fileobj.writes, [(0, 'foo'), (3, 'bar')])
 
     def test_get_file_io_write_task(self):
         fileobj = WriteCollector()
         io_write_task = self.download_output_manager.get_io_write_task(
-            fileobj=fileobj, data='foo', offset=1)
+            fileobj=fileobj, data='foo', offset=1
+        )
         self.assertIsInstance(io_write_task, IOStreamingWriteTask)
 
         io_write_task()
@@ -380,7 +414,7 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
             'osutil': self.osutil,
             'request_executor': self.executor,
             'io_executor': self.io_executor,
-            'transfer_future': self.transfer_future
+            'transfer_future': self.transfer_future,
         }
         self.submission_task = self.get_download_submission_task()
 
@@ -390,9 +424,11 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
 
     def get_call_args(self, **kwargs):
         default_call_args = {
-            'fileobj': self.filename, 'bucket': self.bucket,
-            'key': self.key, 'extra_args': self.extra_args,
-            'subscribers': self.subscribers
+            'fileobj': self.filename,
+            'bucket': self.bucket,
+            'key': self.key,
+            'extra_args': self.extra_args,
+            'subscribers': self.subscribers,
         }
         default_call_args.update(kwargs)
         return CallArgs(**default_call_args)
@@ -412,12 +448,12 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
             # If it was ranged get, make sure we do not include the join task.
             submissions_to_compare = submissions_to_compare[:-1]
         for submission in submissions_to_compare:
-            self.assertEqual(
-                submission['tag'], tag_value)
+            self.assertEqual(submission['tag'], tag_value)
 
     def add_head_object_response(self):
         self.stubber.add_response(
-            'head_object', {'ContentLength': len(self.content)})
+            'head_object', {'ContentLength': len(self.content)}
+        )
 
     def add_get_responses(self):
         chunksize = self.config.multipart_chunksize
@@ -426,7 +462,7 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
                 stream = BytesIO(self.content[i:])
                 self.stubber.add_response('get_object', {'Body': stream})
             else:
-                stream = BytesIO(self.content[i:i+chunksize])
+                stream = BytesIO(self.content[i : i + chunksize])
                 self.stubber.add_response('get_object', {'Body': stream})
 
     def configure_for_ranged_get(self):
@@ -435,7 +471,8 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
 
     def get_download_submission_task(self):
         return self.get_task(
-            DownloadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            DownloadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
 
     def wait_and_assert_completed_successfully(self, submission_task):
         submission_task()
@@ -542,12 +579,16 @@ class TestGetObjectTask(BaseTaskTest):
         self.io_chunksize = 64 * (1024 ** 2)
         self.task_cls = GetObjectTask
         self.download_output_manager = DownloadSeekableOutputManager(
-            self.osutil, self.transfer_coordinator, self.io_executor)
+            self.osutil, self.transfer_coordinator, self.io_executor
+        )
 
     def get_download_task(self, **kwargs):
         default_kwargs = {
-            'client': self.client, 'bucket': self.bucket, 'key': self.key,
-            'fileobj': self.fileobj, 'extra_args': self.extra_args,
+            'client': self.client,
+            'bucket': self.bucket,
+            'key': self.key,
+            'fileobj': self.fileobj,
+            'extra_args': self.extra_args,
             'callbacks': self.callbacks,
             'max_attempts': self.max_attempts,
             'download_output_manager': self.download_output_manager,
@@ -565,8 +606,9 @@ class TestGetObjectTask(BaseTaskTest):
 
     def test_main(self):
         self.stubber.add_response(
-            'get_object', service_response={'Body': self.stream},
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            'get_object',
+            service_response={'Body': self.stream},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         task = self.get_download_task()
         task()
@@ -576,10 +618,13 @@ class TestGetObjectTask(BaseTaskTest):
 
     def test_extra_args(self):
         self.stubber.add_response(
-            'get_object', service_response={'Body': self.stream},
+            'get_object',
+            service_response={'Body': self.stream},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key, 'Range': 'bytes=0-'
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'Range': 'bytes=0-',
+            },
         )
         self.extra_args['Range'] = 'bytes=0-'
         task = self.get_download_task()
@@ -590,8 +635,9 @@ class TestGetObjectTask(BaseTaskTest):
 
     def test_control_chunk_size(self):
         self.stubber.add_response(
-            'get_object', service_response={'Body': self.stream},
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            'get_object',
+            service_response={'Body': self.stream},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         task = self.get_download_task(io_chunksize=1)
         task()
@@ -599,14 +645,15 @@ class TestGetObjectTask(BaseTaskTest):
         self.stubber.assert_no_pending_responses()
         expected_contents = []
         for i in range(len(self.content)):
-            expected_contents.append((i, bytes(self.content[i:i+1])))
+            expected_contents.append((i, bytes(self.content[i : i + 1])))
 
         self.assert_io_writes(expected_contents)
 
     def test_start_index(self):
         self.stubber.add_response(
-            'get_object', service_response={'Body': self.stream},
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            'get_object',
+            service_response={'Body': self.stream},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         task = self.get_download_task(start_index=5)
         task()
@@ -618,8 +665,9 @@ class TestGetObjectTask(BaseTaskTest):
         bandwidth_limiter = mock.Mock(BandwidthLimiter)
 
         self.stubber.add_response(
-            'get_object', service_response={'Body': self.stream},
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            'get_object',
+            service_response={'Body': self.stream},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         task = self.get_download_task(bandwidth_limiter=bandwidth_limiter)
         task()
@@ -627,19 +675,21 @@ class TestGetObjectTask(BaseTaskTest):
         self.stubber.assert_no_pending_responses()
         self.assertEqual(
             bandwidth_limiter.get_bandwith_limited_stream.call_args_list,
-            [mock.call(mock.ANY, self.transfer_coordinator)]
+            [mock.call(mock.ANY, self.transfer_coordinator)],
         )
 
     def test_retries_succeeds(self):
         self.stubber.add_response(
-            'get_object', service_response={
+            'get_object',
+            service_response={
                 'Body': StreamWithError(self.stream, SOCKET_ERROR)
             },
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         self.stubber.add_response(
-            'get_object', service_response={'Body': self.stream},
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            'get_object',
+            service_response={'Body': self.stream},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         task = self.get_download_task()
         task()
@@ -652,10 +702,11 @@ class TestGetObjectTask(BaseTaskTest):
     def test_retries_failure(self):
         for _ in range(self.max_attempts):
             self.stubber.add_response(
-                'get_object', service_response={
+                'get_object',
+                service_response={
                     'Body': StreamWithError(self.stream, SOCKET_ERROR)
                 },
-                expected_params={'Bucket': self.bucket, 'Key': self.key}
+                expected_params={'Bucket': self.bucket, 'Key': self.key},
             )
 
         task = self.get_download_task()
@@ -670,15 +721,18 @@ class TestGetObjectTask(BaseTaskTest):
     def test_retries_in_middle_of_streaming(self):
         # After the first read a retryable error will be thrown
         self.stubber.add_response(
-            'get_object', service_response={
+            'get_object',
+            service_response={
                 'Body': StreamWithError(
-                    copy.deepcopy(self.stream), SOCKET_ERROR, 1)
+                    copy.deepcopy(self.stream), SOCKET_ERROR, 1
+                )
             },
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         self.stubber.add_response(
-            'get_object', service_response={'Body': self.stream},
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            'get_object',
+            service_response={'Body': self.stream},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         task = self.get_download_task(io_chunksize=1)
         task()
@@ -694,7 +748,7 @@ class TestGetObjectTask(BaseTaskTest):
         # element in the list should be a copy of the first element since
         # a retryable exception happened in between.
         for i in range(len(self.content)):
-            expected_contents.append((i, bytes(self.content[i:i+1])))
+            expected_contents.append((i, bytes(self.content[i : i + 1])))
         self.assert_io_writes(expected_contents)
 
     def test_cancels_out_of_queueing(self):
@@ -702,9 +756,10 @@ class TestGetObjectTask(BaseTaskTest):
             'get_object',
             service_response={
                 'Body': CancelledStreamWrapper(
-                    self.stream, self.transfer_coordinator)
+                    self.stream, self.transfer_coordinator
+                )
             },
-            expected_params={'Bucket': self.bucket, 'Key': self.key}
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
         )
         task = self.get_download_task()
         task()
@@ -739,7 +794,8 @@ class TestImmediatelyWriteIOGetObjectTask(TestGetObjectTask):
         # object once downloaded.
         self.io_executor = None
         self.download_output_manager = DownloadSeekableOutputManager(
-            self.osutil, self.transfer_coordinator, self.io_executor)
+            self.osutil, self.transfer_coordinator, self.io_executor
+        )
 
     def assert_io_writes(self, expected_writes):
         self.assertEqual(self.fileobj.writes, expected_writes)
@@ -763,18 +819,12 @@ class TestIOStreamingWriteTask(BaseIOTaskTest):
         with open(self.temp_filename, 'wb') as f:
             task = self.get_task(
                 IOStreamingWriteTask,
-                main_kwargs={
-                    'fileobj': f,
-                    'data': b'foobar'
-                }
+                main_kwargs={'fileobj': f, 'data': b'foobar'},
             )
             task()
             task2 = self.get_task(
                 IOStreamingWriteTask,
-                main_kwargs={
-                    'fileobj': f,
-                    'data': b'baz'
-                }
+                main_kwargs={'fileobj': f, 'data': b'baz'},
             )
             task2()
         with open(self.temp_filename, 'rb') as f:
@@ -789,22 +839,14 @@ class TestIOWriteTask(BaseIOTaskTest):
             # Write once to the file
             task = self.get_task(
                 IOWriteTask,
-                main_kwargs={
-                    'fileobj': f,
-                    'data': b'foo',
-                    'offset': 0
-                }
+                main_kwargs={'fileobj': f, 'data': b'foo', 'offset': 0},
             )
             task()
 
             # Write again to the file
             task = self.get_task(
                 IOWriteTask,
-                main_kwargs={
-                    'fileobj': f,
-                    'data': b'bar',
-                    'offset': 3
-                }
+                main_kwargs={'fileobj': f, 'data': b'bar', 'offset': 3},
             )
             task()
 
@@ -820,8 +862,8 @@ class TestIORenameFileTask(BaseIOTaskTest):
                 main_kwargs={
                     'fileobj': f,
                     'final_filename': self.final_filename,
-                    'osutil': self.osutil
-                }
+                    'osutil': self.osutil,
+                },
             )
             task()
         self.assertTrue(os.path.exists(self.final_filename))
@@ -883,8 +925,8 @@ class TestDeferQueue(unittest.TestCase):
                 {'offset': 0, 'data': 'a'},
                 {'offset': 1, 'data': 'b'},
                 {'offset': 2, 'data': 'c'},
-                {'offset': 3, 'data': 'd'}
-            ]
+                {'offset': 3, 'data': 'd'},
+            ],
         )
 
     def test_unlocks_partial_range(self):
@@ -898,7 +940,7 @@ class TestDeferQueue(unittest.TestCase):
             [
                 {'offset': 0, 'data': 'a'},
                 {'offset': 1, 'data': 'b'},
-            ]
+            ],
         )
 
     def test_data_can_be_any_size(self):
@@ -909,7 +951,7 @@ class TestDeferQueue(unittest.TestCase):
             [
                 {'offset': 0, 'data': 'abcde'},
                 {'offset': 5, 'data': 'hello world'},
-            ]
+            ],
         )
 
     def test_data_queued_in_order(self):
@@ -933,7 +975,7 @@ class TestDeferQueue(unittest.TestCase):
 
         self.assertEqual(
             self.q.request_writes(offset=3, data='d'),
-            [{'offset': 3, 'data': 'd'}]
+            [{'offset': 3, 'data': 'd'}],
         )
 
     def test_duplicate_writes_are_ignored(self):
@@ -953,5 +995,5 @@ class TestDeferQueue(unittest.TestCase):
                 # Note we're seeing 'b' 'c', and not 'X', 'Y'.
                 {'offset': 1, 'data': 'b'},
                 {'offset': 2, 'data': 'c'},
-            ]
+            ],
         )

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -14,28 +14,35 @@ import os
 import sys
 import time
 import traceback
-
 from concurrent.futures import ThreadPoolExecutor
 
-from tests import unittest
-from tests import mock
-from tests import RecordingExecutor
-from tests import TransferCoordinatorWithInterrupt
-from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import FatalError
-from s3transfer.exceptions import TransferNotDoneError
-from s3transfer.futures import TransferFuture
-from s3transfer.futures import TransferMeta
-from s3transfer.futures import TransferCoordinator
-from s3transfer.futures import BoundedExecutor
-from s3transfer.futures import ExecutorFuture
-from s3transfer.futures import BaseExecutor
-from s3transfer.futures import NonThreadedExecutor
-from s3transfer.futures import NonThreadedExecutorFuture
+from s3transfer.exceptions import (
+    CancelledError,
+    FatalError,
+    TransferNotDoneError,
+)
+from s3transfer.futures import (
+    BaseExecutor,
+    BoundedExecutor,
+    ExecutorFuture,
+    NonThreadedExecutor,
+    NonThreadedExecutorFuture,
+    TransferCoordinator,
+    TransferFuture,
+    TransferMeta,
+)
 from s3transfer.tasks import Task
-from s3transfer.utils import FunctionContainer
-from s3transfer.utils import TaskSemaphore
-from s3transfer.utils import NoResourcesAvailable
+from s3transfer.utils import (
+    FunctionContainer,
+    NoResourcesAvailable,
+    TaskSemaphore,
+)
+from tests import (
+    RecordingExecutor,
+    TransferCoordinatorWithInterrupt,
+    mock,
+    unittest,
+)
 
 
 def return_call_args(*args, **kwargs):

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -180,7 +180,8 @@ class TestTransferCoordinator(unittest.TestCase):
     def test_repr(self):
         transfer_coordinator = TransferCoordinator(transfer_id=1)
         self.assertEqual(
-            repr(transfer_coordinator), 'TransferCoordinator(transfer_id=1)')
+            repr(transfer_coordinator), 'TransferCoordinator(transfer_id=1)'
+        )
 
     def test_initial_status(self):
         # A TransferCoordinator with no progress should have the status
@@ -258,7 +259,8 @@ class TestTransferCoordinator(unittest.TestCase):
 
         self.assertEqual(self.transfer_coordinator.status, 'not-started')
         self.transfer_coordinator.add_done_callback(
-            capture_exception, self.transfer_coordinator, exceptions)
+            capture_exception, self.transfer_coordinator, exceptions
+        )
         self.transfer_coordinator.cancel()
 
         self.assertEqual(len(exceptions), 1)
@@ -297,7 +299,8 @@ class TestTransferCoordinator(unittest.TestCase):
         # Submit a callable to the transfer coordinator. It should submit it
         # to the executor.
         executor = RecordingExecutor(
-            BoundedExecutor(1, 1, {'my-tag': TaskSemaphore(1)}))
+            BoundedExecutor(1, 1, {'my-tag': TaskSemaphore(1)})
+        )
         task = ReturnFooTask(self.transfer_coordinator)
         future = self.transfer_coordinator.submit(executor, task, tag='my-tag')
         executor.shutdown()
@@ -305,7 +308,7 @@ class TestTransferCoordinator(unittest.TestCase):
         # result value which should include the provided future tag.
         self.assertEqual(
             executor.submissions,
-            [{'block': True, 'tag': 'my-tag', 'task': task}]
+            [{'block': True, 'tag': 'my-tag', 'task': task}],
         )
         self.assertEqual(future.result(), 'foo')
 
@@ -322,13 +325,12 @@ class TestTransferCoordinator(unittest.TestCase):
         # transfer future at some point.
         self.assertEqual(
             self.transfer_coordinator.all_transfer_futures_ever_associated,
-            {future}
+            {future},
         )
 
         # Make sure the future got disassociated once the future is now done
         # by looking at the currently associated futures.
-        self.assertEqual(
-            self.transfer_coordinator.associated_futures, set())
+        self.assertEqual(self.transfer_coordinator.associated_futures, set())
 
     def test_done(self):
         # These should result in not done state:
@@ -362,8 +364,10 @@ class TestTransferCoordinator(unittest.TestCase):
 
         with ThreadPoolExecutor(max_workers=1) as executor:
             executor.submit(
-                sleep_then_set_result, self.transfer_coordinator,
-                execution_order)
+                sleep_then_set_result,
+                self.transfer_coordinator,
+                execution_order,
+            )
             self.transfer_coordinator.result()
             execution_order.append('after_result')
 
@@ -379,9 +383,11 @@ class TestTransferCoordinator(unittest.TestCase):
         second_kwargs = {'biz': 'baz'}
 
         self.transfer_coordinator.add_failure_cleanup(
-            return_call_args, *args, **kwargs)
+            return_call_args, *args, **kwargs
+        )
         self.transfer_coordinator.add_failure_cleanup(
-            return_call_args, *second_args, **second_kwargs)
+            return_call_args, *second_args, **second_kwargs
+        )
 
         # Ensure the callbacks got added.
         self.assertEqual(len(self.transfer_coordinator.failure_cleanups), 2)
@@ -391,7 +397,8 @@ class TestTransferCoordinator(unittest.TestCase):
         for cleanup in self.transfer_coordinator.failure_cleanups:
             result_list.append(cleanup())
         self.assertEqual(
-            result_list, [(args, kwargs), (second_args, second_kwargs)])
+            result_list, [(args, kwargs), (second_args, second_kwargs)]
+        )
 
     def test_associated_futures(self):
         first_future = object()
@@ -411,12 +418,14 @@ class TestTransferCoordinator(unittest.TestCase):
         # Both futures should be in the returned list.
         self.assertEqual(
             self.transfer_coordinator.associated_futures,
-            {first_future, second_future})
+            {first_future, second_future},
+        )
 
     def test_done_callbacks_on_done(self):
         done_callback_invocations = []
         callback = FunctionContainer(
-            done_callback_invocations.append, 'done callback called')
+            done_callback_invocations.append, 'done callback called'
+        )
 
         # Add the done callback to the transfer.
         self.transfer_coordinator.add_done_callback(callback)
@@ -435,7 +444,8 @@ class TestTransferCoordinator(unittest.TestCase):
     def test_failure_cleanups_on_done(self):
         cleanup_invocations = []
         callback = FunctionContainer(
-            cleanup_invocations.append, 'cleanup called')
+            cleanup_invocations.append, 'cleanup called'
+        )
 
         # Add the failure cleanup to the transfer.
         self.transfer_coordinator.add_failure_cleanup(callback)
@@ -500,7 +510,7 @@ class TestBoundedExecutor(unittest.TestCase):
 
     @unittest.skipIf(
         os.environ.get('USE_SERIAL_EXECUTOR'),
-        "Not supported with serial executor tests"
+        "Not supported with serial executor tests",
     )
     def test_executor_blocks_on_full_capacity(self):
         first_task = self.get_sleep_task()
@@ -523,14 +533,15 @@ class TestBoundedExecutor(unittest.TestCase):
         # blocked because the first task should have finished clearing up
         # capacity.
         self.add_done_callback_to_future(
-            future, self.assert_submit_would_not_block, second_task)
+            future, self.assert_submit_would_not_block, second_task
+        )
 
         # Wait for it to complete.
         self.executor.shutdown()
 
     @unittest.skipIf(
         os.environ.get('USE_SERIAL_EXECUTOR'),
-        "Not supported with serial executor tests"
+        "Not supported with serial executor tests",
     )
     def test_would_not_block_when_full_capacity_in_other_semaphore(self):
         first_task = self.get_sleep_task()
@@ -562,7 +573,7 @@ class TestBoundedExecutor(unittest.TestCase):
 
     @unittest.skipIf(
         os.environ.get('USE_SERIAL_EXECUTOR'),
-        "Not supported with serial executor tests"
+        "Not supported with serial executor tests",
     )
     def test_shutdown_no_wait(self):
         slow_task = self.get_sleep_task()
@@ -598,7 +609,8 @@ class TestExecutorFuture(unittest.TestCase):
             future = executor.submit(return_call_args, 'foo', biz='baz')
             wrapped_future = ExecutorFuture(future)
             wrapped_future.add_done_callback(
-                FunctionContainer(done_callbacks.append, 'called'))
+                FunctionContainer(done_callbacks.append, 'called')
+            )
         self.assertEqual(done_callbacks, ['called'])
 
 

--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -63,11 +63,11 @@ def get_exc_info(exception):
 class RecordingTransferCoordinator(TransferCoordinator):
     def __init__(self):
         self.all_transfer_futures_ever_associated = set()
-        super(RecordingTransferCoordinator, self).__init__()
+        super().__init__()
 
     def add_associated_future(self, future):
         self.all_transfer_futures_ever_associated.add(future)
-        super(RecordingTransferCoordinator, self).add_associated_future(future)
+        super().add_associated_future(future)
 
 
 class ReturnFooTask(Task):
@@ -322,13 +322,13 @@ class TestTransferCoordinator(unittest.TestCase):
         # transfer future at some point.
         self.assertEqual(
             self.transfer_coordinator.all_transfer_futures_ever_associated,
-            set([future])
+            {future}
         )
 
         # Make sure the future got disassociated once the future is now done
         # by looking at the currently associated futures.
         self.assertEqual(
-            self.transfer_coordinator.associated_futures, set([]))
+            self.transfer_coordinator.associated_futures, set())
 
     def test_done(self):
         # These should result in not done state:
@@ -399,19 +399,19 @@ class TestTransferCoordinator(unittest.TestCase):
         self.transfer_coordinator.add_associated_future(first_future)
         associated_futures = self.transfer_coordinator.associated_futures
         # The first future should be in the returned list of futures.
-        self.assertEqual(associated_futures, set([first_future]))
+        self.assertEqual(associated_futures, {first_future})
 
         second_future = object()
         # Associate another future to the transfer.
         self.transfer_coordinator.add_associated_future(second_future)
         # The association should not have mutated the returned list from
         # before.
-        self.assertEqual(associated_futures, set([first_future]))
+        self.assertEqual(associated_futures, {first_future})
 
         # Both futures should be in the returned list.
         self.assertEqual(
             self.transfer_coordinator.associated_futures,
-            set([first_future, second_future]))
+            {first_future, second_future})
 
     def test_done_callbacks_on_done(self):
         done_callback_invocations = []
@@ -479,7 +479,7 @@ class TestBoundedExecutor(unittest.TestCase):
             self.executor.submit(task, tag=tag, block=False)
         except NoResourcesAvailable:
             self.fail(
-                'Task %s should not have been blocked. Caused by:\n%s' % (
+                'Task {} should not have been blocked. Caused by:\n{}'.format(
                     task, traceback.format_exc()
                 )
             )

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -45,29 +45,35 @@ class TestTransferCoordinatorController(unittest.TestCase):
         transfer_coordinator = TransferCoordinator()
         # Add the transfer coordinator
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Ensure that is tracked.
         self.assertEqual(
             self.coordinator_controller.tracked_transfer_coordinators,
-            {transfer_coordinator})
+            {transfer_coordinator},
+        )
 
     def test_remove_transfer_coordinator(self):
         transfer_coordinator = TransferCoordinator()
         # Add the coordinator
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Now remove the coordinator
         self.coordinator_controller.remove_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Make sure that it is no longer getting tracked.
         self.assertEqual(
-            self.coordinator_controller.tracked_transfer_coordinators, set())
+            self.coordinator_controller.tracked_transfer_coordinators, set()
+        )
 
     def test_cancel(self):
         transfer_coordinator = TransferCoordinator()
         # Add the transfer coordinator
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Cancel with the canceler
         self.coordinator_controller.cancel()
         # Check that coordinator got canceled
@@ -77,7 +83,8 @@ class TestTransferCoordinatorController(unittest.TestCase):
         message = 'my cancel message'
         transfer_coordinator = TransferCoordinator()
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         self.coordinator_controller.cancel(message)
         transfer_coordinator.announce_done()
         with self.assertRaisesRegex(CancelledError, message):
@@ -87,7 +94,8 @@ class TestTransferCoordinatorController(unittest.TestCase):
         message = 'my cancel message'
         transfer_coordinator = TransferCoordinator()
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         self.coordinator_controller.cancel(message, exc_type=FatalError)
         transfer_coordinator.announce_done()
         with self.assertRaisesRegex(FatalError, message):
@@ -97,7 +105,8 @@ class TestTransferCoordinatorController(unittest.TestCase):
         # Create a coordinator and add it to the canceler
         transfer_coordinator = TransferCoordinator()
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
 
         sleep_time = 0.02
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -105,8 +114,8 @@ class TestTransferCoordinatorController(unittest.TestCase):
             # to done after sleeping.
             start_time = time.time()
             executor.submit(
-                self.sleep_then_announce_done, transfer_coordinator,
-                sleep_time)
+                self.sleep_then_announce_done, transfer_coordinator, sleep_time
+            )
             # Now call wait to wait for the transfer coordinator to be done.
             self.coordinator_controller.wait()
             end_time = time.time()
@@ -128,6 +137,7 @@ class TestTransferCoordinatorController(unittest.TestCase):
     def test_wait_can_be_interrupted(self):
         inject_interrupt_coordinator = TransferCoordinatorWithInterrupt()
         self.coordinator_controller.add_transfer_coordinator(
-            inject_interrupt_coordinator)
+            inject_interrupt_coordinator
+        )
         with self.assertRaises(KeyboardInterrupt):
             self.coordinator_controller.wait()

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -11,16 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
-
 from concurrent.futures import ThreadPoolExecutor
 
-from tests import unittest
-from tests import TransferCoordinatorWithInterrupt
-from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import FatalError
+from s3transfer.exceptions import CancelledError, FatalError
 from s3transfer.futures import TransferCoordinator
-from s3transfer.manager import TransferConfig
-from s3transfer.manager import TransferCoordinatorController
+from s3transfer.manager import TransferConfig, TransferCoordinatorController
+from tests import TransferCoordinatorWithInterrupt, unittest
 
 
 class FutureResultException(Exception):

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -49,7 +49,7 @@ class TestTransferCoordinatorController(unittest.TestCase):
         # Ensure that is tracked.
         self.assertEqual(
             self.coordinator_controller.tracked_transfer_coordinators,
-            set([transfer_coordinator]))
+            {transfer_coordinator})
 
     def test_remove_transfer_coordinator(self):
         transfer_coordinator = TransferCoordinator()

--- a/tests/unit/test_processpool.py
+++ b/tests/unit/test_processpool.py
@@ -11,16 +11,16 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
+import queue
 import signal
 import threading
 import time
+from io import BytesIO
 
 from botocore.client import BaseClient
 from botocore.config import Config
 from botocore.exceptions import ClientError, ReadTimeoutError
-from six.moves import queue
 
-from s3transfer.compat import six
 from s3transfer.constants import PROCESS_USER_AGENT
 from s3transfer.exceptions import CancelledError, RetriesExceededError
 from s3transfer.processpool import (
@@ -295,7 +295,7 @@ class TestTransferState(unittest.TestCase):
 
 class TestGetObjectSubmitter(StubbedClientTest):
     def setUp(self):
-        super(TestGetObjectSubmitter, self).setUp()
+        super().setUp()
         self.transfer_config = ProcessTransferConfig()
         self.client_factory = mock.Mock(ClientFactory)
         self.client_factory.create_client.return_value = self.client
@@ -482,7 +482,7 @@ class TestGetObjectSubmitter(StubbedClientTest):
 
 class TestGetObjectWorker(StubbedClientTest):
     def setUp(self):
-        super(TestGetObjectWorker, self).setUp()
+        super().setUp()
         self.files = FileCreator()
         self.queue = queue.Queue()
         self.client_factory = mock.Mock(ClientFactory)
@@ -503,12 +503,12 @@ class TestGetObjectWorker(StubbedClientTest):
         self.extra_args = {}
         self.offset = 0
         self.final_filename = self.files.full_path('final_filename')
-        self.stream = six.BytesIO(self.remote_contents)
+        self.stream = BytesIO(self.remote_contents)
         self.transfer_monitor.notify_expected_jobs_to_complete(
             self.transfer_id, 1000)
 
     def tearDown(self):
-        super(TestGetObjectWorker, self).tearDown()
+        super().tearDown()
         self.files.remove_all()
 
     def add_get_object_job(self, **override_kwargs):

--- a/tests/unit/test_processpool.py
+++ b/tests/unit/test_processpool.py
@@ -12,40 +12,41 @@
 # language governing permissions and limitations under the License.
 import os
 import signal
-import time
 import threading
+import time
 
-from six.moves import queue
-from botocore.exceptions import ClientError
-from botocore.exceptions import ReadTimeoutError
 from botocore.client import BaseClient
 from botocore.config import Config
+from botocore.exceptions import ClientError, ReadTimeoutError
+from six.moves import queue
 
-from tests import unittest
-from tests import mock
-from tests import skip_if_windows
-from tests import FileCreator
-from tests import StreamWithError
-from tests import StubbedClientTest
 from s3transfer.compat import six
 from s3transfer.constants import PROCESS_USER_AGENT
-from s3transfer.exceptions import RetriesExceededError
-from s3transfer.exceptions import CancelledError
-from s3transfer.utils import OSUtils
-from s3transfer.utils import CallArgs
-from s3transfer.processpool import SHUTDOWN_SIGNAL
-from s3transfer.processpool import ignore_ctrl_c
-from s3transfer.processpool import DownloadFileRequest
-from s3transfer.processpool import GetObjectJob
-from s3transfer.processpool import ProcessTransferConfig
-from s3transfer.processpool import ProcessPoolDownloader
-from s3transfer.processpool import ProcessPoolTransferFuture
-from s3transfer.processpool import ProcessPoolTransferMeta
-from s3transfer.processpool import TransferMonitor
-from s3transfer.processpool import TransferState
-from s3transfer.processpool import ClientFactory
-from s3transfer.processpool import GetObjectSubmitter
-from s3transfer.processpool import GetObjectWorker
+from s3transfer.exceptions import CancelledError, RetriesExceededError
+from s3transfer.processpool import (
+    SHUTDOWN_SIGNAL,
+    ClientFactory,
+    DownloadFileRequest,
+    GetObjectJob,
+    GetObjectSubmitter,
+    GetObjectWorker,
+    ProcessPoolDownloader,
+    ProcessPoolTransferFuture,
+    ProcessPoolTransferMeta,
+    ProcessTransferConfig,
+    TransferMonitor,
+    TransferState,
+    ignore_ctrl_c,
+)
+from s3transfer.utils import CallArgs, OSUtils
+from tests import (
+    FileCreator,
+    StreamWithError,
+    StubbedClientTest,
+    mock,
+    skip_if_windows,
+    unittest,
+)
 
 
 class RenameFailingOSUtils(OSUtils):

--- a/tests/unit/test_s3transfer.py
+++ b/tests/unit/test_s3transfer.py
@@ -60,8 +60,7 @@ class InMemoryOSLayer(OSUtils):
 
     def rename_file(self, current_filename, new_filename):
         if current_filename in self.filemap:
-            self.filemap[new_filename] = self.filemap.pop(
-                current_filename)
+            self.filemap[new_filename] = self.filemap.pop(current_filename)
 
 
 class SequentialExecutor:
@@ -103,8 +102,9 @@ class TestOSUtils(unittest.TestCase):
     def test_open_file_chunk_reader(self):
         with mock.patch('s3transfer.ReadFileChunk') as m:
             OSUtils().open_file_chunk_reader('myfile', 0, 100, None)
-            m.from_filename.assert_called_with('myfile', 0, 100,
-                                               None, enable_callback=False)
+            m.from_filename.assert_called_with(
+                'myfile', 0, 100, None, enable_callback=False
+            )
 
     def test_open_file(self):
         fileobj = OSUtils().open(os.path.join(self.tempdir, 'foo'), 'w')
@@ -139,7 +139,8 @@ class TestReadFileChunk(unittest.TestCase):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=0, chunk_size=3)
+            filename, start_byte=0, chunk_size=3
+        )
         self.assertEqual(chunk.read(), b'one')
         self.assertEqual(chunk.read(), b'')
 
@@ -148,7 +149,8 @@ class TestReadFileChunk(unittest.TestCase):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=11, chunk_size=4)
+            filename, start_byte=11, chunk_size=4
+        )
         self.assertEqual(chunk.read(1), b'f')
         self.assertEqual(chunk.read(1), b'o')
         self.assertEqual(chunk.read(1), b'u')
@@ -160,7 +162,8 @@ class TestReadFileChunk(unittest.TestCase):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=11, chunk_size=4)
+            filename, start_byte=11, chunk_size=4
+        )
         self.assertEqual(chunk.read(), b'four')
         chunk.seek(0)
         self.assertEqual(chunk.read(), b'four')
@@ -170,7 +173,8 @@ class TestReadFileChunk(unittest.TestCase):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=36, chunk_size=100000)
+            filename, start_byte=36, chunk_size=100000
+        )
         self.assertEqual(chunk.read(), b'ten')
         self.assertEqual(chunk.read(), b'')
         self.assertEqual(len(chunk), 3)
@@ -180,7 +184,8 @@ class TestReadFileChunk(unittest.TestCase):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=36, chunk_size=100000)
+            filename, start_byte=36, chunk_size=100000
+        )
         self.assertEqual(chunk.tell(), 0)
         self.assertEqual(chunk.read(), b'ten')
         self.assertEqual(chunk.tell(), 3)
@@ -191,9 +196,9 @@ class TestReadFileChunk(unittest.TestCase):
         filename = os.path.join(self.tempdir, 'foo')
         with open(filename, 'wb') as f:
             f.write(b'abc')
-        with ReadFileChunk.from_filename(filename,
-                                         start_byte=0,
-                                         chunk_size=2) as chunk:
+        with ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=2
+        ) as chunk:
             val = chunk.read()
             self.assertEqual(val, b'ab')
 
@@ -203,7 +208,8 @@ class TestReadFileChunk(unittest.TestCase):
         filename = os.path.join(self.tempdir, 'foo')
         open(filename, 'wb').close()
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=0, chunk_size=10)
+            filename, start_byte=0, chunk_size=10
+        )
         self.assertEqual(list(chunk), [])
 
 
@@ -220,7 +226,8 @@ class TestReadFileChunkWithCallback(TestReadFileChunk):
 
     def test_callback_is_invoked_on_read(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3, callback=self.callback)
+            self.filename, start_byte=0, chunk_size=3, callback=self.callback
+        )
         chunk.read(1)
         chunk.read(1)
         chunk.read(1)
@@ -228,7 +235,8 @@ class TestReadFileChunkWithCallback(TestReadFileChunk):
 
     def test_callback_can_be_disabled(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3, callback=self.callback)
+            self.filename, start_byte=0, chunk_size=3, callback=self.callback
+        )
         chunk.disable_callback()
         # Now reading from the ReadFileChunk should not invoke
         # the callback.
@@ -237,7 +245,8 @@ class TestReadFileChunkWithCallback(TestReadFileChunk):
 
     def test_callback_will_also_be_triggered_by_seek(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3, callback=self.callback)
+            self.filename, start_byte=0, chunk_size=3, callback=self.callback
+        )
         chunk.read(2)
         chunk.seek(0)
         chunk.read(2)
@@ -247,7 +256,6 @@ class TestReadFileChunkWithCallback(TestReadFileChunk):
 
 
 class TestStreamReaderProgress(unittest.TestCase):
-
     def test_proxies_to_wrapped_stream(self):
         original_stream = StringIO('foobarbaz')
         wrapped = StreamReaderProgress(original_stream)
@@ -269,8 +277,11 @@ class TestMultipartUploader(unittest.TestCase):
     def test_multipart_upload_uses_correct_client_calls(self):
         client = mock.Mock()
         uploader = MultipartUploader(
-            client, TransferConfig(),
-            InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
+            client,
+            TransferConfig(),
+            InMemoryOSLayer({'filename': b'foobar'}),
+            SequentialExecutor,
+        )
         client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
         client.upload_part.return_value = {'ETag': 'first'}
 
@@ -281,41 +292,55 @@ class TestMultipartUploader(unittest.TestCase):
         # 1. The upload_id was plumbed through
         # 2. The collected etags were added to the complete call.
         client.create_multipart_upload.assert_called_with(
-            Bucket='bucket', Key='key')
+            Bucket='bucket', Key='key'
+        )
         # Should be two parts.
         client.upload_part.assert_called_with(
-            Body=mock.ANY, Bucket='bucket',
-            UploadId='upload_id', Key='key', PartNumber=1)
+            Body=mock.ANY,
+            Bucket='bucket',
+            UploadId='upload_id',
+            Key='key',
+            PartNumber=1,
+        )
         client.complete_multipart_upload.assert_called_with(
             MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
             Bucket='bucket',
             UploadId='upload_id',
-            Key='key')
+            Key='key',
+        )
 
     def test_multipart_upload_injects_proper_kwargs(self):
         client = mock.Mock()
         uploader = MultipartUploader(
-            client, TransferConfig(),
-            InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
+            client,
+            TransferConfig(),
+            InMemoryOSLayer({'filename': b'foobar'}),
+            SequentialExecutor,
+        )
         client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
         client.upload_part.return_value = {'ETag': 'first'}
 
         extra_args = {
             'SSECustomerKey': 'fakekey',
             'SSECustomerAlgorithm': 'AES256',
-            'StorageClass': 'REDUCED_REDUNDANCY'
+            'StorageClass': 'REDUCED_REDUNDANCY',
         }
         uploader.upload_file('filename', 'bucket', 'key', None, extra_args)
 
         client.create_multipart_upload.assert_called_with(
-            Bucket='bucket', Key='key',
+            Bucket='bucket',
+            Key='key',
             # The initial call should inject all the storage class params.
             SSECustomerKey='fakekey',
             SSECustomerAlgorithm='AES256',
-            StorageClass='REDUCED_REDUNDANCY')
+            StorageClass='REDUCED_REDUNDANCY',
+        )
         client.upload_part.assert_called_with(
-            Body=mock.ANY, Bucket='bucket',
-            UploadId='upload_id', Key='key', PartNumber=1,
+            Body=mock.ANY,
+            Bucket='bucket',
+            UploadId='upload_id',
+            Key='key',
+            PartNumber=1,
             # We only have to forward certain **extra_args in subsequent
             # UploadPart calls.
             SSECustomerKey='fakekey',
@@ -325,24 +350,30 @@ class TestMultipartUploader(unittest.TestCase):
             MultipartUpload={'Parts': [{'PartNumber': 1, 'ETag': 'first'}]},
             Bucket='bucket',
             UploadId='upload_id',
-            Key='key')
+            Key='key',
+        )
 
     def test_multipart_upload_is_aborted_on_error(self):
         # If the create_multipart_upload succeeds and any upload_part
         # fails, then abort_multipart_upload will be called.
         client = mock.Mock()
         uploader = MultipartUploader(
-            client, TransferConfig(),
-            InMemoryOSLayer({'filename': b'foobar'}), SequentialExecutor)
+            client,
+            TransferConfig(),
+            InMemoryOSLayer({'filename': b'foobar'}),
+            SequentialExecutor,
+        )
         client.create_multipart_upload.return_value = {'UploadId': 'upload_id'}
         client.upload_part.side_effect = Exception(
-            "Some kind of error occurred.")
+            "Some kind of error occurred."
+        )
 
         with self.assertRaises(S3UploadFailedError):
             uploader.upload_file('filename', 'bucket', 'key', None, {})
 
         client.abort_multipart_upload.assert_called_with(
-            Bucket='bucket', Key='key', UploadId='upload_id')
+            Bucket='bucket', Key='key', UploadId='upload_id'
+        )
 
 
 class TestMultipartDownloader(unittest.TestCase):
@@ -354,16 +385,15 @@ class TestMultipartDownloader(unittest.TestCase):
         response_body = b'foobarbaz'
         client.get_object.return_value = {'Body': BytesIO(response_body)}
 
-        downloader = MultipartDownloader(client, TransferConfig(),
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
-        downloader.download_file('bucket', 'key', 'filename',
-                                 len(response_body), {})
+        downloader = MultipartDownloader(
+            client, TransferConfig(), InMemoryOSLayer({}), SequentialExecutor
+        )
+        downloader.download_file(
+            'bucket', 'key', 'filename', len(response_body), {}
+        )
 
         client.get_object.assert_called_with(
-            Range='bytes=0-',
-            Bucket='bucket',
-            Key='key'
+            Range='bytes=0-', Bucket='bucket', Key='key'
         )
 
     def test_multipart_download_with_multiple_parts(self):
@@ -375,24 +405,28 @@ class TestMultipartDownloader(unittest.TestCase):
         # this should result in 3 calls.  In python slices this would be:
         # r[0:4], r[4:8], r[8:9].  But the Range param will be slightly
         # different because they use inclusive ranges.
-        config = TransferConfig(multipart_threshold=4,
-                                multipart_chunksize=4)
+        config = TransferConfig(multipart_threshold=4, multipart_chunksize=4)
 
-        downloader = MultipartDownloader(client, config,
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
-        downloader.download_file('bucket', 'key', 'filename',
-                                 len(response_body), {})
+        downloader = MultipartDownloader(
+            client, config, InMemoryOSLayer({}), SequentialExecutor
+        )
+        downloader.download_file(
+            'bucket', 'key', 'filename', len(response_body), {}
+        )
 
         # We're storing these in **extra because the assertEqual
         # below is really about verifying we have the correct value
         # for the Range param.
         extra = {'Bucket': 'bucket', 'Key': 'key'}
-        self.assertEqual(client.get_object.call_args_list,
-                         # Note these are inclusive ranges.
-                         [mock.call(Range='bytes=0-3', **extra),
-                          mock.call(Range='bytes=4-7', **extra),
-                          mock.call(Range='bytes=8-', **extra)])
+        self.assertEqual(
+            client.get_object.call_args_list,
+            # Note these are inclusive ranges.
+            [
+                mock.call(Range='bytes=0-3', **extra),
+                mock.call(Range='bytes=4-7', **extra),
+                mock.call(Range='bytes=8-', **extra),
+            ],
+        )
 
     def test_retry_on_failures_from_stream_reads(self):
         # If we get an exception during a call to the response body's .read()
@@ -402,31 +436,35 @@ class TestMultipartDownloader(unittest.TestCase):
         stream_with_errors = mock.Mock()
         stream_with_errors.read.side_effect = [
             socket.error("fake error"),
-            response_body
+            response_body,
         ]
         client.get_object.return_value = {'Body': stream_with_errors}
-        config = TransferConfig(multipart_threshold=4,
-                                multipart_chunksize=4)
+        config = TransferConfig(multipart_threshold=4, multipart_chunksize=4)
 
-        downloader = MultipartDownloader(client, config,
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
-        downloader.download_file('bucket', 'key', 'filename',
-                                 len(response_body), {})
+        downloader = MultipartDownloader(
+            client, config, InMemoryOSLayer({}), SequentialExecutor
+        )
+        downloader.download_file(
+            'bucket', 'key', 'filename', len(response_body), {}
+        )
 
         # We're storing these in **extra because the assertEqual
         # below is really about verifying we have the correct value
         # for the Range param.
         extra = {'Bucket': 'bucket', 'Key': 'key'}
-        self.assertEqual(client.get_object.call_args_list,
-                         # The first call to range=0-3 fails because of the
-                         # side_effect above where we make the .read() raise a
-                         # socket.error.
-                         # The second call to range=0-3 then succeeds.
-                         [mock.call(Range='bytes=0-3', **extra),
-                          mock.call(Range='bytes=0-3', **extra),
-                          mock.call(Range='bytes=4-7', **extra),
-                          mock.call(Range='bytes=8-', **extra)])
+        self.assertEqual(
+            client.get_object.call_args_list,
+            # The first call to range=0-3 fails because of the
+            # side_effect above where we make the .read() raise a
+            # socket.error.
+            # The second call to range=0-3 then succeeds.
+            [
+                mock.call(Range='bytes=0-3', **extra),
+                mock.call(Range='bytes=0-3', **extra),
+                mock.call(Range='bytes=4-7', **extra),
+                mock.call(Range='bytes=8-', **extra),
+            ],
+        )
 
     def test_exception_raised_on_exceeded_retries(self):
         client = mock.Mock()
@@ -434,15 +472,15 @@ class TestMultipartDownloader(unittest.TestCase):
         stream_with_errors = mock.Mock()
         stream_with_errors.read.side_effect = socket.error("fake error")
         client.get_object.return_value = {'Body': stream_with_errors}
-        config = TransferConfig(multipart_threshold=4,
-                                multipart_chunksize=4)
+        config = TransferConfig(multipart_threshold=4, multipart_chunksize=4)
 
-        downloader = MultipartDownloader(client, config,
-                                         InMemoryOSLayer({}),
-                                         SequentialExecutor)
+        downloader = MultipartDownloader(
+            client, config, InMemoryOSLayer({}), SequentialExecutor
+        )
         with self.assertRaises(RetriesExceededError):
-            downloader.download_file('bucket', 'key', 'filename',
-                                     len(response_body), {})
+            downloader.download_file(
+                'bucket', 'key', 'filename', len(response_body), {}
+            )
 
     def test_io_thread_failure_triggers_shutdown(self):
         client = mock.Mock()
@@ -454,13 +492,15 @@ class TestMultipartDownloader(unittest.TestCase):
         mock_fileobj.write.side_effect = Exception("fake IO error")
         os_layer.open.return_value = mock_fileobj
 
-        downloader = MultipartDownloader(client, TransferConfig(),
-                                         os_layer, SequentialExecutor)
+        downloader = MultipartDownloader(
+            client, TransferConfig(), os_layer, SequentialExecutor
+        )
         # We're verifying that the exception raised from the IO future
         # propagates back up via download_file().
         with self.assertRaisesRegex(Exception, "fake IO error"):
-            downloader.download_file('bucket', 'key', 'filename',
-                                     len(response_body), {})
+            downloader.download_file(
+                'bucket', 'key', 'filename', len(response_body), {}
+            )
 
     def test_download_futures_fail_triggers_shutdown(self):
         class FailedDownloadParts(SequentialExecutor):
@@ -472,7 +512,8 @@ class TestMultipartDownloader(unittest.TestCase):
                 if self.is_first:
                     # This is the download_parts_thread.
                     future.set_exception(
-                        Exception("fake download parts error"))
+                        Exception("fake download parts error")
+                    )
                     self.is_first = False
                 return future
 
@@ -480,19 +521,19 @@ class TestMultipartDownloader(unittest.TestCase):
         response_body = b'foobarbaz'
         client.get_object.return_value = {'Body': BytesIO(response_body)}
 
-        downloader = MultipartDownloader(client, TransferConfig(),
-                                         InMemoryOSLayer({}),
-                                         FailedDownloadParts)
+        downloader = MultipartDownloader(
+            client, TransferConfig(), InMemoryOSLayer({}), FailedDownloadParts
+        )
         with self.assertRaisesRegex(Exception, "fake download parts error"):
-            downloader.download_file('bucket', 'key', 'filename',
-                                     len(response_body), {})
+            downloader.download_file(
+                'bucket', 'key', 'filename', len(response_body), {}
+            )
 
 
 class TestS3Transfer(unittest.TestCase):
     def setUp(self):
         self.client = mock.Mock()
-        self.random_file_patch = mock.patch(
-            's3transfer.random_file_extension')
+        self.random_file_patch = mock.patch('s3transfer.random_file_extension')
         self.random_file = self.random_file_patch.start()
         self.random_file.return_value = 'RANDOM'
 
@@ -528,16 +569,14 @@ class TestS3Transfer(unittest.TestCase):
 
     def test_extra_args_on_uploaded_passed_to_api_call(self):
         extra_args = {'ACL': 'public-read'}
-        fake_files = {
-            'smallfile': b'hello world'
-        }
+        fake_files = {'smallfile': b'hello world'}
         osutil = InMemoryOSLayer(fake_files)
         transfer = S3Transfer(self.client, osutil=osutil)
-        transfer.upload_file('smallfile', 'bucket', 'key',
-                             extra_args=extra_args)
+        transfer.upload_file(
+            'smallfile', 'bucket', 'key', extra_args=extra_args
+        )
         self.client.put_object.assert_called_with(
-            Bucket='bucket', Key='key', Body=mock.ANY,
-            ACL='public-read'
+            Bucket='bucket', Key='key', Body=mock.ANY, ACL='public-read'
         )
 
     def test_uses_multipart_upload_when_over_threshold(self):
@@ -546,13 +585,15 @@ class TestS3Transfer(unittest.TestCase):
                 'smallfile': b'foobar',
             }
             osutil = InMemoryOSLayer(fake_files)
-            config = TransferConfig(multipart_threshold=2,
-                                    multipart_chunksize=2)
+            config = TransferConfig(
+                multipart_threshold=2, multipart_chunksize=2
+            )
             transfer = S3Transfer(self.client, osutil=osutil, config=config)
             transfer.upload_file('smallfile', 'bucket', 'key')
 
             uploader.return_value.upload_file.assert_called_with(
-                'smallfile', 'bucket', 'key', None, {})
+                'smallfile', 'bucket', 'key', None, {}
+            )
 
     def test_uses_multipart_download_when_over_threshold(self):
         with mock.patch('s3transfer.MultipartDownloader') as downloader:
@@ -563,31 +604,43 @@ class TestS3Transfer(unittest.TestCase):
             self.client.head_object.return_value = {
                 'ContentLength': over_multipart_threshold,
             }
-            transfer.download_file('bucket', 'key', 'filename',
-                                   callback=callback)
+            transfer.download_file(
+                'bucket', 'key', 'filename', callback=callback
+            )
 
             downloader.return_value.download_file.assert_called_with(
                 # Note how we're downloading to a temporary random file.
-                'bucket', 'key', 'filename.RANDOM', over_multipart_threshold,
-                {}, callback)
+                'bucket',
+                'key',
+                'filename.RANDOM',
+                over_multipart_threshold,
+                {},
+                callback,
+            )
 
     def test_download_file_with_invalid_extra_args(self):
         below_threshold = 20
         osutil = InMemoryOSLayer({})
         transfer = S3Transfer(self.client, osutil=osutil)
         self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
+            'ContentLength': below_threshold
+        }
         with self.assertRaises(ValueError):
-            transfer.download_file('bucket', 'key', '/tmp/smallfile',
-                                   extra_args={'BadValue': 'foo'})
+            transfer.download_file(
+                'bucket',
+                'key',
+                '/tmp/smallfile',
+                extra_args={'BadValue': 'foo'},
+            )
 
     def test_upload_file_with_invalid_extra_args(self):
         osutil = InMemoryOSLayer({})
         transfer = S3Transfer(self.client, osutil=osutil)
         bad_args = {"WebsiteRedirectLocation": "/foo"}
         with self.assertRaises(ValueError):
-            transfer.upload_file('bucket', 'key', '/tmp/smallfile',
-                                 extra_args=bad_args)
+            transfer.upload_file(
+                'bucket', 'key', '/tmp/smallfile', extra_args=bad_args
+            )
 
     def test_download_file_fowards_extra_args(self):
         extra_args = {
@@ -598,12 +651,12 @@ class TestS3Transfer(unittest.TestCase):
         osutil = InMemoryOSLayer({'smallfile': b'hello world'})
         transfer = S3Transfer(self.client, osutil=osutil)
         self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
-        self.client.get_object.return_value = {
-            'Body': BytesIO(b'foobar')
+            'ContentLength': below_threshold
         }
-        transfer.download_file('bucket', 'key', '/tmp/smallfile',
-                               extra_args=extra_args)
+        self.client.get_object.return_value = {'Body': BytesIO(b'foobar')}
+        transfer.download_file(
+            'bucket', 'key', '/tmp/smallfile', extra_args=extra_args
+        )
 
         # Note that we need to invoke the HeadObject call
         # and the PutObject call with the extra_args.
@@ -611,15 +664,19 @@ class TestS3Transfer(unittest.TestCase):
         # will return a 400 if you don't provide the required
         # params.
         self.client.get_object.assert_called_with(
-            Bucket='bucket', Key='key', SSECustomerAlgorithm='AES256',
-            SSECustomerKey='foo')
+            Bucket='bucket',
+            Key='key',
+            SSECustomerAlgorithm='AES256',
+            SSECustomerKey='foo',
+        )
 
     def test_get_object_stream_is_retried_and_succeeds(self):
         below_threshold = 20
         osutil = InMemoryOSLayer({'smallfile': b'hello world'})
         transfer = S3Transfer(self.client, osutil=osutil)
         self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
+            'ContentLength': below_threshold
+        }
         self.client.get_object.side_effect = [
             # First request fails.
             socket.error("fake error"),
@@ -635,7 +692,8 @@ class TestS3Transfer(unittest.TestCase):
         osutil = InMemoryOSLayer({})
         transfer = S3Transfer(self.client, osutil=osutil)
         self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
+            'ContentLength': below_threshold
+        }
         # Here we're raising an exception every single time, which
         # will exhaust our retry count and propagate a
         # RetriesExceededError.
@@ -653,10 +711,9 @@ class TestS3Transfer(unittest.TestCase):
         osutil = InMemoryOSLayer({'smallfile': b'hello world'})
         transfer = S3Transfer(self.client, osutil=osutil)
         self.client.head_object.return_value = {
-            'ContentLength': below_threshold}
-        self.client.get_object.return_value = {
-            'Body': BytesIO(b'foobar')
+            'ContentLength': below_threshold
         }
+        self.client.get_object.return_value = {'Body': BytesIO(b'foobar')}
         transfer.download_file('bucket', 'key', 'smallfile')
 
         self.client.get_object.assert_called_with(Bucket='bucket', Key='key')
@@ -681,8 +738,7 @@ class TestShutdownQueue(unittest.TestCase):
 
 class TestRandomFileExtension(unittest.TestCase):
     def test_has_proper_length(self):
-        self.assertEqual(
-            len(random_file_extension(num_digits=4)), 4)
+        self.assertEqual(len(random_file_extension(num_digits=4)), 4)
 
 
 class TestCallbackHandlers(unittest.TestCase):
@@ -717,10 +773,8 @@ class TestCallbackHandlers(unittest.TestCase):
 
     def test_dont_disable_if_wrong_operation(self):
         disable_upload_callbacks(self.request, 'OtherOperation')
-        self.assertFalse(
-            self.request.body.disable_callback.called)
+        self.assertFalse(self.request.body.disable_callback.called)
 
     def test_dont_enable_if_wrong_operation(self):
         enable_upload_callbacks(self.request, 'OtherOperation')
-        self.assertFalse(
-            self.request.body.enable_callback.called)
+        self.assertFalse(self.request.body.enable_callback.called)

--- a/tests/unit/test_s3transfer.py
+++ b/tests/unit/test_s3transfer.py
@@ -11,25 +11,30 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import tempfile
 import shutil
 import socket
-from tests import mock, unittest
+import tempfile
+from concurrent import futures
 from contextlib import closing
 
 from botocore.vendored import six
-from concurrent import futures
 
-from s3transfer.exceptions import RetriesExceededError
-from s3transfer.exceptions import S3UploadFailedError
-from s3transfer import ReadFileChunk, StreamReaderProgress
-from s3transfer import S3Transfer
-from s3transfer import OSUtils, TransferConfig
-from s3transfer import MultipartDownloader, MultipartUploader
-from s3transfer import ShutdownQueue
-from s3transfer import QueueShutdownError
-from s3transfer import random_file_extension
-from s3transfer import disable_upload_callbacks, enable_upload_callbacks
+from s3transfer import (
+    MultipartDownloader,
+    MultipartUploader,
+    OSUtils,
+    QueueShutdownError,
+    ReadFileChunk,
+    S3Transfer,
+    ShutdownQueue,
+    StreamReaderProgress,
+    TransferConfig,
+    disable_upload_callbacks,
+    enable_upload_callbacks,
+    random_file_extension,
+)
+from s3transfer.exceptions import RetriesExceededError, S3UploadFailedError
+from tests import mock, unittest
 
 
 class InMemoryOSLayer(OSUtils):

--- a/tests/unit/test_subscribers.py
+++ b/tests/unit/test_subscribers.py
@@ -10,9 +10,9 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
 from s3transfer.exceptions import InvalidSubscriberMethodError
 from s3transfer.subscribers import BaseSubscriber
+from tests import unittest
 
 
 class ExtraMethodsSubscriber(BaseSubscriber):

--- a/tests/unit/test_subscribers.py
+++ b/tests/unit/test_subscribers.py
@@ -54,7 +54,8 @@ class TestSubscribers(unittest.TestCase):
         except Exception as e:
             self.fail(
                 'Should be able to call base class subscriber method. '
-                'instead got: %s' % e)
+                'instead got: %s' % e
+            )
 
     def test_subclass_can_have_and_call_additional_methods(self):
         subscriber = ExtraMethodsSubscriber()
@@ -79,10 +80,12 @@ class TestSubscribers(unittest.TestCase):
 
     def test_not_callable_in_subclass_subscriber_method(self):
         with self.assertRaisesRegex(
-                InvalidSubscriberMethodError, 'must be callable'):
+            InvalidSubscriberMethodError, 'must be callable'
+        ):
             NotCallableSubscriber()
 
     def test_no_kwargs_in_subclass_subscriber_method(self):
         with self.assertRaisesRegex(
-                InvalidSubscriberMethodError, 'must accept keyword'):
+            InvalidSubscriberMethodError, 'must accept keyword'
+        ):
             NoKwargsSubscriber()

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -36,8 +36,9 @@ class TaskFailureException(Exception):
 
 
 class SuccessTask(Task):
-    def _main(self, return_value='success', callbacks=None,
-              failure_cleanups=None):
+    def _main(
+        self, return_value='success', callbacks=None, failure_cleanups=None
+    ):
         if callbacks:
             for callback in callbacks:
                 callback()
@@ -69,8 +70,14 @@ class NOOPSubmissionTask(SubmissionTask):
 
 
 class ExceptionSubmissionTask(SubmissionTask):
-    def _submit(self, transfer_future, executor=None, tasks_to_submit=None,
-                additional_callbacks=None, exception=TaskFailureException):
+    def _submit(
+        self,
+        transfer_future,
+        executor=None,
+        tasks_to_submit=None,
+        additional_callbacks=None,
+        exception=TaskFailureException,
+    ):
         if executor and tasks_to_submit:
             for task_to_submit in tasks_to_submit:
                 self._transfer_coordinator.submit(executor, task_to_submit)
@@ -117,7 +124,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
     def test_transitions_from_not_started_to_queued_to_running(self):
         self.transfer_coordinator = StatusRecordingTransferCoordinator()
         submission_task = self.get_task(
-            NOOPSubmissionTask, main_kwargs=self.main_kwargs)
+            NOOPSubmissionTask, main_kwargs=self.main_kwargs
+        )
         # Status should be queued until submission task has been ran.
         self.assertEqual(self.transfer_coordinator.status, 'not-started')
 
@@ -128,23 +136,26 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
         # Ensure the transitions were as expected as well.
         self.assertEqual(
             self.transfer_coordinator.status_changes,
-            ['not-started', 'queued', 'running']
+            ['not-started', 'queued', 'running'],
         )
 
     def test_on_queued_callbacks(self):
         submission_task = self.get_task(
-            NOOPSubmissionTask, main_kwargs=self.main_kwargs)
+            NOOPSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         subscriber = RecordingSubscriber()
         self.call_args.subscribers.append(subscriber)
         submission_task()
         # Make sure the on_queued callback of the subscriber is called.
         self.assertEqual(
-            subscriber.on_queued_calls, [{'future': self.transfer_future}])
+            subscriber.on_queued_calls, [{'future': self.transfer_future}]
+        )
 
     def test_on_queued_status_in_callbacks(self):
         submission_task = self.get_task(
-            NOOPSubmissionTask, main_kwargs=self.main_kwargs)
+            NOOPSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         subscriber = RecordingStateSubscriber(self.transfer_coordinator)
         self.call_args.subscribers.append(subscriber)
@@ -154,7 +165,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
 
     def test_sets_exception_from_submit(self):
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
         submission_task()
 
         # Make sure the status of the future is failed
@@ -168,7 +180,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
     def test_catches_and_sets_keyboard_interrupt_exception_from_submit(self):
         self.main_kwargs['exception'] = KeyboardInterrupt
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
         submission_task()
 
         self.assertEqual(self.transfer_coordinator.status, 'failed')
@@ -177,7 +190,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
 
     def test_calls_done_callbacks_on_exception(self):
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         subscriber = RecordingSubscriber()
         self.call_args.subscribers.append(subscriber)
@@ -194,17 +208,20 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
 
         # Make sure the on_done callback of the subscriber is called.
         self.assertEqual(
-            subscriber.on_done_calls, [{'future': self.transfer_future}])
+            subscriber.on_done_calls, [{'future': self.transfer_future}]
+        )
 
     def test_calls_failure_cleanups_on_exception(self):
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         # Add the callback to the callbacks to be invoked when the
         # transfer fails.
         invocations_of_cleanup = []
         cleanup_callback = FunctionContainer(
-            invocations_of_cleanup.append, 'cleanup happened')
+            invocations_of_cleanup.append, 'cleanup happened'
+        )
         self.transfer_coordinator.add_failure_cleanup(cleanup_callback)
         submission_task()
 
@@ -225,7 +242,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
         self.main_kwargs['tasks_to_submit'] = [final_task]
 
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         subscriber = RecordingSubscriber()
         self.call_args.subscribers.append(subscriber)
@@ -243,7 +261,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
 
         # Make sure the on_done callback of the subscriber is called only once.
         self.assertEqual(
-            subscriber.on_done_calls, [{'future': self.transfer_future}])
+            subscriber.on_done_calls, [{'future': self.transfer_future}]
+        )
 
     def test_done_callbacks_only_ran_once_on_exception(self):
         # We want to be able to handle the case where the final task completes
@@ -256,13 +275,15 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
         self.main_kwargs['tasks_to_submit'] = [final_task]
 
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         # Add the callback to the callbacks to be invoked when the
         # transfer fails.
         invocations_of_cleanup = []
         cleanup_callback = FunctionContainer(
-            invocations_of_cleanup.append, 'cleanup happened')
+            invocations_of_cleanup.append, 'cleanup happened'
+        )
         self.transfer_coordinator.add_failure_cleanup(cleanup_callback)
         submission_task()
 
@@ -276,14 +297,16 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
         invocations_of_cleanup = []
         event = Event()
         cleanup_callback = FunctionContainer(
-            invocations_of_cleanup.append, 'cleanup happened')
+            invocations_of_cleanup.append, 'cleanup happened'
+        )
         # We want the cleanup to be added in the execution of the task and
         # still be executed by the submission task when it fails.
         task = self.get_task(
-            SuccessTask, main_kwargs={
+            SuccessTask,
+            main_kwargs={
                 'callbacks': [event.set],
-                'failure_cleanups': [cleanup_callback]
-            }
+                'failure_cleanups': [cleanup_callback],
+            },
         )
 
         self.main_kwargs['executor'] = self.executor
@@ -291,7 +314,8 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
         self.main_kwargs['additional_callbacks'] = [event.wait]
 
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         submission_task()
         self.assertEqual(self.transfer_coordinator.status, 'failed')
@@ -325,28 +349,33 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
         invocations_of_cleanup = []
         event = Event()
         cleanup_callback = FunctionContainer(
-            invocations_of_cleanup.append, 'cleanup happened')
+            invocations_of_cleanup.append, 'cleanup happened'
+        )
 
         cleanup_task = self.get_task(
-            SuccessTask, main_kwargs={
+            SuccessTask,
+            main_kwargs={
                 'callbacks': [event.set],
-                'failure_cleanups': [cleanup_callback]
-            }
+                'failure_cleanups': [cleanup_callback],
+            },
         )
         task_for_submitting_cleanup_task = self.get_task(
-            SubmitMoreTasksTask, main_kwargs={
+            SubmitMoreTasksTask,
+            main_kwargs={
                 'executor': self.executor,
-                'tasks_to_submit': [cleanup_task]
-            }
+                'tasks_to_submit': [cleanup_task],
+            },
         )
 
         self.main_kwargs['executor'] = self.executor
         self.main_kwargs['tasks_to_submit'] = [
-            task_for_submitting_cleanup_task]
+            task_for_submitting_cleanup_task
+        ]
         self.main_kwargs['additional_callbacks'] = [event.wait]
 
         submission_task = self.get_task(
-            ExceptionSubmissionTask, main_kwargs=self.main_kwargs)
+            ExceptionSubmissionTask, main_kwargs=self.main_kwargs
+        )
 
         submission_task()
         self.assertEqual(self.transfer_coordinator.status, 'failed')
@@ -355,12 +384,14 @@ class TestSubmissionTask(BaseSubmissionTaskTest):
     def test_submission_task_announces_done_if_cancelled_before_main(self):
         invocations_of_done = []
         done_callback = FunctionContainer(
-            invocations_of_done.append, 'done announced')
+            invocations_of_done.append, 'done announced'
+        )
         self.transfer_coordinator.add_done_callback(done_callback)
 
         self.transfer_coordinator.cancel()
         submission_task = self.get_task(
-            NOOPSubmissionTask, main_kwargs=self.main_kwargs)
+            NOOPSubmissionTask, main_kwargs=self.main_kwargs
+        )
         submission_task()
 
         # Because the submission task was cancelled before being run
@@ -373,21 +404,21 @@ class TestTask(unittest.TestCase):
     def setUp(self):
         self.transfer_id = 1
         self.transfer_coordinator = TransferCoordinator(
-            transfer_id=self.transfer_id)
+            transfer_id=self.transfer_id
+        )
 
     def test_repr(self):
-        main_kwargs = {
-            'bucket': 'mybucket',
-            'param_to_not_include': 'foo'
-        }
+        main_kwargs = {'bucket': 'mybucket', 'param_to_not_include': 'foo'}
         task = ReturnKwargsTask(
-            self.transfer_coordinator, main_kwargs=main_kwargs)
+            self.transfer_coordinator, main_kwargs=main_kwargs
+        )
         # The repr should not include the other parameter because it is not
         # a desired parameter to include.
         self.assertEqual(
             repr(task),
             'ReturnKwargsTask(transfer_id={}, {})'.format(
-                self.transfer_id, {'bucket': 'mybucket'})
+                self.transfer_id, {'bucket': 'mybucket'}
+            ),
         )
 
     def test_transfer_id(self):
@@ -426,8 +457,11 @@ class TestTask(unittest.TestCase):
     def test_result_setting_for_success(self):
         override_return = 'foo'
         SuccessTask(self.transfer_coordinator)()
-        SuccessTask(self.transfer_coordinator, main_kwargs={
-            'return_value': override_return}, is_final=True)()
+        SuccessTask(
+            self.transfer_coordinator,
+            main_kwargs={'return_value': override_return},
+            is_final=True,
+        )()
 
         # The return value for the transfer future should be of the final
         # task.
@@ -438,8 +472,9 @@ class TestTask(unittest.TestCase):
 
         # If another failure comes in, the result should still throw the
         # original exception when result() is eventually called.
-        FailureTask(self.transfer_coordinator, main_kwargs={
-            'exception': Exception})()
+        FailureTask(
+            self.transfer_coordinator, main_kwargs={'exception': Exception}
+        )()
 
         # Even if a success task comes along, the result of the future
         # should be the original exception
@@ -449,36 +484,48 @@ class TestTask(unittest.TestCase):
 
     def test_done_callbacks_success(self):
         callback_results = []
-        SuccessTask(self.transfer_coordinator, done_callbacks=[
-            partial(callback_results.append, 'first'),
-            partial(callback_results.append, 'second')
-        ])()
+        SuccessTask(
+            self.transfer_coordinator,
+            done_callbacks=[
+                partial(callback_results.append, 'first'),
+                partial(callback_results.append, 'second'),
+            ],
+        )()
         # For successful tasks, the done callbacks should get called.
         self.assertEqual(callback_results, ['first', 'second'])
 
     def test_done_callbacks_failure(self):
         callback_results = []
-        FailureTask(self.transfer_coordinator, done_callbacks=[
-            partial(callback_results.append, 'first'),
-            partial(callback_results.append, 'second')
-        ])()
+        FailureTask(
+            self.transfer_coordinator,
+            done_callbacks=[
+                partial(callback_results.append, 'first'),
+                partial(callback_results.append, 'second'),
+            ],
+        )()
         # For even failed tasks, the done callbacks should get called.
         self.assertEqual(callback_results, ['first', 'second'])
 
         # Callbacks should continue to be called even after a related failure
-        SuccessTask(self.transfer_coordinator, done_callbacks=[
-            partial(callback_results.append, 'third'),
-            partial(callback_results.append, 'fourth')
-        ])()
+        SuccessTask(
+            self.transfer_coordinator,
+            done_callbacks=[
+                partial(callback_results.append, 'third'),
+                partial(callback_results.append, 'fourth'),
+            ],
+        )()
         self.assertEqual(
-            callback_results, ['first', 'second', 'third', 'fourth'])
+            callback_results, ['first', 'second', 'third', 'fourth']
+        )
 
     def test_failure_cleanups_on_failure(self):
         callback_results = []
         self.transfer_coordinator.add_failure_cleanup(
-            callback_results.append, 'first')
+            callback_results.append, 'first'
+        )
         self.transfer_coordinator.add_failure_cleanup(
-            callback_results.append, 'second')
+            callback_results.append, 'second'
+        )
         FailureTask(self.transfer_coordinator)()
         # The failure callbacks should have not been called yet because it
         # is not the last task
@@ -491,9 +538,11 @@ class TestTask(unittest.TestCase):
     def test_no_failure_cleanups_on_success(self):
         callback_results = []
         self.transfer_coordinator.add_failure_cleanup(
-            callback_results.append, 'first')
+            callback_results.append, 'first'
+        )
         self.transfer_coordinator.add_failure_cleanup(
-            callback_results.append, 'second')
+            callback_results.append, 'second'
+        )
         SuccessTask(self.transfer_coordinator, is_final=True)()
         # The failure cleanups should not have been called because no task
         # failed for the transfer context.
@@ -502,8 +551,8 @@ class TestTask(unittest.TestCase):
     def test_passing_main_kwargs(self):
         main_kwargs = {'foo': 'bar', 'baz': 'biz'}
         ReturnKwargsTask(
-            self.transfer_coordinator, main_kwargs=main_kwargs,
-            is_final=True)()
+            self.transfer_coordinator, main_kwargs=main_kwargs, is_final=True
+        )()
         # The kwargs should have been passed to the main()
         self.assertEqual(self.transfer_coordinator.result(), main_kwargs)
 
@@ -516,20 +565,22 @@ class TestTask(unittest.TestCase):
             pending_kwargs['foo'] = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value': ref_main_kwargs['foo']}
+                    main_kwargs={'return_value': ref_main_kwargs['foo']},
                 )
             )
             pending_kwargs['baz'] = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value': ref_main_kwargs['baz']}
+                    main_kwargs={'return_value': ref_main_kwargs['baz']},
                 )
             )
 
         # Create a task that depends on the tasks passed to the executor
         ReturnKwargsTask(
-            self.transfer_coordinator, pending_main_kwargs=pending_kwargs,
-            is_final=True)()
+            self.transfer_coordinator,
+            pending_main_kwargs=pending_kwargs,
+            is_final=True,
+        )()
         # The result should have the pending keyword arg values flushed
         # out.
         self.assertEqual(self.transfer_coordinator.result(), ref_main_kwargs)
@@ -543,13 +594,13 @@ class TestTask(unittest.TestCase):
             first_future = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value': ref_main_kwargs['foo'][0]}
+                    main_kwargs={'return_value': ref_main_kwargs['foo'][0]},
                 )
             )
             second_future = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value': ref_main_kwargs['foo'][1]}
+                    main_kwargs={'return_value': ref_main_kwargs['foo'][1]},
                 )
             )
             # Make the pending keyword arg value a list
@@ -557,8 +608,10 @@ class TestTask(unittest.TestCase):
 
         # Create a task that depends on the tasks passed to the executor
         ReturnKwargsTask(
-            self.transfer_coordinator, pending_main_kwargs=pending_kwargs,
-            is_final=True)()
+            self.transfer_coordinator,
+            pending_main_kwargs=pending_kwargs,
+            is_final=True,
+        )()
         # The result should have the pending keyword arg values flushed
         # out in the expected order.
         self.assertEqual(self.transfer_coordinator.result(), ref_main_kwargs)
@@ -569,7 +622,7 @@ class TestTask(unittest.TestCase):
         ref_main_kwargs = {
             'nonpending_value': 'foo',
             'pending_value': 'bar',
-            'pending_list': ['first', 'second']
+            'pending_list': ['first', 'second'],
         }
 
         # Create the pending tasks
@@ -577,23 +630,26 @@ class TestTask(unittest.TestCase):
             pending_kwargs['pending_value'] = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value':
-                                 ref_main_kwargs['pending_value']}
+                    main_kwargs={
+                        'return_value': ref_main_kwargs['pending_value']
+                    },
                 )
             )
 
             first_future = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value':
-                                 ref_main_kwargs['pending_list'][0]}
+                    main_kwargs={
+                        'return_value': ref_main_kwargs['pending_list'][0]
+                    },
                 )
             )
             second_future = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value':
-                                 ref_main_kwargs['pending_list'][1]}
+                    main_kwargs={
+                        'return_value': ref_main_kwargs['pending_list'][1]
+                    },
                 )
             )
             # Make the pending keyword arg value a list
@@ -602,9 +658,11 @@ class TestTask(unittest.TestCase):
         # Create a task that depends on the tasks passed to the executor
         # and just regular nonpending kwargs.
         ReturnKwargsTask(
-            self.transfer_coordinator, main_kwargs=main_kwargs,
+            self.transfer_coordinator,
+            main_kwargs=main_kwargs,
             pending_main_kwargs=pending_kwargs,
-            is_final=True)()
+            is_final=True,
+        )()
         # The result should have all of the kwargs (both pending and
         # nonpending)
         self.assertEqual(self.transfer_coordinator.result(), ref_main_kwargs)
@@ -618,16 +676,19 @@ class TestTask(unittest.TestCase):
             pending_kwargs['foo'] = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value': 'bar'}
+                    main_kwargs={'return_value': 'bar'},
                 )
             )
             pending_kwargs['baz'] = executor.submit(
-                FailureTask(self.transfer_coordinator))
+                FailureTask(self.transfer_coordinator)
+            )
 
         # Create a task that depends on the tasks passed to the executor
         ReturnKwargsTask(
-            self.transfer_coordinator, pending_main_kwargs=pending_kwargs,
-            is_final=True)()
+            self.transfer_coordinator,
+            pending_main_kwargs=pending_kwargs,
+            is_final=True,
+        )()
         # The end result should raise the exception from the initial
         # pending future value
         with self.assertRaises(TaskFailureException):
@@ -642,18 +703,21 @@ class TestTask(unittest.TestCase):
             first_future = executor.submit(
                 SuccessTask(
                     self.transfer_coordinator,
-                    main_kwargs={'return_value': 'bar'}
+                    main_kwargs={'return_value': 'bar'},
                 )
             )
             second_future = executor.submit(
-                FailureTask(self.transfer_coordinator))
+                FailureTask(self.transfer_coordinator)
+            )
 
             pending_kwargs['pending_list'] = [first_future, second_future]
 
         # Create a task that depends on the tasks passed to the executor
         ReturnKwargsTask(
-            self.transfer_coordinator, pending_main_kwargs=pending_kwargs,
-            is_final=True)()
+            self.transfer_coordinator,
+            pending_main_kwargs=pending_kwargs,
+            is_final=True,
+        )()
         # The end result should raise the exception from the initial
         # pending future value in the list
         with self.assertRaises(TaskFailureException):
@@ -678,8 +742,8 @@ class TestCreateMultipartUploadTask(BaseMultipartTaskTest):
                 'client': self.client,
                 'bucket': self.bucket,
                 'key': self.key,
-                'extra_args': extra_args
-            }
+                'extra_args': extra_args,
+            },
         )
         self.stubber.add_response(
             method='create_multipart_upload',
@@ -687,8 +751,8 @@ class TestCreateMultipartUploadTask(BaseMultipartTaskTest):
             expected_params={
                 'Bucket': self.bucket,
                 'Key': self.key,
-                'Metadata': {'foo': 'bar'}
-            }
+                'Metadata': {'foo': 'bar'},
+            },
         )
         result_id = task()
         self.stubber.assert_no_pending_responses()
@@ -705,8 +769,8 @@ class TestCreateMultipartUploadTask(BaseMultipartTaskTest):
             expected_params={
                 'Bucket': self.bucket,
                 'Key': self.key,
-                'UploadId': upload_id
-            }
+                'UploadId': upload_id,
+            },
         )
         self.transfer_coordinator.failure_cleanups[0]()
         self.stubber.assert_no_pending_responses()
@@ -724,19 +788,18 @@ class TestCompleteMultipartUploadTask(BaseMultipartTaskTest):
                 'key': self.key,
                 'upload_id': upload_id,
                 'parts': parts,
-                'extra_args': {}
-            }
+                'extra_args': {},
+            },
         )
         self.stubber.add_response(
             method='complete_multipart_upload',
             service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
+                'Bucket': self.bucket,
+                'Key': self.key,
                 'UploadId': upload_id,
-                'MultipartUpload': {
-                    'Parts': parts
-                }
-            }
+                'MultipartUpload': {'Parts': parts},
+            },
         )
         task()
         self.stubber.assert_no_pending_responses()
@@ -752,20 +815,19 @@ class TestCompleteMultipartUploadTask(BaseMultipartTaskTest):
                 'key': self.key,
                 'upload_id': upload_id,
                 'parts': parts,
-                'extra_args': {'RequestPayer': 'requester'}
-            }
+                'extra_args': {'RequestPayer': 'requester'},
+            },
         )
         self.stubber.add_response(
             method='complete_multipart_upload',
             service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
+                'Bucket': self.bucket,
+                'Key': self.key,
                 'UploadId': upload_id,
-                'MultipartUpload': {
-                    'Parts': parts
-                },
-                'RequestPayer': 'requester'
-            }
+                'MultipartUpload': {'Parts': parts},
+                'RequestPayer': 'requester',
+            },
         )
         task()
         self.stubber.assert_no_pending_responses()

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -82,15 +82,15 @@ class ExceptionSubmissionTask(SubmissionTask):
 
 class StatusRecordingTransferCoordinator(TransferCoordinator):
     def __init__(self, transfer_id=None):
-        super(StatusRecordingTransferCoordinator, self).__init__(transfer_id)
+        super().__init__(transfer_id)
         self.status_changes = [self._status]
 
     def set_status_to_queued(self):
-        super(StatusRecordingTransferCoordinator, self).set_status_to_queued()
+        super().set_status_to_queued()
         self._record_status_change()
 
     def set_status_to_running(self):
-        super(StatusRecordingTransferCoordinator, self).set_status_to_running()
+        super().set_status_to_running()
         self._record_status_change()
 
     def _record_status_change(self):
@@ -108,7 +108,7 @@ class RecordingStateSubscriber(BaseSubscriber):
 
 class TestSubmissionTask(BaseSubmissionTaskTest):
     def setUp(self):
-        super(TestSubmissionTask, self).setUp()
+        super().setUp()
         self.executor = BoundedExecutor(1000, 5)
         self.call_args = CallArgs(subscribers=[])
         self.transfer_future = self.get_transfer_future(self.call_args)
@@ -386,7 +386,7 @@ class TestTask(unittest.TestCase):
         # a desired parameter to include.
         self.assertEqual(
             repr(task),
-            'ReturnKwargsTask(transfer_id=%s, %s)' % (
+            'ReturnKwargsTask(transfer_id={}, {})'.format(
                 self.transfer_id, {'bucket': 'mybucket'})
         )
 
@@ -662,7 +662,7 @@ class TestTask(unittest.TestCase):
 
 class BaseMultipartTaskTest(BaseTaskTest):
     def setUp(self):
-        super(BaseMultipartTaskTest, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'foo'
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -14,20 +14,21 @@ from concurrent import futures
 from functools import partial
 from threading import Event
 
-from tests import unittest
-from tests import RecordingSubscriber
-from tests import BaseTaskTest
-from tests import BaseSubmissionTaskTest
-from s3transfer.futures import TransferCoordinator
-from s3transfer.futures import BoundedExecutor
+from s3transfer.futures import BoundedExecutor, TransferCoordinator
 from s3transfer.subscribers import BaseSubscriber
-from s3transfer.tasks import Task
-from s3transfer.tasks import SubmissionTask
-from s3transfer.tasks import CreateMultipartUploadTask
-from s3transfer.tasks import CompleteMultipartUploadTask
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import CallArgs
-from s3transfer.utils import FunctionContainer
+from s3transfer.tasks import (
+    CompleteMultipartUploadTask,
+    CreateMultipartUploadTask,
+    SubmissionTask,
+    Task,
+)
+from s3transfer.utils import CallArgs, FunctionContainer, get_callbacks
+from tests import (
+    BaseSubmissionTaskTest,
+    BaseTaskTest,
+    RecordingSubscriber,
+    unittest,
+)
 
 
 class TaskFailureException(Exception):

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -10,16 +10,15 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from __future__ import division
 
 import math
 import os
 import shutil
 import tempfile
+from io import BytesIO
 
 from botocore.stub import ANY
 
-from s3transfer.compat import six
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.manager import TransferConfig
 from s3transfer.upload import (
@@ -56,7 +55,7 @@ class OSUtilsExceptionOnFileSize(OSUtils):
 
 class BaseUploadTest(BaseTaskTest):
     def setUp(self):
-        super(BaseUploadTest, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'foo'
         self.osutil = OSUtils()
@@ -76,7 +75,7 @@ class BaseUploadTest(BaseTaskTest):
             'before-parameter-build.s3.*', self.collect_body)
 
     def tearDown(self):
-        super(BaseUploadTest, self).tearDown()
+        super().tearDown()
         shutil.rmtree(self.tempdir)
 
     def collect_body(self, params, **kwargs):
@@ -157,7 +156,7 @@ class TestInterruptReader(BaseUploadTest):
 
 class BaseUploadInputManagerTest(BaseUploadTest):
     def setUp(self):
-        super(BaseUploadInputManagerTest, self).setUp()
+        super().setUp()
         self.osutil = OSUtils()
         self.config = TransferConfig()
         self.recording_subscriber = RecordingSubscriber()
@@ -177,7 +176,7 @@ class BaseUploadInputManagerTest(BaseUploadTest):
 
 class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
     def setUp(self):
-        super(TestUploadFilenameInputManager, self).setUp()
+        super().setUp()
         self.upload_input_manager = UploadFilenameInputManager(
             self.osutil, self.transfer_coordinator)
         self.call_args = CallArgs(
@@ -294,7 +293,7 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
 
 class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
     def setUp(self):
-        super(TestUploadSeekableInputManager, self).setUp()
+        super().setUp()
         self.upload_input_manager = UploadSeekableInputManager(
             self.osutil, self.transfer_coordinator)
         self.fileobj = open(self.filename, 'rb')
@@ -304,11 +303,11 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
 
     def tearDown(self):
         self.fileobj.close()
-        super(TestUploadSeekableInputManager, self).tearDown()
+        super().tearDown()
 
     def test_is_compatible_bytes_io(self):
         self.assertTrue(
-            self.upload_input_manager.is_compatible(six.BytesIO()))
+            self.upload_input_manager.is_compatible(BytesIO()))
 
     def test_not_compatible_for_non_filelike_obj(self):
         self.assertFalse(self.upload_input_manager.is_compatible(object()))
@@ -337,7 +336,7 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
 
 class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
     def setUp(self):
-        super(TestUploadNonSeekableInputManager, self).setUp()
+        super().setUp()
         self.upload_input_manager = UploadNonSeekableInputManager(
             self.osutil, self.transfer_coordinator)
         self.fileobj = NonSeekableReader(self.content)
@@ -416,7 +415,7 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
 
 class TestUploadSubmissionTask(BaseSubmissionTaskTest):
     def setUp(self):
-        super(TestUploadSubmissionTask, self).setUp()
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
         self.filename = os.path.join(self.tempdir, 'myfile')
         self.content = b'0' * (MIN_UPLOAD_CHUNKSIZE * 3)
@@ -450,7 +449,7 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
             UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
 
     def tearDown(self):
-        super(TestUploadSubmissionTask, self).tearDown()
+        super().tearDown()
         shutil.rmtree(self.tempdir)
 
     def collect_body(self, params, **kwargs):

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -11,34 +11,37 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from __future__ import division
-import os
-import tempfile
-import shutil
+
 import math
+import os
+import shutil
+import tempfile
 
 from botocore.stub import ANY
 
-from tests import unittest
-from tests import BaseTaskTest
-from tests import BaseSubmissionTaskTest
-from tests import FileSizeProvider
-from tests import RecordingSubscriber
-from tests import RecordingExecutor
-from tests import NonSeekableReader
 from s3transfer.compat import six
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.manager import TransferConfig
-from s3transfer.upload import AggregatedProgressCallback
-from s3transfer.upload import InterruptReader
-from s3transfer.upload import UploadFilenameInputManager
-from s3transfer.upload import UploadSeekableInputManager
-from s3transfer.upload import UploadNonSeekableInputManager
-from s3transfer.upload import UploadSubmissionTask
-from s3transfer.upload import PutObjectTask
-from s3transfer.upload import UploadPartTask
-from s3transfer.utils import CallArgs
-from s3transfer.utils import OSUtils
-from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE
+from s3transfer.upload import (
+    AggregatedProgressCallback,
+    InterruptReader,
+    PutObjectTask,
+    UploadFilenameInputManager,
+    UploadNonSeekableInputManager,
+    UploadPartTask,
+    UploadSeekableInputManager,
+    UploadSubmissionTask,
+)
+from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE, CallArgs, OSUtils
+from tests import (
+    BaseSubmissionTaskTest,
+    BaseTaskTest,
+    FileSizeProvider,
+    NonSeekableReader,
+    RecordingExecutor,
+    RecordingSubscriber,
+    unittest,
+)
 
 
 class InterruptionError(Exception):

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -50,7 +50,8 @@ class InterruptionError(Exception):
 class OSUtilsExceptionOnFileSize(OSUtils):
     def get_file_size(self, filename):
         raise AssertionError(
-            "The file %s should not have been stated" % filename)
+            "The file %s should not have been stated" % filename
+        )
 
 
 class BaseUploadTest(BaseTaskTest):
@@ -72,7 +73,8 @@ class BaseUploadTest(BaseTaskTest):
         # and their order.
         self.sent_bodies = []
         self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
+            'before-parameter-build.s3.*', self.collect_body
+        )
 
     def tearDown(self):
         super().tearDown()
@@ -88,7 +90,8 @@ class TestAggregatedProgressCallback(unittest.TestCase):
         self.aggregated_amounts = []
         self.threshold = 3
         self.aggregated_progress_callback = AggregatedProgressCallback(
-            [self.callback], self.threshold)
+            [self.callback], self.threshold
+        )
 
     def callback(self, bytes_transferred):
         self.aggregated_amounts.append(bytes_transferred)
@@ -178,24 +181,29 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
     def setUp(self):
         super().setUp()
         self.upload_input_manager = UploadFilenameInputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator
+        )
         self.call_args = CallArgs(
-            fileobj=self.filename, subscribers=self.subscribers)
+            fileobj=self.filename, subscribers=self.subscribers
+        )
         self.future = self.get_transfer_future(self.call_args)
 
     def test_is_compatible(self):
         self.assertTrue(
             self.upload_input_manager.is_compatible(
-                self.future.meta.call_args.fileobj)
+                self.future.meta.call_args.fileobj
+            )
         )
 
     def test_stores_bodies_in_memory_put_object(self):
         self.assertFalse(
-            self.upload_input_manager.stores_body_in_memory('put_object'))
+            self.upload_input_manager.stores_body_in_memory('put_object')
+        )
 
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertFalse(
-            self.upload_input_manager.stores_body_in_memory('upload_part'))
+            self.upload_input_manager.stores_body_in_memory('upload_part')
+        )
 
     def test_provide_transfer_size(self):
         self.upload_input_manager.provide_transfer_size(self.future)
@@ -210,18 +218,23 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # transfer.
         self.assertFalse(
             self.upload_input_manager.requires_multipart_upload(
-                self.future, self.config))
+                self.future, self.config
+            )
+        )
         # Decreasing the threshold to that of the length of the content of
         # the file should trigger the need for a multipart upload.
         self.config.multipart_threshold = len(self.content)
         self.assertTrue(
             self.upload_input_manager.requires_multipart_upload(
-                self.future, self.config))
+                self.future, self.config
+            )
+        )
 
     def test_get_put_object_body(self):
         self.future.meta.provide_transfer_size(len(self.content))
         read_file_chunk = self.upload_input_manager.get_put_object_body(
-            self.future)
+            self.future
+        )
         read_file_chunk.enable_callback()
         # The file-like object provided back should be the same as the content
         # of the file.
@@ -230,13 +243,14 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # The file-like object should also have been wrapped with the
         # on_queued callbacks to track the amount of bytes being transferred.
         self.assertEqual(
-            self.recording_subscriber.calculate_bytes_seen(),
-            len(self.content))
+            self.recording_subscriber.calculate_bytes_seen(), len(self.content)
+        )
 
     def test_get_put_object_body_is_interruptable(self):
         self.future.meta.provide_transfer_size(len(self.content))
         read_file_chunk = self.upload_input_manager.get_put_object_body(
-            self.future)
+            self.future
+        )
 
         # Set an exception in the transfer coordinator
         self.transfer_coordinator.set_exception(InterruptionError)
@@ -253,7 +267,8 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # Get an iterator that will yield all of the bodies and their
         # respective part number.
         part_iterator = self.upload_input_manager.yield_upload_part_bodies(
-            self.future, self.config.multipart_chunksize)
+            self.future, self.config.multipart_chunksize
+        )
         expected_part_number = 1
         for part_number, read_file_chunk in part_iterator:
             # Ensure that the part number is as expected
@@ -263,14 +278,15 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
             with read_file_chunk:
                 self.assertEqual(
                     read_file_chunk.read(),
-                    self._get_expected_body_for_part(part_number))
+                    self._get_expected_body_for_part(part_number),
+                )
             expected_part_number += 1
 
         # All of the file-like object should also have been wrapped with the
         # on_queued callbacks to track the amount of bytes being transferred.
         self.assertEqual(
-            self.recording_subscriber.calculate_bytes_seen(),
-            len(self.content))
+            self.recording_subscriber.calculate_bytes_seen(), len(self.content)
+        )
 
     def test_yield_upload_part_bodies_are_interruptable(self):
         # Adjust the chunk size to something more grainular for testing.
@@ -280,7 +296,8 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # Get an iterator that will yield all of the bodies and their
         # respective part number.
         part_iterator = self.upload_input_manager.yield_upload_part_bodies(
-            self.future, self.config.multipart_chunksize)
+            self.future, self.config.multipart_chunksize
+        )
 
         # Set an exception in the transfer coordinator
         self.transfer_coordinator.set_exception(InterruptionError)
@@ -295,10 +312,12 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
     def setUp(self):
         super().setUp()
         self.upload_input_manager = UploadSeekableInputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator
+        )
         self.fileobj = open(self.filename, 'rb')
         self.call_args = CallArgs(
-            fileobj=self.fileobj, subscribers=self.subscribers)
+            fileobj=self.fileobj, subscribers=self.subscribers
+        )
         self.future = self.get_transfer_future(self.call_args)
 
     def tearDown(self):
@@ -306,15 +325,15 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
         super().tearDown()
 
     def test_is_compatible_bytes_io(self):
-        self.assertTrue(
-            self.upload_input_manager.is_compatible(BytesIO()))
+        self.assertTrue(self.upload_input_manager.is_compatible(BytesIO()))
 
     def test_not_compatible_for_non_filelike_obj(self):
         self.assertFalse(self.upload_input_manager.is_compatible(object()))
 
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertTrue(
-            self.upload_input_manager.stores_body_in_memory('upload_part'))
+            self.upload_input_manager.stores_body_in_memory('upload_part')
+        )
 
     def test_get_put_object_body(self):
         start_pos = 3
@@ -322,7 +341,8 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
         adjusted_size = len(self.content) - start_pos
         self.future.meta.provide_transfer_size(adjusted_size)
         read_file_chunk = self.upload_input_manager.get_put_object_body(
-            self.future)
+            self.future
+        )
 
         read_file_chunk.enable_callback()
         # The fact that the file was seeked to start should be taken into
@@ -331,17 +351,20 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
             self.assertEqual(len(read_file_chunk), adjusted_size)
             self.assertEqual(read_file_chunk.read(), self.content[start_pos:])
         self.assertEqual(
-            self.recording_subscriber.calculate_bytes_seen(), adjusted_size)
+            self.recording_subscriber.calculate_bytes_seen(), adjusted_size
+        )
 
 
 class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
     def setUp(self):
         super().setUp()
         self.upload_input_manager = UploadNonSeekableInputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator
+        )
         self.fileobj = NonSeekableReader(self.content)
         self.call_args = CallArgs(
-            fileobj=self.fileobj, subscribers=self.subscribers)
+            fileobj=self.fileobj, subscribers=self.subscribers
+        )
         self.future = self.get_transfer_future(self.call_args)
 
     def assert_multipart_parts(self):
@@ -352,12 +375,16 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
         # Assert that a multipart upload is required.
         self.assertTrue(
             self.upload_input_manager.requires_multipart_upload(
-                self.future, self.config))
+                self.future, self.config
+            )
+        )
 
         # Get a list of all the parts that would be sent.
         parts = list(
             self.upload_input_manager.yield_upload_part_bodies(
-                self.future, self.config.multipart_chunksize))
+                self.future, self.config.multipart_chunksize
+            )
+        )
 
         # Assert that the actual number of parts is what we would expect
         # based on the configuration.
@@ -388,11 +415,13 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
 
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertTrue(
-            self.upload_input_manager.stores_body_in_memory('upload_part'))
+            self.upload_input_manager.stores_body_in_memory('upload_part')
+        )
 
     def test_stores_bodies_in_memory_put_object(self):
         self.assertTrue(
-            self.upload_input_manager.stores_body_in_memory('put_object'))
+            self.upload_input_manager.stores_body_in_memory('put_object')
+        )
 
     def test_initial_data_parts_threshold_lesser(self):
         # threshold < size
@@ -434,7 +463,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         # and their order.
         self.sent_bodies = []
         self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
+            'before-parameter-build.s3.*', self.collect_body
+        )
 
         self.call_args = self.get_call_args()
         self.transfer_future = self.get_transfer_future(self.call_args)
@@ -443,10 +473,11 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
             'config': self.config,
             'osutil': self.osutil,
             'request_executor': self.executor,
-            'transfer_future': self.transfer_future
+            'transfer_future': self.transfer_future,
         }
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
 
     def tearDown(self):
         super().tearDown()
@@ -458,9 +489,11 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
 
     def get_call_args(self, **kwargs):
         default_call_args = {
-            'fileobj': self.filename, 'bucket': self.bucket,
-            'key': self.key, 'extra_args': self.extra_args,
-            'subscribers': self.subscribers
+            'fileobj': self.filename,
+            'bucket': self.bucket,
+            'key': self.key,
+            'extra_args': self.extra_args,
+            'subscribers': self.subscribers,
         }
         default_call_args.update(kwargs)
         return CallArgs(**default_call_args)
@@ -468,23 +501,19 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
     def add_multipart_upload_stubbed_responses(self):
         self.stubber.add_response(
             method='create_multipart_upload',
-            service_response={'UploadId': 'my-id'}
+            service_response={'UploadId': 'my-id'},
         )
         self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': 'etag-1'}
+            method='upload_part', service_response={'ETag': 'etag-1'}
         )
         self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': 'etag-2'}
+            method='upload_part', service_response={'ETag': 'etag-2'}
         )
         self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': 'etag-3'}
+            method='upload_part', service_response={'ETag': 'etag-3'}
         )
         self.stubber.add_response(
-            method='complete_multipart_upload',
-            service_response={}
+            method='complete_multipart_upload', service_response={}
         )
 
     def wrap_executor_in_recorder(self):
@@ -497,13 +526,11 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.submission_main_kwargs['transfer_future'] = self.transfer_future
 
     def assert_tag_value_for_put_object(self, tag_value):
-        self.assertEqual(
-            self.executor.submissions[0]['tag'], tag_value)
+        self.assertEqual(self.executor.submissions[0]['tag'], tag_value)
 
     def assert_tag_value_for_upload_parts(self, tag_value):
         for submission in self.executor.submissions[1:-1]:
-            self.assertEqual(
-                submission['tag'], tag_value)
+            self.assertEqual(submission['tag'], tag_value)
 
     def test_provide_file_size_on_put(self):
         self.call_args.subscribers.append(FileSizeProvider(len(self.content)))
@@ -511,9 +538,10 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
             method='put_object',
             service_response={},
             expected_params={
-                'Body': ANY, 'Bucket': self.bucket,
-                'Key': self.key
-            }
+                'Body': ANY,
+                'Bucket': self.bucket,
+                'Key': self.key,
+            },
         )
 
         # With this submitter, it will fail to stat the file if a transfer
@@ -521,7 +549,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.submission_main_kwargs['osutil'] = OSUtilsExceptionOnFileSize()
 
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
         self.submission_task()
         self.transfer_future.result()
         self.stubber.assert_no_pending_responses()
@@ -532,7 +561,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.stubber.add_response('put_object', {})
 
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
         self.submission_task()
         self.transfer_future.result()
         self.stubber.assert_no_pending_responses()
@@ -549,7 +579,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.config.multipart_threshold = 1
 
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
         self.submission_task()
         self.transfer_future.result()
         self.stubber.assert_no_pending_responses()
@@ -565,7 +596,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         with open(self.filename, 'rb') as f:
             self.use_fileobj_in_call_args(f)
             self.submission_task = self.get_task(
-                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+            )
             self.submission_task()
             self.transfer_future.result()
             self.stubber.assert_no_pending_responses()
@@ -584,7 +616,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         with open(self.filename, 'rb') as f:
             self.use_fileobj_in_call_args(f)
             self.submission_task = self.get_task(
-                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+            )
             self.submission_task()
             self.transfer_future.result()
             self.stubber.assert_no_pending_responses()
@@ -606,16 +639,18 @@ class TestPutObjectTask(BaseUploadTest):
                     'fileobj': fileobj,
                     'bucket': self.bucket,
                     'key': self.key,
-                    'extra_args': extra_args
-                }
+                    'extra_args': extra_args,
+                },
             )
             self.stubber.add_response(
                 method='put_object',
                 service_response={},
                 expected_params={
-                    'Body': ANY, 'Bucket': self.bucket, 'Key': self.key,
-                    'Metadata': {'foo': 'bar'}
-                }
+                    'Body': ANY,
+                    'Bucket': self.bucket,
+                    'Key': self.key,
+                    'Metadata': {'foo': 'bar'},
+                },
             )
             task()
             self.stubber.assert_no_pending_responses()
@@ -638,17 +673,20 @@ class TestUploadPartTask(BaseUploadTest):
                     'key': self.key,
                     'upload_id': upload_id,
                     'part_number': part_number,
-                    'extra_args': extra_args
-                }
+                    'extra_args': extra_args,
+                },
             )
             self.stubber.add_response(
                 method='upload_part',
                 service_response={'ETag': etag},
                 expected_params={
-                    'Body': ANY, 'Bucket': self.bucket, 'Key': self.key,
-                    'UploadId': upload_id, 'PartNumber': part_number,
-                    'RequestPayer': 'requester'
-                }
+                    'Body': ANY,
+                    'Bucket': self.bucket,
+                    'Key': self.key,
+                    'UploadId': upload_id,
+                    'PartNumber': part_number,
+                    'RequestPayer': 'requester',
+                },
             )
             rval = task()
             self.stubber.assert_no_pending_responses()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,39 +10,40 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 import os.path
+import random
+import re
 import shutil
 import tempfile
 import threading
-import random
-import re
 import time
-import io
 
-
-from tests import mock, unittest, RecordingSubscriber, NonSeekableWriter
 from s3transfer.compat import six
-from s3transfer.futures import TransferFuture
-from s3transfer.futures import TransferMeta
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import random_file_extension
-from s3transfer.utils import invoke_progress_callbacks
-from s3transfer.utils import calculate_num_parts
-from s3transfer.utils import calculate_range_parameter
-from s3transfer.utils import get_filtered_dict
-from s3transfer.utils import CallArgs
-from s3transfer.utils import FunctionContainer
-from s3transfer.utils import CountCallbackInvoker
-from s3transfer.utils import OSUtils
-from s3transfer.utils import DeferredOpenFile
-from s3transfer.utils import ReadFileChunk
-from s3transfer.utils import StreamReaderProgress
-from s3transfer.utils import TaskSemaphore
-from s3transfer.utils import SlidingWindowSemaphore
-from s3transfer.utils import NoResourcesAvailable
-from s3transfer.utils import ChunksizeAdjuster
-from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE, MAX_SINGLE_UPLOAD_SIZE
-from s3transfer.utils import MAX_PARTS
+from s3transfer.futures import TransferFuture, TransferMeta
+from s3transfer.utils import (
+    MAX_PARTS,
+    MAX_SINGLE_UPLOAD_SIZE,
+    MIN_UPLOAD_CHUNKSIZE,
+    CallArgs,
+    ChunksizeAdjuster,
+    CountCallbackInvoker,
+    DeferredOpenFile,
+    FunctionContainer,
+    NoResourcesAvailable,
+    OSUtils,
+    ReadFileChunk,
+    SlidingWindowSemaphore,
+    StreamReaderProgress,
+    TaskSemaphore,
+    calculate_num_parts,
+    calculate_range_parameter,
+    get_callbacks,
+    get_filtered_dict,
+    invoke_progress_callbacks,
+    random_file_extension,
+)
+from tests import NonSeekableWriter, RecordingSubscriber, mock, unittest
 
 
 class TestGetCallbacks(unittest.TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,8 +18,8 @@ import shutil
 import tempfile
 import threading
 import time
+from io import BytesIO, StringIO
 
-from s3transfer.compat import six
 from s3transfer.futures import TransferFuture, TransferMeta
 from s3transfer.utils import (
     MAX_PARTS,
@@ -110,7 +110,7 @@ class TestFunctionContainer(unittest.TestCase):
         func_container = FunctionContainer(
             self.get_args_kwargs, 'foo', bar='baz')
         self.assertEqual(
-            str(func_container), 'Function: %s with args %s and kwargs %s' % (
+            str(func_container), 'Function: {} with args {} and kwargs {}'.format(
                 self.get_args_kwargs, ('foo',), {'bar': 'baz'}))
 
 
@@ -336,7 +336,7 @@ class TestOSUtils(BaseUtilsTest):
 
 class TestDeferredOpenFile(BaseUtilsTest):
     def setUp(self):
-        super(TestDeferredOpenFile, self).setUp()
+        super().setUp()
         self.filename = os.path.join(self.tempdir, 'foo')
         self.contents = b'my contents'
         with open(self.filename, 'wb') as f:
@@ -347,7 +347,7 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def tearDown(self):
         self.deferred_open_file.close()
-        super(TestDeferredOpenFile, self).tearDown()
+        super().tearDown()
 
     def recording_open_function(self, filename, mode):
         self.open_call_args.append((filename, mode))
@@ -355,7 +355,7 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def open_nonseekable(self, filename, mode):
         self.open_call_args.append((filename, mode))
-        return NonSeekableWriter(six.BytesIO(self.content))
+        return NonSeekableWriter(BytesIO(self.content))
 
     def test_instantiation_does_not_open_file(self):
         DeferredOpenFile(
@@ -825,12 +825,12 @@ class TestReadFileChunk(BaseUtilsTest):
 
 class TestStreamReaderProgress(BaseUtilsTest):
     def test_proxies_to_wrapped_stream(self):
-        original_stream = six.StringIO('foobarbaz')
+        original_stream = StringIO('foobarbaz')
         wrapped = StreamReaderProgress(original_stream)
         self.assertEqual(wrapped.read(), 'foobarbaz')
 
     def test_callback_invoked(self):
-        original_stream = six.StringIO('foobarbaz')
+        original_stream = StringIO('foobarbaz')
         wrapped = StreamReaderProgress(
             original_stream, [self.callback, self.callback])
         self.assertEqual(wrapped.read(), 'foobarbaz')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -50,8 +50,8 @@ class TestGetCallbacks(unittest.TestCase):
     def setUp(self):
         self.subscriber = RecordingSubscriber()
         self.second_subscriber = RecordingSubscriber()
-        self.call_args = CallArgs(subscribers=[
-            self.subscriber, self.second_subscriber]
+        self.call_args = CallArgs(
+            subscribers=[self.subscriber, self.second_subscriber]
         )
         self.transfer_meta = TransferMeta(self.call_args)
         self.transfer_future = TransferFuture(self.transfer_meta)
@@ -66,8 +66,7 @@ class TestGetCallbacks(unittest.TestCase):
         # one of them and checking that the future was used in the call.
         callbacks[0]()
         self.assertEqual(
-            self.subscriber.on_queued_calls,
-            [{'future': self.transfer_future}]
+            self.subscriber.on_queued_calls, [{'future': self.transfer_future}]
         )
 
     def test_get_callbacks_for_missing_type(self):
@@ -79,14 +78,10 @@ class TestGetCallbacks(unittest.TestCase):
 
 class TestGetFilteredDict(unittest.TestCase):
     def test_get_filtered_dict(self):
-        original = {
-            'Include': 'IncludeValue',
-            'NotInlude': 'NotIncludeValue'
-        }
+        original = {'Include': 'IncludeValue', 'NotInlude': 'NotIncludeValue'}
         whitelist = ['Include']
         self.assertEqual(
-            get_filtered_dict(original, whitelist),
-            {'Include': 'IncludeValue'}
+            get_filtered_dict(original, whitelist), {'Include': 'IncludeValue'}
         )
 
 
@@ -103,15 +98,20 @@ class TestFunctionContainer(unittest.TestCase):
 
     def test_call(self):
         func_container = FunctionContainer(
-            self.get_args_kwargs, 'foo', bar='baz')
+            self.get_args_kwargs, 'foo', bar='baz'
+        )
         self.assertEqual(func_container(), (('foo',), {'bar': 'baz'}))
 
     def test_repr(self):
         func_container = FunctionContainer(
-            self.get_args_kwargs, 'foo', bar='baz')
+            self.get_args_kwargs, 'foo', bar='baz'
+        )
         self.assertEqual(
-            str(func_container), 'Function: {} with args {} and kwargs {}'.format(
-                self.get_args_kwargs, ('foo',), {'bar': 'baz'}))
+            str(func_container),
+            'Function: {} with args {} and kwargs {}'.format(
+                self.get_args_kwargs, ('foo',), {'bar': 'baz'}
+            ),
+        )
 
 
 class TestCountCallbackInvoker(unittest.TestCase):
@@ -167,8 +167,7 @@ class TestCountCallbackInvoker(unittest.TestCase):
 
 class TestRandomFileExtension(unittest.TestCase):
     def test_has_proper_length(self):
-        self.assertEqual(
-            len(random_file_extension(num_digits=4)), 4)
+        self.assertEqual(len(random_file_extension(num_digits=4)), 4)
 
 
 class TestInvokeProgressCallbacks(unittest.TestCase):
@@ -199,17 +198,20 @@ class TestCalculateRangeParameter(unittest.TestCase):
 
     def test_calculate_range_paramter(self):
         range_val = calculate_range_parameter(
-            self.part_size, self.part_index, self.num_parts)
+            self.part_size, self.part_index, self.num_parts
+        )
         self.assertEqual(range_val, 'bytes=5-9')
 
     def test_last_part_with_no_total_size(self):
         range_val = calculate_range_parameter(
-            self.part_size, self.part_index, num_parts=2)
+            self.part_size, self.part_index, num_parts=2
+        )
         self.assertEqual(range_val, 'bytes=5-')
 
     def test_last_part_with_total_size(self):
         range_val = calculate_range_parameter(
-            self.part_size, self.part_index, num_parts=2, total_size=8)
+            self.part_size, self.part_index, num_parts=2, total_size=8
+        )
         self.assertEqual(range_val, 'bytes=5-7')
 
 
@@ -236,11 +238,13 @@ class BaseUtilsTest(unittest.TestCase):
 class TestOSUtils(BaseUtilsTest):
     def test_get_file_size(self):
         self.assertEqual(
-            OSUtils().get_file_size(self.filename), len(self.content))
+            OSUtils().get_file_size(self.filename), len(self.content)
+        )
 
     def test_open_file_chunk_reader(self):
         reader = OSUtils().open_file_chunk_reader(
-            self.filename, 0, 3, [self.callback])
+            self.filename, 0, 3, [self.callback]
+        )
 
         # The returned reader should be a ReadFileChunk.
         self.assertIsInstance(reader, ReadFileChunk)
@@ -252,7 +256,8 @@ class TestOSUtils(BaseUtilsTest):
     def test_open_file_chunk_reader_from_fileobj(self):
         with open(self.filename, 'rb') as f:
             reader = OSUtils().open_file_chunk_reader_from_fileobj(
-                f, len(self.content), len(self.content), [self.callback])
+                f, len(self.content), len(self.content), [self.callback]
+            )
 
             # The returned reader should be a ReadFileChunk.
             self.assertIsInstance(reader, ReadFileChunk)
@@ -299,17 +304,17 @@ class TestOSUtils(BaseUtilsTest):
         self.assertIsNotNone(
             re.match(
                 r'%s\.[0-9A-Fa-f]{8}$' % filename,
-                OSUtils().get_temp_filename(filename)
+                OSUtils().get_temp_filename(filename),
             )
         )
 
     def test_get_temp_filename_len_255(self):
-        filename = 'a'*255
+        filename = 'a' * 255
         temp_filename = OSUtils().get_temp_filename(filename)
         self.assertLessEqual(len(temp_filename), 255)
 
     def test_get_temp_filename_len_gt_255(self):
-        filename = 'a'*280
+        filename = 'a' * 280
         temp_filename = OSUtils().get_temp_filename(filename)
         self.assertLessEqual(len(temp_filename), 255)
 
@@ -342,7 +347,8 @@ class TestDeferredOpenFile(BaseUtilsTest):
         with open(self.filename, 'wb') as f:
             f.write(self.contents)
         self.deferred_open_file = DeferredOpenFile(
-            self.filename, open_function=self.recording_open_function)
+            self.filename, open_function=self.recording_open_function
+        )
         self.open_call_args = []
 
     def tearDown(self):
@@ -359,7 +365,8 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def test_instantiation_does_not_open_file(self):
         DeferredOpenFile(
-            self.filename, open_function=self.recording_open_function)
+            self.filename, open_function=self.recording_open_function
+        )
         self.assertEqual(len(self.open_call_args), 0)
 
     def test_name(self):
@@ -374,8 +381,10 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def test_write(self):
         self.deferred_open_file = DeferredOpenFile(
-            self.filename, mode='wb',
-            open_function=self.recording_open_function)
+            self.filename,
+            mode='wb',
+            open_function=self.recording_open_function,
+        )
 
         write_content = b'foo'
         self.deferred_open_file.write(write_content)
@@ -383,7 +392,7 @@ class TestDeferredOpenFile(BaseUtilsTest):
         self.deferred_open_file.close()
         # Both of the writes should now be in the file.
         with open(self.filename, 'rb') as f:
-            self.assertEqual(f.read(), write_content*2)
+            self.assertEqual(f.read(), write_content * 2)
         # Open should have only been called once.
         self.assertEqual(len(self.open_call_args), 1)
 
@@ -395,8 +404,11 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def test_open_does_not_seek_with_zero_start_byte(self):
         self.deferred_open_file = DeferredOpenFile(
-            self.filename, mode='wb', start_byte=0,
-            open_function=self.open_nonseekable)
+            self.filename,
+            mode='wb',
+            start_byte=0,
+            open_function=self.open_nonseekable,
+        )
 
         try:
             # If this seeks, an UnsupportedOperation error will be raised.
@@ -406,8 +418,11 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def test_open_seeks_with_nonzero_start_byte(self):
         self.deferred_open_file = DeferredOpenFile(
-            self.filename, mode='wb', start_byte=5,
-            open_function=self.open_nonseekable)
+            self.filename,
+            mode='wb',
+            start_byte=5,
+            open_function=self.open_nonseekable,
+        )
 
         # Since a non-seekable file is being opened, calling Seek will raise
         # an UnsupportedOperation error.
@@ -426,8 +441,10 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def test_open_args(self):
         self.deferred_open_file = DeferredOpenFile(
-            self.filename, mode='ab+',
-            open_function=self.recording_open_function)
+            self.filename,
+            mode='ab+',
+            open_function=self.recording_open_function,
+        )
         # Force an open
         self.deferred_open_file.write(b'data')
         self.assertEqual(len(self.open_call_args), 1)
@@ -444,7 +461,8 @@ class TestReadFileChunk(BaseUtilsTest):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=0, chunk_size=3)
+            filename, start_byte=0, chunk_size=3
+        )
         self.assertEqual(chunk.read(), b'one')
         self.assertEqual(chunk.read(), b'')
 
@@ -453,7 +471,8 @@ class TestReadFileChunk(BaseUtilsTest):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=11, chunk_size=4)
+            filename, start_byte=11, chunk_size=4
+        )
         self.assertEqual(chunk.read(1), b'f')
         self.assertEqual(chunk.read(1), b'o')
         self.assertEqual(chunk.read(1), b'u')
@@ -465,7 +484,8 @@ class TestReadFileChunk(BaseUtilsTest):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=11, chunk_size=4)
+            filename, start_byte=11, chunk_size=4
+        )
         self.assertEqual(chunk.read(), b'four')
         chunk.seek(0)
         self.assertEqual(chunk.read(), b'four')
@@ -475,7 +495,8 @@ class TestReadFileChunk(BaseUtilsTest):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=36, chunk_size=100000)
+            filename, start_byte=36, chunk_size=100000
+        )
         self.assertEqual(chunk.read(), b'ten')
         self.assertEqual(chunk.read(), b'')
         self.assertEqual(len(chunk), 3)
@@ -485,7 +506,8 @@ class TestReadFileChunk(BaseUtilsTest):
         with open(filename, 'wb') as f:
             f.write(b'onetwothreefourfivesixseveneightnineten')
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=36, chunk_size=100000)
+            filename, start_byte=36, chunk_size=100000
+        )
         self.assertEqual(chunk.tell(), 0)
         self.assertEqual(chunk.read(), b'ten')
         self.assertEqual(chunk.tell(), 3)
@@ -515,7 +537,8 @@ class TestReadFileChunk(BaseUtilsTest):
         file_objects = [
             ReadFileChunk.from_filename(
                 filename, start_byte=start_pos, chunk_size=chunk_size
-            )]
+            )
+        ]
 
         # Uncomment next line to validate we match Python's io.BytesIO
         # file_objects.append(io.BytesIO(data[start_pos:start_pos+chunk_size]))
@@ -610,9 +633,9 @@ class TestReadFileChunk(BaseUtilsTest):
         filename = os.path.join(self.tempdir, 'foo')
         with open(filename, 'wb') as f:
             f.write(b'abc')
-        with ReadFileChunk.from_filename(filename,
-                                         start_byte=0,
-                                         chunk_size=2) as chunk:
+        with ReadFileChunk.from_filename(
+            filename, start_byte=0, chunk_size=2
+        ) as chunk:
             val = chunk.read()
             self.assertEqual(val, b'ab')
 
@@ -622,13 +645,17 @@ class TestReadFileChunk(BaseUtilsTest):
         filename = os.path.join(self.tempdir, 'foo')
         open(filename, 'wb').close()
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=0, chunk_size=10)
+            filename, start_byte=0, chunk_size=10
+        )
         self.assertEqual(list(chunk), [])
 
     def test_callback_is_invoked_on_read(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3,
-            callbacks=[self.callback])
+            self.filename,
+            start_byte=0,
+            chunk_size=3,
+            callbacks=[self.callback],
+        )
         chunk.read(1)
         chunk.read(1)
         chunk.read(1)
@@ -636,8 +663,11 @@ class TestReadFileChunk(BaseUtilsTest):
 
     def test_all_callbacks_invoked_on_read(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3,
-            callbacks=[self.callback, self.callback])
+            self.filename,
+            start_byte=0,
+            chunk_size=3,
+            callbacks=[self.callback, self.callback],
+        )
         chunk.read(1)
         chunk.read(1)
         chunk.read(1)
@@ -647,8 +677,11 @@ class TestReadFileChunk(BaseUtilsTest):
 
     def test_callback_can_be_disabled(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3,
-            callbacks=[self.callback])
+            self.filename,
+            start_byte=0,
+            chunk_size=3,
+            callbacks=[self.callback],
+        )
         chunk.disable_callback()
         # Now reading from the ReadFileChunk should not invoke
         # the callback.
@@ -657,8 +690,11 @@ class TestReadFileChunk(BaseUtilsTest):
 
     def test_callback_will_also_be_triggered_by_seek(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3,
-            callbacks=[self.callback])
+            self.filename,
+            start_byte=0,
+            chunk_size=3,
+            callbacks=[self.callback],
+        )
         chunk.read(2)
         chunk.seek(0)
         chunk.read(2)
@@ -674,8 +710,8 @@ class TestReadFileChunk(BaseUtilsTest):
         with open(filename, 'wb') as f:
             f.write(data)
         chunk = ReadFileChunk.from_filename(
-            filename, start_byte=10, chunk_size=10,
-            callbacks=[self.callback])
+            filename, start_byte=10, chunk_size=10, callbacks=[self.callback]
+        )
 
         # Seek calls that generate "0" progress are skipped by
         # invoke_progress_callbacks and won't appear in the list.
@@ -692,18 +728,18 @@ class TestReadFileChunk(BaseUtilsTest):
 
         # (position, change)
         chunk.seek(20)  # (20, 10)
-        chunk.seek(5)   # (5, -5)
+        chunk.seek(5)  # (5, -5)
         chunk.seek(20)  # (20, 5)
-        chunk.seek(9)   # (9, -1)
+        chunk.seek(9)  # (9, -1)
         chunk.seek(20)  # (20, 1)
         chunk.seek(11)  # (11, 0)
         chunk.seek(20)  # (20, 0)
-        chunk.seek(9)   # (9, -1)
+        chunk.seek(9)  # (9, -1)
         chunk.seek(20)  # (20, 1)
-        chunk.seek(5)   # (5, -5)
+        chunk.seek(5)  # (5, -5)
         chunk.seek(20)  # (20, 5)
-        chunk.seek(0)   # (0, -10)
-        chunk.seek(0)   # (0, 0)
+        chunk.seek(0)  # (0, -10)
+        chunk.seek(0)  # (0, 0)
 
         self.assertEqual(self.amounts_seen, expected)
 
@@ -713,18 +749,18 @@ class TestReadFileChunk(BaseUtilsTest):
         self.assertEqual(self.amounts_seen, [])
 
         # (position, change)
-        chunk.seek(20, 1)     # (20, 10)
-        chunk.seek(-15, 1)    # (5, -5)
-        chunk.seek(15, 1)     # (20, 5)
-        chunk.seek(-11, 1)    # (9, -1)
-        chunk.seek(11, 1)     # (20, 1)
-        chunk.seek(-9, 1)     # (11, 0)
-        chunk.seek(9, 1)      # (20, 0)
-        chunk.seek(-11, 1)    # (9, -1)
-        chunk.seek(11, 1)     # (20, 1)
-        chunk.seek(-15, 1)    # (5, -5)
-        chunk.seek(15, 1)     # (20, 5)
-        chunk.seek(-20, 1)    # (0, -10)
+        chunk.seek(20, 1)  # (20, 10)
+        chunk.seek(-15, 1)  # (5, -5)
+        chunk.seek(15, 1)  # (20, 5)
+        chunk.seek(-11, 1)  # (9, -1)
+        chunk.seek(11, 1)  # (20, 1)
+        chunk.seek(-9, 1)  # (11, 0)
+        chunk.seek(9, 1)  # (20, 0)
+        chunk.seek(-11, 1)  # (9, -1)
+        chunk.seek(11, 1)  # (20, 1)
+        chunk.seek(-15, 1)  # (5, -5)
+        chunk.seek(15, 1)  # (20, 5)
+        chunk.seek(-20, 1)  # (0, -10)
         chunk.seek(-1000, 1)  # (0, 0)
 
         self.assertEqual(self.amounts_seen, expected)
@@ -735,48 +771,63 @@ class TestReadFileChunk(BaseUtilsTest):
         self.assertEqual(self.amounts_seen, [])
 
         # (position, change)
-        chunk.seek(10, 2)     # (20, 10)
-        chunk.seek(-5, 2)     # (5, -5)
-        chunk.seek(10, 2)     # (20, 5)
-        chunk.seek(-1, 2)     # (9, -1)
-        chunk.seek(10, 2)     # (20, 1)
-        chunk.seek(1, 2)      # (11, 0)
-        chunk.seek(10, 2)     # (20, 0)
-        chunk.seek(-1, 2)     # (9, -1)
-        chunk.seek(10, 2)     # (20, 1)
-        chunk.seek(-5, 2)     # (5, -5)
-        chunk.seek(10, 2)     # (20, 5)
-        chunk.seek(-10, 2)    # (0, -10)
+        chunk.seek(10, 2)  # (20, 10)
+        chunk.seek(-5, 2)  # (5, -5)
+        chunk.seek(10, 2)  # (20, 5)
+        chunk.seek(-1, 2)  # (9, -1)
+        chunk.seek(10, 2)  # (20, 1)
+        chunk.seek(1, 2)  # (11, 0)
+        chunk.seek(10, 2)  # (20, 0)
+        chunk.seek(-1, 2)  # (9, -1)
+        chunk.seek(10, 2)  # (20, 1)
+        chunk.seek(-5, 2)  # (5, -5)
+        chunk.seek(10, 2)  # (20, 5)
+        chunk.seek(-10, 2)  # (0, -10)
         chunk.seek(-1000, 2)  # (0, 0)
 
         self.assertEqual(self.amounts_seen, expected)
 
     def test_close_callbacks(self):
         with open(self.filename) as f:
-            chunk = ReadFileChunk(f, chunk_size=1, full_file_size=3,
-                                  close_callbacks=[self.close_callback])
+            chunk = ReadFileChunk(
+                f,
+                chunk_size=1,
+                full_file_size=3,
+                close_callbacks=[self.close_callback],
+            )
             chunk.close()
             self.assertEqual(self.num_close_callback_calls, 1)
 
     def test_close_callbacks_when_not_enabled(self):
         with open(self.filename) as f:
-            chunk = ReadFileChunk(f, chunk_size=1, full_file_size=3,
-                                  enable_callbacks=False,
-                                  close_callbacks=[self.close_callback])
+            chunk = ReadFileChunk(
+                f,
+                chunk_size=1,
+                full_file_size=3,
+                enable_callbacks=False,
+                close_callbacks=[self.close_callback],
+            )
             chunk.close()
             self.assertEqual(self.num_close_callback_calls, 0)
 
     def test_close_callbacks_when_context_handler_is_used(self):
         with open(self.filename) as f:
-            with ReadFileChunk(f, chunk_size=1, full_file_size=3,
-                               close_callbacks=[self.close_callback]) as chunk:
+            with ReadFileChunk(
+                f,
+                chunk_size=1,
+                full_file_size=3,
+                close_callbacks=[self.close_callback],
+            ) as chunk:
                 chunk.read(1)
             self.assertEqual(self.num_close_callback_calls, 1)
 
     def test_signal_transferring(self):
         chunk = ReadFileChunk.from_filename(
-            self.filename, start_byte=0, chunk_size=3,
-            callbacks=[self.callback])
+            self.filename,
+            start_byte=0,
+            chunk_size=3,
+            callbacks=[self.callback],
+        )
         chunk.signal_not_transferring()
         chunk.read(1)
         self.assertEqual(self.amounts_seen, [])
@@ -832,7 +883,8 @@ class TestStreamReaderProgress(BaseUtilsTest):
     def test_callback_invoked(self):
         original_stream = StringIO('foobarbaz')
         wrapped = StreamReaderProgress(
-            original_stream, [self.callback, self.callback])
+            original_stream, [self.callback, self.callback]
+        )
         self.assertEqual(wrapped.read(), 'foobarbaz')
         self.assertEqual(self.amounts_seen, [9, 9])
 
@@ -1084,8 +1136,9 @@ class TestThreadingPropertiesForSlidingWindowSemaphore(unittest.TestCase):
         # Should have all the available resources freed.
         self.assertEqual(sem.current_count(), 5)
         # Should have acquired num_threads * num_iterations
-        self.assertEqual(sem.acquire('a', blocking=False),
-                         num_threads * num_iterations)
+        self.assertEqual(
+            sem.acquire('a', blocking=False), num_threads * num_iterations
+        )
 
 
 class TestAdjustChunksize(unittest.TestCase):


### PR DESCRIPTION
This is a continuation of #205 to add some more substantial framing for how we handle code structure in the boto projects. This PR is currently a draft for comment and may be broken up into smaller parts for easier review. The current proposal adds 3 new tools to ensure we're cleaning up old code and keeping what we have currently consistent. This also helps expedite PR review by removing the need for iterations on minor style fixes.

### Proposed additions:
* **isort** - This will order our imports and ensure consistent layout. This avoids duplicate imports by keeping everything in the same spot and makes it easier to find what's already available.
* **pyupgrade** - This will automatically "upgrade" existing code to use the feature set configured for the lowest supported version (in this case Python 3.6). This is a more significant change that most version bumps because it's cleaning up all of our Python 2.6, 2.7 and 3.0-3.5 code.
* **black** -  This is the last one and maybe most contentious. We're adopting black with two caveats, we're not going to enforce quote normalization for now, and we're going to keep line length at 79 for the time being. 