### PR TITLE
Add user provided SSE-C arguments to CompleteMultipartUpload call

### DIFF
--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -69,7 +69,13 @@ class CopySubmissionTask(SubmissionTask):
         'TaggingDirective',
     ]
 
-    COMPLETE_MULTIPART_ARGS = ['RequestPayer', 'ExpectedBucketOwner']
+    COMPLETE_MULTIPART_ARGS = [
+        'SSECustomerKey',
+        'SSECustomerAlgorithm',
+        'SSECustomerKeyMD5',
+        'RequestPayer',
+        'ExpectedBucketOwner',
+    ]
 
     def _submit(
         self, client, config, osutil, request_executor, transfer_future

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -521,7 +521,13 @@ class UploadSubmissionTask(SubmissionTask):
         'ExpectedBucketOwner',
     ]
 
-    COMPLETE_MULTIPART_ARGS = ['RequestPayer', 'ExpectedBucketOwner']
+    COMPLETE_MULTIPART_ARGS = [
+        'SSECustomerKey',
+        'SSECustomerAlgorithm',
+        'SSECustomerKeyMD5',
+        'RequestPayer',
+        'ExpectedBucketOwner',
+    ]
 
     def _get_upload_input_manager_cls(self, transfer_future):
         """Retrieves a class for managing input for an upload based on file type

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -629,7 +629,9 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response(expected_params=head_params)
 
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['create_mpu', 'copy'], self.extra_args
+            add_copy_kwargs,
+            ['create_mpu', 'copy', 'complete_mpu'],
+            self.extra_args,
         )
         self.add_successful_copy_responses(**add_copy_kwargs)
 

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -599,3 +599,28 @@ class TestMultipartUpload(BaseUploadTest):
         )
         future.result()
         self.assert_expected_client_calls_were_correct()
+
+    def test_multipart_upload_with_ssec_args(self):
+        params = {
+            'RequestPayer': 'requester',
+            'SSECustomerKey': 'key',
+            'SSECustomerAlgorithm': 'AES256',
+            'SSECustomerKeyMD5': 'key-hash',
+        }
+        self.extra_args.update(params)
+
+        self.add_create_multipart_response_with_default_expected_params(
+            extra_expected_params=params
+        )
+
+        self.add_upload_part_responses_with_default_expected_params(
+            extra_expected_params=params
+        )
+        self.add_complete_multipart_response_with_default_expected_params(
+            extra_expected_params=params
+        )
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()


### PR DESCRIPTION
This PR will forward SSE-C arguments provided by the user to the final CompleteMultipartUpload call to handle cases where a policy has been defined which requires these for all PutObject calls.

This is to resolve a recently published workflow by S3 which changed the requiredness of these arguments due to `PutObject` being used under the hood for CompleteMultipartUpload.