### PR TITLE
fix args sent to shutdown

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -618,7 +618,7 @@ class TransferManager:
         :param cancel_msg: The message to specify if canceling all in-progress
             transfers.
         """
-        self._shutdown(cancel, cancel, cancel_msg)
+        self._shutdown(cancel, cancel_msg)
 
     def _shutdown(self, cancel, cancel_msg, exc_type=CancelledError):
         if cancel:


### PR DESCRIPTION
fixes following error when submitting a cancellation message.

```
s3transfer/futures.py", line 279, in cancel
self._exception = exc_type(msg)
TypeError: 'str' object is not callable
```