### PR TITLE
Add changelog for Python 3.10 support

### DIFF
--- a/.changes/next-release/enhancement-Python-96455.json
+++ b/.changes/next-release/enhancement-Python-96455.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Officially add Python 3.10 support"
+}


### PR DESCRIPTION
Adding changelog to version bump and create a new PyPI release. This will add metadata to PyPI to display the 3.10 trove classifier we added back in October.