### PR TITLE
Returned ETag for uploaded entities

### DIFF
--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -377,11 +377,17 @@ class CompleteMultipartUploadTask(Task):
             ``UploadPartTask.main()``.
         :param extra_args:  A dictionary of any extra arguments that may be
             used in completing the multipart transfer.
+        :returns: A dictionary representing metadata information about the
+            upload, such as the ETag for the uploaded entity.
         """
-        client.complete_multipart_upload(
+        response = client.complete_multipart_upload(
             Bucket=bucket,
             Key=key,
             UploadId=upload_id,
             MultipartUpload={'Parts': parts},
             **extra_args,
         )
+        metadata = dict()
+        if 'ETag' in response:
+            metadata['ETag'] = response['ETag']
+        return metadata

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -753,9 +753,16 @@ class PutObjectTask(Task):
         :param key: The name of the key to upload to
         :param extra_args: A dictionary of any extra arguments that may be
             used in the upload.
+        :returns: A dictionary representing metadata information about the
+            upload, such as the ETag for the uploaded entity.
         """
         with fileobj as body:
-            client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
+            response = client.put_object(Bucket=bucket, Key=key, Body=body,
+                **extra_args)
+            metadata = dict()
+            if 'ETag' in response:
+                metadata['ETag'] = response['ETag']
+            return metadata
 
 
 class UploadPartTask(Task):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -779,7 +779,8 @@ class TestCreateMultipartUploadTask(BaseMultipartTaskTest):
 class TestCompleteMultipartUploadTask(BaseMultipartTaskTest):
     def test_main(self):
         upload_id = 'my-id'
-        parts = [{'ETag': 'etag', 'PartNumber': 0}]
+        parts = [{'ETag': 'part-etag', 'PartNumber': 0}]
+        etag = 'uploaded-etag'
         task = self.get_task(
             CompleteMultipartUploadTask,
             main_kwargs={
@@ -793,7 +794,7 @@ class TestCompleteMultipartUploadTask(BaseMultipartTaskTest):
         )
         self.stubber.add_response(
             method='complete_multipart_upload',
-            service_response={},
+            service_response={'ETag': etag},
             expected_params={
                 'Bucket': self.bucket,
                 'Key': self.key,
@@ -801,7 +802,9 @@ class TestCompleteMultipartUploadTask(BaseMultipartTaskTest):
                 'MultipartUpload': {'Parts': parts},
             },
         )
-        task()
+        task_response = task()
+        self.assertIn("ETag", task_response)
+        self.assertEqual(task_response["ETag"], etag)
         self.stubber.assert_no_pending_responses()
 
     def test_includes_extra_args(self):

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -631,6 +631,7 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
 class TestPutObjectTask(BaseUploadTest):
     def test_main(self):
         extra_args = {'Metadata': {'foo': 'bar'}}
+        etag = 'uploaded-etag'
         with open(self.filename, 'rb') as fileobj:
             task = self.get_task(
                 PutObjectTask,
@@ -644,7 +645,7 @@ class TestPutObjectTask(BaseUploadTest):
             )
             self.stubber.add_response(
                 method='put_object',
-                service_response={},
+                service_response={'ETag': etag},
                 expected_params={
                     'Body': ANY,
                     'Bucket': self.bucket,
@@ -652,7 +653,9 @@ class TestPutObjectTask(BaseUploadTest):
                     'Metadata': {'foo': 'bar'},
                 },
             )
-            task()
+            task_response = task()
+            self.assertIn("ETag", task_response)
+            self.assertEqual(task_response["ETag"], etag)
             self.stubber.assert_no_pending_responses()
             self.assertEqual(self.sent_bodies, [self.content])
 


### PR DESCRIPTION
**Summary of Changes**
- If 'ETag' is present in service response, return it inside a metadata dictionary for both `tasks.CompleteMultipartUploadTask` and `upload.PutObjectTask`.
- This change will allow integrations which rely on these call sites to access the ETag.

**Background**
- There's a feature request over at `boto3` to return ETag information for several call sites, i.e.: https://github.com/boto/boto3/issues/2861. In order to achieve this, I believe we need `s3transfer` to return the ETag information at the call sites changed in this Pull Request.

**Design decisions**
- I was unsure how to model the entity which would be returning the ETag information. I chose to follow [the pattern](https://github.com/boto/s3transfer/blob/develop/s3transfer/upload.py#L795-L802) I found inside `upload.UploadPartTask`, i.e. a pattern already in the codebase. This pattern returns the ETag inside an outer `metadata` dictionary.
- Let me know if I should use another strategy, or if this general approach to the problem is problematic for some reason.