### PR TITLE
Add Codespell to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,7 @@ repos:
     rev: 3.9.2
     hooks:
     -   id: flake8
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+    -   id: codespell


### PR DESCRIPTION
Adding codespell as part of our CI/pre-commit to prevent reoccurring waves of typo fixes.