### PR TITLE
Use codecov-action instead of pip installing.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,13 +22,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install codecov
         python scripts/ci/install
     - name: Run tests
       run: |
         python scripts/ci/run-tests --with-cov
     - name: codecov
-      run: |
-        rm tests/coverage.xml
-        mv tests/.coverage ./
-        codecov
+      uses: codecov/codecov-action@v3
+      with:
+        directory: tests


### PR DESCRIPTION
## Overview

Codecov has removed their package from PyPi ([see message](https://about.codecov.io/blog/message-regarding-the-pypi-package/)) which has caused our HitHub workflows to fail since we pip install codecov. This PR uses their GitHub Action ([codecov-action](https://github.com/codecov/codecov-action)) instead.