### PR TITLE
feature: Download subrange of an object instead of downloading the whole object

### DIFF
--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -360,13 +360,27 @@ class DownloadSubmissionTask(SubmissionTask):
                 response['ContentLength']
             )
 
+        # Clamp range_start and range_end to the length of the object
+        range_start = transfer_future.meta.call_args.range_start
+        if range_start < 0:
+            range_start = 0
+        range_end = transfer_future.meta.call_args.range_end
+        if range_end is None or range_end >= transfer_future.meta.size:
+            range_end = transfer_future.meta.size - 1
+        transfer_future.meta.call_args.range_start = range_start
+        transfer_future.meta.call_args.range_end = range_end
+
         download_output_manager = self._get_download_output_manager_cls(
             transfer_future, osutil
         )(osutil, self._transfer_coordinator, io_executor)
 
-        # If it is greater than threshold do a ranged download, otherwise
-        # do a regular GetObject download.
-        if transfer_future.meta.size < config.multipart_threshold:
+        # If it is greater than threshold and the whole object do a ranged download,
+        # otherwise do a regular GetObject download.
+        if (
+            transfer_future.meta.size < config.multipart_threshold
+            and range_start == 0
+            and range_end == transfer_future.meta.size - 1
+        ):
             self._submit_download_request(
                 client,
                 config,
@@ -463,7 +477,9 @@ class DownloadSubmissionTask(SubmissionTask):
 
         # Determine the number of parts
         part_size = config.multipart_chunksize
-        num_parts = calculate_num_parts(transfer_future.meta.size, part_size)
+        num_parts = calculate_num_parts(
+            max(call_args.range_end - call_args.range_start + 1, 0), part_size
+        )
 
         # Get any associated tags for the get object task.
         get_object_tag = download_output_manager.get_download_task_tag()
@@ -478,7 +494,11 @@ class DownloadSubmissionTask(SubmissionTask):
         for i in range(num_parts):
             # Calculate the range parameter
             range_parameter = calculate_range_parameter(
-                part_size, i, num_parts
+                part_size,
+                i,
+                num_parts,
+                call_args.range_end + 1,
+                call_args.range_start,
             )
 
             # Inject the Range parameter to the parameters to be passed in
@@ -517,16 +537,6 @@ class DownloadSubmissionTask(SubmissionTask):
         return FunctionContainer(
             self._transfer_coordinator.submit, io_executor, final_task
         )
-
-    def _calculate_range_param(self, part_size, part_index, num_parts):
-        # Used to calculate the Range parameter
-        start_range = part_index * part_size
-        if part_index == num_parts - 1:
-            end_range = ''
-        else:
-            end_range = start_range + part_size - 1
-        range_param = f'bytes={start_range}-{end_range}'
-        return range_param
 
 
 class GetObjectTask(Task):

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -335,7 +335,15 @@ class TransferManager:
         )
 
     def download(
-        self, bucket, key, fileobj, extra_args=None, subscribers=None
+        self,
+        bucket,
+        key,
+        fileobj,
+        extra_args=None,
+        subscribers=None,
+        *,
+        range_start=0,
+        range_end=None
     ):
         """Downloads a file from S3
 
@@ -359,6 +367,14 @@ class TransferManager:
             order provided based on the event emit during the process of
             the transfer request.
 
+        :type range_start: int
+        :param range_start: The start of the range to download from the object.
+
+        :type range_end: int
+        :param range_end: The end of the range to download from the object.  Default is
+            the length of the object minus one.  Total length is of the download is
+            `range_end - range_start + 1`
+
         :rtype: s3transfer.futures.TransferFuture
         :returns: Transfer future representing the download
         """
@@ -374,6 +390,8 @@ class TransferManager:
             fileobj=fileobj,
             extra_args=extra_args,
             subscribers=subscribers,
+            range_start=range_start,
+            range_end=range_end,
         )
         extra_main_kwargs = {'io_executor': self._io_executor}
         if self._bandwidth_limiter:

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -65,7 +65,7 @@ def calculate_num_parts(size, part_size):
 
 
 def calculate_range_parameter(
-    part_size, part_index, num_parts, total_size=None
+    part_size, part_index, num_parts, total_size=None, offset=0
 ):
     """Calculate the range parameter for multipart downloads/copies
 
@@ -79,11 +79,17 @@ def calculate_range_parameter(
     :type num_parts: int
     :param num_parts: The total number of parts in the transfer
 
+    :type total_size: int
+    :param total_size: The total size of the object be transferred
+
+    :type offset: int
+    :param offset: The offset from the beginning of the object to start the range
+
     :returns: The value to use for Range parameter on downloads or
         the CopySourceRange parameter for copies
     """
     # Used to calculate the Range parameter
-    start_range = part_index * part_size
+    start_range = part_index * part_size + offset
     if part_index == num_parts - 1:
         end_range = ''
         if total_size is not None:

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -397,6 +397,8 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
         self.key = 'mykey'
         self.extra_args = {}
         self.subscribers = []
+        self.range_start = 0
+        self.range_end = None
 
         # Create a stream to read from
         self.content = b'my content'
@@ -429,6 +431,8 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
             'key': self.key,
             'extra_args': self.extra_args,
             'subscribers': self.subscribers,
+            'range_start': self.range_start,
+            'range_end': self.range_end,
         }
         default_call_args.update(kwargs)
         return CallArgs(**default_call_args)

--- a/tests/unit/test_processpool.py
+++ b/tests/unit/test_processpool.py
@@ -337,6 +337,8 @@ class TestGetObjectSubmitter(StubbedClientTest):
             'filename': self.filename,
             'extra_args': self.extra_args,
             'expected_size': self.expected_size,
+            'range_start': 0,
+            'range_end': None,
         }
         kwargs.update(override_kwargs)
         self.download_request_queue.put(DownloadFileRequest(**kwargs))
@@ -393,7 +395,7 @@ class TestGetObjectSubmitter(StubbedClientTest):
                     key=self.key,
                     temp_filename=self.temp_filename,
                     offset=2,
-                    extra_args={'Range': 'bytes=2-'},
+                    extra_args={'Range': 'bytes=2-3'},
                     filename=self.filename,
                 ),
             ]


### PR DESCRIPTION
Feature request #248 