### PR TITLE
Add streaming fileobj support to CRTTransferManager

### DIFF
--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -451,10 +451,15 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
 
         # Explicitly set "Content-Length: 0" when there's no body.
         # Botocore doesn't bother setting this, but CRT likes to know.
-        # Note that Content-Length SHOULD be absent if body is unseekable.
+        # Note that Content-Length SHOULD be absent if body is nonseekable.
         if crt_request.headers.get('Content-Length') is None:
             if botocore_http_request.body is None:
                 crt_request.headers.add('Content-Length', "0")
+
+        # Botocore sets "Transfer-Encoding: chunked" for nonseekable streams.
+        # TODO: CRT chokes on this header. It ought to simply discard it.
+        if crt_request.headers.get('Transfer-Encoding') is not None:
+            crt_request.headers.remove('Transfer-Encoding')
 
         return crt_request
 

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -567,7 +567,7 @@ class S3ClientArgsCreator:
                 on_done_before_calls.append(file_ondone_call)
             else:
                 # fileobj is a file-like object
-                def _on_body(chunk, offset, **kwargs): # TODO: make helper class
+                def _on_body(chunk, offset, **kwargs):  # TODO: make helper class
                     call_args.fileobj.write(chunk)
                 on_body = _on_body
 
@@ -580,11 +580,13 @@ class S3ClientArgsCreator:
             else:
                 # fileobj is a file-like object
                 call_args.extra_args["Body"] = call_args.fileobj
-                call_args.extra_args["ContentMD5"] = "deleteme" # TODO: clean up hacks
+                call_args.extra_args["ContentMD5"] = "deleteme"  # TODO: clean up hacks
 
         crt_request = self._request_serializer.serialize_http_request(
             request_type, future
         )
+
+        # TODO: should content-length be getting passed for download & misc?
 
         return {
             'request': crt_request,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -506,8 +506,8 @@ class NonSeekableReader(io.RawIOBase):
         # kind of error even though writeable returns False.
         raise io.UnsupportedOperation("write")
 
-    def read(self, n=-1):
-        return self._data.read(n)
+    def readinto(self, b):
+        return self._data.readinto(b)
 
 
 class NonSeekableWriter(io.RawIOBase):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -510,22 +510,26 @@ class NonSeekableReader(io.RawIOBase):
         return self._data.readinto(b)
 
 
-class NonSeekableWriter(io.RawIOBase):
-    def __init__(self, fileobj):
-        super().__init__()
-        self._fileobj = fileobj
+def create_nonseekable_writer(fileobj):
 
     def seekable(self):
         return False
 
+    fileobj.seekable = seekable
+
     def writable(self):
         return True
+
+    fileobj.writable = writable
 
     def readable(self):
         return False
 
-    def write(self, b):
-        self._fileobj.write(b)
+    fileobj.readable = readable
 
     def read(self, n=-1):
         raise io.UnsupportedOperation("read")
+
+    fileobj.read = read
+
+    return fileobj

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -130,17 +130,17 @@ class TestCRTTransferManager(unittest.TestCase):
             self.assertIsNone(call_kwargs.get("send_filepath"))
             self.assertIsNotNone(crt_request.body_stream)
 
+        if expecting_content_length:
+            self.assertEqual(str(len(self.content)), crt_request.headers.get("content-length"))
+        else:
+            self.assertIsNone(crt_request.headers.get("content-length"))
+
         self.assertIsNone(call_kwargs.get("recv_filepath"))
         self.assertIsNone(call_kwargs.get("on_body"))
         self.assertEqual(awscrt.s3.S3RequestType.PUT_OBJECT, call_kwargs.get("type"))
         self.assertEqual("PUT", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
-
-        if expecting_content_length:
-            self.assertEqual(str(len(self.content)), crt_request.headers.get("content-length"))
-        else:
-            self.assertIsNone(crt_request.headers.get("content-length"))
 
     def _assert_expected_make_request_callargs_for_upload_file(self):
         self._assert_expected_make_request_callargs_for_upload_helper(
@@ -182,6 +182,7 @@ class TestCRTTransferManager(unittest.TestCase):
 
         self.assertIsNone(call_kwargs.get("send_filepath"))
         self.assertIsNone(crt_request.body_stream)
+        self.assertEqual("0", crt_request.headers.get("content-length"))
         self.assertEqual(awscrt.s3.S3RequestType.GET_OBJECT, call_kwargs.get("type"))
         self.assertEqual("GET", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -26,10 +26,10 @@ from s3transfer.manager import TransferConfig, TransferManager
 from tests import (
     BaseGeneralInterfaceTest,
     FileSizeProvider,
-    NonSeekableWriter,
     RecordingOSUtils,
     RecordingSubscriber,
     StreamWithError,
+    create_nonseekable_writer,
     skip_if_using_serial_implementation,
     skip_if_windows,
 )
@@ -181,7 +181,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
 
         with open(self.filename, 'wb') as f:
             future = self.manager.download(
-                self.bucket, self.key, NonSeekableWriter(f), self.extra_args
+                self.bucket, self.key, create_nonseekable_writer(f), self.extra_args
             )
             future.result()
 

--- a/tests/integration/test_download.py
+++ b/tests/integration/test_download.py
@@ -18,9 +18,9 @@ from concurrent.futures import CancelledError
 
 from s3transfer.manager import TransferConfig
 from tests import (
-    NonSeekableWriter,
     RecordingSubscriber,
     assert_files_equal,
+    create_nonseekable_writer,
     skip_if_using_serial_implementation,
     skip_if_windows,
 )
@@ -248,7 +248,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         download_path = os.path.join(self.files.rootdir, '1mb.txt')
         with open(download_path, 'wb') as f:
             future = transfer_manager.download(
-                self.bucket_name, '1mb.txt', NonSeekableWriter(f)
+                self.bucket_name, '1mb.txt', create_nonseekable_writer(f)
             )
             future.result()
         assert_files_equal(filename, download_path)
@@ -264,7 +264,7 @@ class TestDownload(BaseTransferManagerIntegTest):
         download_path = os.path.join(self.files.rootdir, '20mb.txt')
         with open(download_path, 'wb') as f:
             future = transfer_manager.download(
-                self.bucket_name, '20mb.txt', NonSeekableWriter(f)
+                self.bucket_name, '20mb.txt', create_nonseekable_writer(f)
             )
             future.result()
         assert_files_equal(filename, download_path)

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -41,9 +41,9 @@ from tests import (
     BaseSubmissionTaskTest,
     BaseTaskTest,
     FileCreator,
-    NonSeekableWriter,
     RecordingExecutor,
     StreamWithError,
+    create_nonseekable_writer,
     mock,
     unittest,
 )
@@ -539,7 +539,7 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
         self.add_get_responses()
 
         with open(self.filename, 'wb') as f:
-            self.use_fileobj_in_call_args(NonSeekableWriter(f))
+            self.use_fileobj_in_call_args(create_nonseekable_writer(f))
             self.submission_task = self.get_download_submission_task()
             self.wait_and_assert_completed_successfully(self.submission_task)
 
@@ -554,7 +554,7 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
         self.add_get_responses()
 
         with open(self.filename, 'wb') as f:
-            self.use_fileobj_in_call_args(NonSeekableWriter(f))
+            self.use_fileobj_in_call_args(create_nonseekable_writer(f))
             self.submission_task = self.get_download_submission_task()
             self.wait_and_assert_completed_successfully(self.submission_task)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -43,7 +43,7 @@ from s3transfer.utils import (
     invoke_progress_callbacks,
     random_file_extension,
 )
-from tests import NonSeekableWriter, RecordingSubscriber, mock, unittest
+from tests import RecordingSubscriber, create_nonseekable_writer, mock, unittest
 
 
 class TestGetCallbacks(unittest.TestCase):
@@ -361,7 +361,7 @@ class TestDeferredOpenFile(BaseUtilsTest):
 
     def open_nonseekable(self, filename, mode):
         self.open_call_args.append((filename, mode))
-        return NonSeekableWriter(BytesIO(self.content))
+        return create_nonseekable_writer(BytesIO(self.content))
 
     def test_instantiation_does_not_open_file(self):
         DeferredOpenFile(


### PR DESCRIPTION
Improvements to CRTTransferManager:
* Add streaming fileobj support
    * Previously, it only worked with file paths.
* Add support for `ChecksumAlgorithm`
* Use ALLOWED lists to limit what can be passed in `extra_args`
    * The default TransferManager uses these lists to prevent unexpected weirdness when splitting uploads and downloads into parts, but the CRTTransferManager hadn't hooked up these filters