### PR TITLE
Test: TestBaseManager no longer works under python 3.8+

### DIFF
--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -12,12 +12,11 @@
 # language governing permissions and limitations under the License.
 import os
 import shutil
-import signal
 import tempfile
 from io import BytesIO
 
-from s3transfer.compat import BaseManager, readable, seekable
-from tests import skip_if_windows, unittest
+from s3transfer.compat import readable, seekable
+from tests import unittest
 
 
 class ErrorRaisingSeekWrapper:
@@ -75,31 +74,3 @@ class TestReadable(unittest.TestCase):
 
     def test_non_file_like_obj(self):
         self.assertFalse(readable(object()))
-
-
-class TestBaseManager(unittest.TestCase):
-    def create_pid_manager(self):
-        class PIDManager(BaseManager):
-            pass
-
-        PIDManager.register('getpid', os.getpid)
-        return PIDManager()
-
-    def get_pid(self, pid_manager):
-        pid = pid_manager.getpid()
-        # A proxy object is returned back. The needed value can be acquired
-        # from the repr and converting that to an integer
-        return int(str(pid))
-
-    @skip_if_windows('os.kill() with SIGINT not supported on Windows')
-    def test_can_provide_signal_handler_initializers_to_start(self):
-        manager = self.create_pid_manager()
-        manager.start(signal.signal, (signal.SIGINT, signal.SIG_IGN))
-        pid = self.get_pid(manager)
-        try:
-            os.kill(pid, signal.SIGINT)
-        except KeyboardInterrupt:
-            pass
-        # Try using the manager after the os.kill on the parent process. The
-        # manager should not have died and should still be usable.
-        self.assertEqual(pid, self.get_pid(manager))


### PR DESCRIPTION
Issue #229 

This test is no longer needed:
* Python 3.8+ pickle can not serialize local classes
* Python 3.8+ can no longer correctly handle `manager.start(signal.signal, (signal.SIGINT, signal.SIG_IGN))`.  It will cause the error `PicklingError: Can't pickle <function signal at ...>: it's not the same object as _signal.signal`
* s3transfer no longer calls `manager.start` as above.