### PR TITLE
add return values to s3transfer tasks

### DIFF
--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -309,13 +309,15 @@ class CopyObjectTask(Task):
         :param size: The size of the transfer. This value is passed into
             the callbacks
 
+        :rtype: dict
+        :returns: A dictionary containing client response
         """
-        client.copy_object(
+        resp = client.copy_object(
             CopySource=copy_source, Bucket=bucket, Key=key, **extra_args
         )
         for callback in callbacks:
             callback(bytes_transferred=size)
-
+        return resp
 
 class CopyPartTask(Task):
     """Task to upload a part in a multipart copy"""

--- a/s3transfer/delete.py
+++ b/s3transfer/delete.py
@@ -67,5 +67,7 @@ class DeleteObjectTask(Task):
         :type extra_args: dict
         :param extra_args: Extra arguments to pass to the DeleteObject call.
 
+        :rtype: dict
+        :returns: A dictionary containing client response
         """
-        client.delete_object(Bucket=bucket, Key=key, **extra_args)
+        return client.delete_object(Bucket=bucket, Key=key, **extra_args)

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -561,6 +561,10 @@ class GetObjectTask(Task):
             content of the key to.
         :param bandwidth_limiter: The bandwidth limiter to use when throttling
             the downloading of data in streams.
+
+        :rtype: dict
+        :returns: A dictionary containing client response stripped of the
+        response Body
         """
         last_exception = None
         for i in range(max_attempts):
@@ -570,7 +574,7 @@ class GetObjectTask(Task):
                     Bucket=bucket, Key=key, **extra_args
                 )
                 streaming_body = StreamReaderProgress(
-                    response['Body'], callbacks
+                    response.pop('Body'), callbacks
                 )
                 if bandwidth_limiter:
                     streaming_body = (
@@ -593,8 +597,8 @@ class GetObjectTask(Task):
                         )
                         current_index += len(chunk)
                     else:
-                        return
-                return
+                        return response
+                return response
             except S3_RETRYABLE_DOWNLOAD_ERRORS as e:
                 logger.debug(
                     "Retrying exception caught (%s), "

--- a/s3transfer/tasks.py
+++ b/s3transfer/tasks.py
@@ -377,8 +377,11 @@ class CompleteMultipartUploadTask(Task):
             ``UploadPartTask.main()``.
         :param extra_args:  A dictionary of any extra arguments that may be
             used in completing the multipart transfer.
+
+        :rtype: dict
+        :returns: A dictionary containing client response
         """
-        client.complete_multipart_upload(
+        return client.complete_multipart_upload(
             Bucket=bucket,
             Key=key,
             UploadId=upload_id,

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -753,9 +753,12 @@ class PutObjectTask(Task):
         :param key: The name of the key to upload to
         :param extra_args: A dictionary of any extra arguments that may be
             used in the upload.
+
+        :rtype: dict
+        :returns: A dictionary containing client response
         """
         with fileobj as body:
-            client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
+            return client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
 
 
 class UploadPartTask(Task):


### PR DESCRIPTION
implements workaround in issue upload_file return value [#82](https://github.com/boto/s3transfer/issues/82) and delete, copy, download tasks where a client response is made available to the transfer future result() return

Change-Id: I434a0af1155cf66536d2222a097752a13ebb8d6a