### PR TITLE
fix ExpectedBucketOwner argument mapping in head_object request durin…

### DIFF
--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -39,7 +39,7 @@ class CopySubmissionTask(SubmissionTask):
         'CopySourceSSECustomerAlgorithm': 'SSECustomerAlgorithm',
         'CopySourceSSECustomerKeyMD5': 'SSECustomerKeyMD5',
         'RequestPayer': 'RequestPayer',
-        'ExpectedBucketOwner': 'ExpectedBucketOwner',
+        'ExpectedSourceBucketOwner': 'ExpectedBucketOwner',
     }
 
     UPLOAD_PART_COPY_ARGS = [

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -227,6 +227,7 @@ class TestNonMultipartCopy(BaseCopyTest):
 
     def test_copy_maps_extra_args_to_head_object(self):
         self.extra_args['CopySourceSSECustomerAlgorithm'] = 'AES256'
+        self.extra_args['ExpectedBucketOwner'] = 'expectedbucketowner'
 
         expected_head_params = {
             'Bucket': 'mysourcebucket',
@@ -238,6 +239,7 @@ class TestNonMultipartCopy(BaseCopyTest):
             'Key': self.key,
             'CopySource': self.copy_source,
             'CopySourceSSECustomerAlgorithm': 'AES256',
+            'ExpectedBucketOwner': 'expectedbucketowner',
         }
 
         self.add_head_object_response(expected_params=expected_head_params)


### PR DESCRIPTION
This PR fixes an issue during copy operation on head_object: the `ExpectedBucketOwner` is mapped onto itself, when `ExpectedSourceBucketOwner` should be used instead. 
A complete fix would be to add support of `ExpectedSourceBucketOwner`, but this PR will solve issue #232 in the meantime.