### PR TITLE
Handle checksums on copy

### DIFF
--- a/.changes/next-release/bugfix-copy-96913.json
+++ b/.changes/next-release/bugfix-copy-96913.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "copy",
+  "description": "Added support for ``ChecksumAlgorithm`` when uploading copy data in parts."
+}

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -372,9 +372,9 @@ class CopyPartTask(Task):
         for callback in callbacks:
             callback(bytes_transferred=size)
         etag = response['CopyPartResult']['ETag']
-        part = {'ETag': etag, 'PartNumber': part_number}
+        part_metadata = {'ETag': etag, 'PartNumber': part_number}
         if checksum_algorithm:
             checksum_member = f'Checksum{checksum_algorithm.upper()}'
             if checksum_member in response['CopyPartResult']:
-                part[checksum_member] = response['CopyPartResult'][checksum_member]
-        return part
+                part_metadata[checksum_member] = response['CopyPartResult'][checksum_member]
+        return part_metadata

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -367,7 +367,7 @@ class CopyPartTask(Task):
             Key=key,
             UploadId=upload_id,
             PartNumber=part_number,
-            **extra_args
+            **extra_args,
         )
         for callback in callbacks:
             callback(bytes_transferred=size)
@@ -376,5 +376,7 @@ class CopyPartTask(Task):
         if checksum_algorithm:
             checksum_member = f'Checksum{checksum_algorithm.upper()}'
             if checksum_member in response['CopyPartResult']:
-                part_metadata[checksum_member] = response['CopyPartResult'][checksum_member]
+                part_metadata[checksum_member] = response['CopyPartResult'][
+                    checksum_member
+                ]
         return part_metadata

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -352,7 +352,8 @@ class CopyPartTask(Task):
             {'Etag': etag_value, 'PartNumber': part_number}
 
             This value can be appended to a list to be used to complete
-            the multipart upload.
+            the multipart upload. if checksum is in the response, it will be included
+            in such dictionary
         """
         response = client.upload_part_copy(
             CopySource=copy_source,
@@ -365,4 +366,14 @@ class CopyPartTask(Task):
         for callback in callbacks:
             callback(bytes_transferred=size)
         etag = response['CopyPartResult']['ETag']
-        return {'ETag': etag, 'PartNumber': part_number}
+        part = {'ETag': etag, 'PartNumber': part_number}
+        checksums = [
+            'ChecksumCRC32',
+            'ChecksumCRC32C',
+            'ChecksumSHA1',
+            'ChecksumSHA256',
+        ]
+        for checksum in checksums:
+            if checksum in response['CopyPartResult']:
+                part[checksum] = response['CopyPartResult'][checksum]
+        return part

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -220,6 +220,8 @@ class CopySubmissionTask(SubmissionTask):
                 num_parts,
                 transfer_future.meta.size,
             )
+            # Get the checksum algorithm of the multipart request.
+            checksum_algorithm = call_args.extra_args.get("ChecksumAlgorithm")
             part_futures.append(
                 self._transfer_coordinator.submit(
                     request_executor,
@@ -234,6 +236,7 @@ class CopySubmissionTask(SubmissionTask):
                             'extra_args': extra_part_args,
                             'callbacks': progress_callbacks,
                             'size': size,
+                            'checksum_algorithm': checksum_algorithm,
                         },
                         pending_main_kwargs={
                             'upload_id': create_multipart_future
@@ -331,6 +334,7 @@ class CopyPartTask(Task):
         extra_args,
         callbacks,
         size,
+        checksum_algorithm=None,
     ):
         """
         :param client: The client to use when calling PutObject
@@ -345,6 +349,8 @@ class CopyPartTask(Task):
         :param callbacks: List of callbacks to call after copy part
         :param size: The size of the transfer. This value is passed into
             the callbacks
+        :param checksum_algorithm: The algorithm that was used to create the multipart
+            upload
 
         :rtype: dict
         :returns: A dictionary representing a part::
@@ -352,8 +358,8 @@ class CopyPartTask(Task):
             {'Etag': etag_value, 'PartNumber': part_number}
 
             This value can be appended to a list to be used to complete
-            the multipart upload. if checksum is in the response, it will be included
-            in such dictionary
+            the multipart upload. If a checksum is in the response,
+            it will also be included.
         """
         response = client.upload_part_copy(
             CopySource=copy_source,
@@ -367,13 +373,8 @@ class CopyPartTask(Task):
             callback(bytes_transferred=size)
         etag = response['CopyPartResult']['ETag']
         part = {'ETag': etag, 'PartNumber': part_number}
-        checksums = [
-            'ChecksumCRC32',
-            'ChecksumCRC32C',
-            'ChecksumSHA1',
-            'ChecksumSHA256',
-        ]
-        for checksum in checksums:
-            if checksum in response['CopyPartResult']:
-                part[checksum] = response['CopyPartResult'][checksum]
+        if checksum_algorithm:
+            checksum_member = f'Checksum{checksum_algorithm.upper()}'
+            if checksum_member in response['CopyPartResult']:
+                part[checksum_member] = response['CopyPartResult'][checksum_member]
         return part

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -200,6 +200,29 @@ class TestNonMultipartCopy(BaseCopyTest):
         future.result()
         self.stubber.assert_no_pending_responses()
 
+    def test_copy_with_checksum(self):
+        self.extra_args['ChecksumAlgorithm'] = 'crc32'
+        expected_head_params = {
+            'Bucket': 'mysourcebucket',
+            'Key': 'mysourcekey',
+        }
+        expected_copy_object = {
+            'Bucket': self.bucket,
+            'Key': self.key,
+            'CopySource': self.copy_source,
+            'ChecksumAlgorithm': 'crc32',
+        }
+        self.add_head_object_response(expected_params=expected_head_params)
+        self.add_successful_copy_responses(
+            expected_copy_params=expected_copy_object
+        )
+
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = self.extra_args
+        future = self.manager.copy(**call_kwargs)
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
     def test_copy_with_extra_args(self):
         self.extra_args['MetadataDirective'] = 'REPLACE'
 
@@ -302,6 +325,7 @@ class TestMultipartCopy(BaseCopyTest):
             multipart_chunksize=4,
         )
         self._manager = TransferManager(self.client, self.config)
+        self.multipart_id = 'my-upload-id'
 
     def create_stubbed_responses(self):
         return [
@@ -311,7 +335,7 @@ class TestMultipartCopy(BaseCopyTest):
             },
             {
                 'method': 'create_multipart_upload',
-                'service_response': {'UploadId': 'my-upload-id'},
+                'service_response': {'UploadId': self.multipart_id},
             },
             {
                 'method': 'upload_part_copy',
@@ -328,6 +352,82 @@ class TestMultipartCopy(BaseCopyTest):
             {'method': 'complete_multipart_upload', 'service_response': {}},
         ]
 
+    def add_get_head_response_with_default_expected_params(
+            self, extra_expected_params=None
+    ):
+        expected_params = {
+            'Bucket': 'mysourcebucket',
+            'Key': 'mysourcekey',
+        }
+        if extra_expected_params:
+            expected_params.update(extra_expected_params)
+        response = self.create_stubbed_responses()[0]
+        response['expected_params'] = expected_params
+        self.stubber.add_response(**response)
+
+    def add_create_multipart_response_with_default_expected_params(
+        self, extra_expected_params=None
+    ):
+        expected_params = {'Bucket': self.bucket, 'Key': self.key}
+        if extra_expected_params:
+            expected_params.update(extra_expected_params)
+        response = self.create_stubbed_responses()[1]
+        response['expected_params'] = expected_params
+        self.stubber.add_response(**response)
+
+    def add_upload_part_copy_responses_with_default_expected_params(
+        self, extra_expected_params=None
+    ):
+        ranges = [
+            'bytes=0-5242879',
+            'bytes=5242880-10485759',
+            'bytes=10485760-13107199',
+        ]
+        upload_part_responses = self.create_stubbed_responses()[2:-1]
+        for i, range_val in enumerate(ranges):
+            upload_part_response = upload_part_responses[i]
+            expected_params = {
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.multipart_id,
+                'PartNumber': i + 1,
+                'CopySourceRange': range_val,
+            }
+            if extra_expected_params:
+                if 'ChecksumAlgorithm' in extra_expected_params:
+                    name = extra_expected_params['ChecksumAlgorithm']
+                    checksum_member = 'Checksum%s' % name.upper()
+                    response = upload_part_response['service_response']
+                    response['CopyPartResult'][checksum_member] = 'sum%s==' % (i + 1)
+                else:
+                    expected_params.update(extra_expected_params)
+
+            upload_part_response['expected_params'] = expected_params
+            self.stubber.add_response(**upload_part_response)
+
+    def add_complete_multipart_response_with_default_expected_params(
+        self, extra_expected_params=None
+    ):
+        expected_params = {
+            'Bucket': self.bucket,
+            'Key': self.key,
+            'UploadId': self.multipart_id,
+            'MultipartUpload': {
+                'Parts': [
+                    {'ETag': 'etag-1', 'PartNumber': 1},
+                    {'ETag': 'etag-2', 'PartNumber': 2},
+                    {'ETag': 'etag-3', 'PartNumber': 3},
+                ]
+            },
+        }
+        if extra_expected_params:
+            expected_params.update(extra_expected_params)
+
+        response = self.create_stubbed_responses()[-1]
+        response['expected_params'] = expected_params
+        self.stubber.add_response(**response)
+
     def create_expected_progress_callback_info(self):
         # Note that last read is from the empty sentinel indicating
         # that the stream is done.
@@ -341,8 +441,6 @@ class TestMultipartCopy(BaseCopyTest):
         self.stubber.add_response(**self.create_stubbed_responses()[1])
 
     def _get_expected_params(self):
-        upload_id = 'my-upload-id'
-
         # Add expected parameters to the head object
         expected_head_params = {
             'Bucket': 'mysourcebucket',
@@ -368,7 +466,7 @@ class TestMultipartCopy(BaseCopyTest):
                     'Bucket': self.bucket,
                     'Key': self.key,
                     'CopySource': self.copy_source,
-                    'UploadId': upload_id,
+                    'UploadId': self.multipart_id,
                     'PartNumber': i + 1,
                     'CopySourceRange': range_val,
                 }
@@ -378,7 +476,7 @@ class TestMultipartCopy(BaseCopyTest):
         expected_complete_mpu_params = {
             'Bucket': self.bucket,
             'Key': self.key,
-            'UploadId': upload_id,
+            'UploadId': self.multipart_id,
             'MultipartUpload': {
                 'Parts': [
                     {'ETag': 'etag-1', 'PartNumber': 1},
@@ -434,6 +532,54 @@ class TestMultipartCopy(BaseCopyTest):
             self.extra_args,
         )
         self.add_successful_copy_responses(**add_copy_kwargs)
+
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = self.extra_args
+        future = self.manager.copy(**call_kwargs)
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_copy_passes_checksums(self):
+        # This extra argument should be added to the head object,
+        # the create multipart upload, and upload part copy.
+        self.extra_args['ChecksumAlgorithm'] = 'sha256'
+
+        self.add_get_head_response_with_default_expected_params()
+
+        # ChecksumAlgorithm should be passed on the create_multipart call
+        self.add_create_multipart_response_with_default_expected_params(
+            self.extra_args,
+        )
+
+        # ChecksumAlgorithm should be passed to the upload_part_copy calls
+        self.add_upload_part_copy_responses_with_default_expected_params(
+            self.extra_args,
+        )
+
+        # The checksums should be used in the complete call like etags
+        self.add_complete_multipart_response_with_default_expected_params(
+            extra_expected_params={
+                'MultipartUpload': {
+                    'Parts': [
+                        {
+                            'ETag': 'etag-1',
+                            'PartNumber': 1,
+                            'ChecksumSHA256': 'sum1==',
+                        },
+                        {
+                            'ETag': 'etag-2',
+                            'PartNumber': 2,
+                            'ChecksumSHA256': 'sum2==',
+                        },
+                        {
+                            'ETag': 'etag-3',
+                            'PartNumber': 3,
+                            'ChecksumSHA256': 'sum3==',
+                        },
+                    ]
+                }
+            }
+        )
 
         call_kwargs = self.create_call_kwargs()
         call_kwargs['extra_args'] = self.extra_args
@@ -528,7 +674,7 @@ class TestMultipartCopy(BaseCopyTest):
             expected_params={
                 'Bucket': self.bucket,
                 'Key': self.key,
-                'UploadId': 'my-upload-id',
+                'UploadId': 'self.multipart_id',
             },
         )
 

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -353,7 +353,7 @@ class TestMultipartCopy(BaseCopyTest):
         ]
 
     def add_get_head_response_with_default_expected_params(
-            self, extra_expected_params=None
+        self, extra_expected_params=None
     ):
         expected_params = {
             'Bucket': 'mysourcebucket',
@@ -399,7 +399,9 @@ class TestMultipartCopy(BaseCopyTest):
                     name = extra_expected_params['ChecksumAlgorithm']
                     checksum_member = 'Checksum%s' % name.upper()
                     response = upload_part_response['service_response']
-                    response['CopyPartResult'][checksum_member] = 'sum%s==' % (i + 1)
+                    response['CopyPartResult'][checksum_member] = 'sum%s==' % (
+                        i + 1
+                    )
                 else:
                     expected_params.update(extra_expected_params)
 
@@ -674,7 +676,7 @@ class TestMultipartCopy(BaseCopyTest):
             expected_params={
                 'Bucket': self.bucket,
                 'Key': self.key,
-                'UploadId': 'self.multipart_id',
+                'UploadId': self.multipart_id,
             },
         )
 

--- a/tests/unit/test_copies.py
+++ b/tests/unit/test_copies.py
@@ -98,6 +98,10 @@ class TestCopyPartTask(BaseCopyTaskTest):
         self.upload_id = 'myuploadid'
         self.part_number = 1
         self.result_etag = 'my-etag'
+        self.checksum_crc32 = 'my-checksum_crc32'
+        self.checksum_crc32c = 'my-checksum_crc32c'
+        self.checksum_sha1 = 'my-checksum_sha1'
+        self.checksum_sha256 = 'my-checksum_sha256'
 
     def get_copy_task(self, **kwargs):
         default_kwargs = {
@@ -130,6 +134,122 @@ class TestCopyPartTask(BaseCopyTaskTest):
         task = self.get_copy_task()
         self.assertEqual(
             task(), {'PartNumber': self.part_number, 'ETag': self.result_etag}
+        )
+        self.stubber.assert_no_pending_responses()
+
+    def test_main_checksum_crc32(self):
+        self.stubber.add_response(
+            'upload_part_copy',
+            service_response={
+                'CopyPartResult': {
+                    'ETag': self.result_etag,
+                    'ChecksumCRC32': self.checksum_crc32,
+                }
+            },
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
+                'PartNumber': self.part_number,
+                'CopySourceRange': self.copy_source_range,
+            },
+        )
+        task = self.get_copy_task()
+        self.assertEqual(
+            task(),
+            {
+                'PartNumber': self.part_number,
+                'ETag': self.result_etag,
+                'ChecksumCRC32': self.checksum_crc32,
+            },
+        )
+        self.stubber.assert_no_pending_responses()
+
+    def test_main_checksum_crc32c(self):
+        self.stubber.add_response(
+            'upload_part_copy',
+            service_response={
+                'CopyPartResult': {
+                    'ETag': self.result_etag,
+                    'ChecksumCRC32C': self.checksum_crc32c,
+                }
+            },
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
+                'PartNumber': self.part_number,
+                'CopySourceRange': self.copy_source_range,
+            },
+        )
+        task = self.get_copy_task()
+        self.assertEqual(
+            task(),
+            {
+                'PartNumber': self.part_number,
+                'ETag': self.result_etag,
+                'ChecksumCRC32C': self.checksum_crc32c,
+            },
+        )
+        self.stubber.assert_no_pending_responses()
+
+    def test_main_checksum_sha1(self):
+        self.stubber.add_response(
+            'upload_part_copy',
+            service_response={
+                'CopyPartResult': {
+                    'ETag': self.result_etag,
+                    'ChecksumSHA1': self.checksum_sha1,
+                }
+            },
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
+                'PartNumber': self.part_number,
+                'CopySourceRange': self.copy_source_range,
+            },
+        )
+        task = self.get_copy_task()
+        self.assertEqual(
+            task(),
+            {
+                'PartNumber': self.part_number,
+                'ETag': self.result_etag,
+                'ChecksumSHA1': self.checksum_sha1,
+            },
+        )
+        self.stubber.assert_no_pending_responses()
+
+    def test_main_checksum_sha256(self):
+        self.stubber.add_response(
+            'upload_part_copy',
+            service_response={
+                'CopyPartResult': {
+                    'ETag': self.result_etag,
+                    'ChecksumSHA256': self.checksum_sha256,
+                }
+            },
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
+                'PartNumber': self.part_number,
+                'CopySourceRange': self.copy_source_range,
+            },
+        )
+        task = self.get_copy_task()
+        self.assertEqual(
+            task(),
+            {
+                'PartNumber': self.part_number,
+                'ETag': self.result_etag,
+                'ChecksumSHA256': self.checksum_sha256,
+            },
         )
         self.stubber.assert_no_pending_responses()
 

--- a/tests/unit/test_copies.py
+++ b/tests/unit/test_copies.py
@@ -98,10 +98,7 @@ class TestCopyPartTask(BaseCopyTaskTest):
         self.upload_id = 'myuploadid'
         self.part_number = 1
         self.result_etag = 'my-etag'
-        self.checksum_crc32 = 'my-checksum_crc32'
-        self.checksum_crc32c = 'my-checksum_crc32c'
         self.checksum_sha1 = 'my-checksum_sha1'
-        self.checksum_sha256 = 'my-checksum_sha256'
 
     def get_copy_task(self, **kwargs):
         default_kwargs = {
@@ -137,65 +134,7 @@ class TestCopyPartTask(BaseCopyTaskTest):
         )
         self.stubber.assert_no_pending_responses()
 
-    def test_main_checksum_crc32(self):
-        self.stubber.add_response(
-            'upload_part_copy',
-            service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag,
-                    'ChecksumCRC32': self.checksum_crc32,
-                }
-            },
-            expected_params={
-                'Bucket': self.bucket,
-                'Key': self.key,
-                'CopySource': self.copy_source,
-                'UploadId': self.upload_id,
-                'PartNumber': self.part_number,
-                'CopySourceRange': self.copy_source_range,
-            },
-        )
-        task = self.get_copy_task()
-        self.assertEqual(
-            task(),
-            {
-                'PartNumber': self.part_number,
-                'ETag': self.result_etag,
-                'ChecksumCRC32': self.checksum_crc32,
-            },
-        )
-        self.stubber.assert_no_pending_responses()
-
-    def test_main_checksum_crc32c(self):
-        self.stubber.add_response(
-            'upload_part_copy',
-            service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag,
-                    'ChecksumCRC32C': self.checksum_crc32c,
-                }
-            },
-            expected_params={
-                'Bucket': self.bucket,
-                'Key': self.key,
-                'CopySource': self.copy_source,
-                'UploadId': self.upload_id,
-                'PartNumber': self.part_number,
-                'CopySourceRange': self.copy_source_range,
-            },
-        )
-        task = self.get_copy_task()
-        self.assertEqual(
-            task(),
-            {
-                'PartNumber': self.part_number,
-                'ETag': self.result_etag,
-                'ChecksumCRC32C': self.checksum_crc32c,
-            },
-        )
-        self.stubber.assert_no_pending_responses()
-
-    def test_main_checksum_sha1(self):
+    def test_main_with_checksum(self):
         self.stubber.add_response(
             'upload_part_copy',
             service_response={
@@ -213,42 +152,13 @@ class TestCopyPartTask(BaseCopyTaskTest):
                 'CopySourceRange': self.copy_source_range,
             },
         )
-        task = self.get_copy_task()
+        task = self.get_copy_task(checksum_algorithm="sha1")
         self.assertEqual(
             task(),
             {
                 'PartNumber': self.part_number,
                 'ETag': self.result_etag,
                 'ChecksumSHA1': self.checksum_sha1,
-            },
-        )
-        self.stubber.assert_no_pending_responses()
-
-    def test_main_checksum_sha256(self):
-        self.stubber.add_response(
-            'upload_part_copy',
-            service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag,
-                    'ChecksumSHA256': self.checksum_sha256,
-                }
-            },
-            expected_params={
-                'Bucket': self.bucket,
-                'Key': self.key,
-                'CopySource': self.copy_source,
-                'UploadId': self.upload_id,
-                'PartNumber': self.part_number,
-                'CopySourceRange': self.copy_source_range,
-            },
-        )
-        task = self.get_copy_task()
-        self.assertEqual(
-            task(),
-            {
-                'PartNumber': self.part_number,
-                'ETag': self.result_etag,
-                'ChecksumSHA256': self.checksum_sha256,
             },
         )
         self.stubber.assert_no_pending_responses()


### PR DESCRIPTION
`S3.Object.copy()` fails with multipart and `ChecksumAlgorithm` as mentioned in #241 

This fixes the issue by adding the checksum information to `CompleteMultipartUpload `