### PR TITLE
Add Python 3.12 support to s3transfer

### DIFF
--- a/.changes/next-release/enhancement-Python-27390.json
+++ b/.changes/next-release/enhancement-Python-27390.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Added provisional Python 3.12 support to s3transfer"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ psutil>=4.1.0,<5.0.0
 tabulate==0.7.5
 coverage==5.5
 wheel==0.38.1
+setuptools==67.8.0;python_version>="3.12"
 
 # Pytest specific deps
 pytest==7.1.2

--- a/scripts/ci/install-dev-deps
+++ b/scripts/ci/install-dev-deps
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import sys
 from contextlib import contextmanager
 from subprocess import check_call
 
@@ -25,4 +26,6 @@ def run(command):
 
 if __name__ == "__main__":
     with cd(REPO_ROOT):
+        if sys.version_info[:2] >= (3, 12):
+            run("pip install setuptools")
         run("pip install -r requirements-dev-lock.txt")

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,12 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py37,py38,py39,py310,py311,py312
 
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time


### PR DESCRIPTION
This PR will start running our test suite against Python 3.12 release candidate builds to ensure we're ready for final release later this year. The current targeted release date for Python 3.12 is October 2, 2023.