### PR TITLE
Add changelog for sse-c changes

### DIFF
--- a/.changes/next-release/bugfix-SSEC-19962.json
+++ b/.changes/next-release/bugfix-SSEC-19962.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``SSE-C``",
+  "description": "Pass SSECustomer* arguments to CompleteMultipartUpload for upload operations"
+}


### PR DESCRIPTION
This got dropped out of #274 during the rebase and I didn't catch it before merging.