### PR TITLE
Move change to feature for backwards compatibility

### DIFF
--- a/.changes/next-release/feature-SSEC-99694.json
+++ b/.changes/next-release/feature-SSEC-99694.json
@@ -1,5 +1,5 @@
 {
-  "type": "bugfix",
+  "type": "feature",
   "category": "``SSE-C``",
   "description": "Pass SSECustomer* arguments to CompleteMultipartUpload for upload operations"
 }


### PR DESCRIPTION
This change has some implications on botocore because it allows any version in the 0.6.x series. This change will bump us to 0.7.x to avoid any unintentional breakages.