### PR TITLE
Support file-like objects in CRT transfer manager

### DIFF
--- a/.changes/next-release/enhancement-crt-51520.json
+++ b/.changes/next-release/enhancement-crt-51520.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``crt``",
+  "description": "Add support for uploading and downloading file-like objects using CRT transfer manager. It supports both seekable and non-seekable file-like objects."
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -509,6 +509,9 @@ class NonSeekableReader(io.RawIOBase):
     def read(self, n=-1):
         return self._data.read(n)
 
+    def readinto(self, b):
+        return self._data.readinto(b)
+
 
 class NonSeekableWriter(io.RawIOBase):
     def __init__(self, fileobj):

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import fnmatch
+import io
 import threading
 import time
 from concurrent.futures import Future
@@ -18,7 +19,15 @@ from concurrent.futures import Future
 from botocore.session import Session
 
 from s3transfer.subscribers import BaseSubscriber
-from tests import HAS_CRT, FileCreator, mock, requires_crt, unittest
+from tests import (
+    HAS_CRT,
+    FileCreator,
+    NonSeekableReader,
+    NonSeekableWriter,
+    mock,
+    requires_crt,
+    unittest,
+)
 
 if HAS_CRT:
     import awscrt
@@ -60,13 +69,19 @@ class TestCRTTransferManager(unittest.TestCase):
         self.region = 'us-west-2'
         self.bucket = "test_bucket"
         self.key = "test_key"
+        self.expected_content = b'my content'
+        self.expected_download_content = b'new content'
         self.files = FileCreator()
-        self.filename = self.files.create_file('myfile', 'my content')
+        self.filename = self.files.create_file(
+            'myfile', self.expected_content, mode='wb'
+        )
         self.expected_path = "/" + self.bucket + "/" + self.key
         self.expected_host = "s3.%s.amazonaws.com" % (self.region)
         self.s3_request = mock.Mock(awscrt.s3.S3Request)
         self.s3_crt_client = mock.Mock(awscrt.s3.S3Client)
-        self.s3_crt_client.make_request.return_value = self.s3_request
+        self.s3_crt_client.make_request.side_effect = (
+            self._simulate_make_request_side_effect
+        )
         self.session = Session()
         self.session.set_config_variable('region', self.region)
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
@@ -80,6 +95,42 @@ class TestCRTTransferManager(unittest.TestCase):
 
     def tearDown(self):
         self.files.remove_all()
+
+    def _assert_expected_crt_http_request(
+        self,
+        crt_http_request,
+        expected_http_method='GET',
+        expected_host=None,
+        expected_path=None,
+        expected_body_content=None,
+        expected_content_length=None,
+        expected_missing_headers=None,
+    ):
+        if expected_host is None:
+            expected_host = self.expected_host
+        if expected_path is None:
+            expected_path = self.expected_path
+        self.assertEqual(crt_http_request.method, expected_http_method)
+        self.assertEqual(crt_http_request.headers.get("host"), expected_host)
+        self.assertEqual(crt_http_request.path, expected_path)
+        if expected_body_content is not None:
+            # Note: The underlying CRT awscrt.io.InputStream does not expose
+            # a public read method so we have to reach into the private,
+            # underlying stream to determine the content. We should update
+            # to use a public interface if a public interface is ever exposed.
+            self.assertEqual(
+                crt_http_request.body_stream._stream.read(),
+                expected_body_content,
+            )
+        if expected_content_length is not None:
+            self.assertEqual(
+                crt_http_request.headers.get('Content-Length'),
+                str(expected_content_length),
+            )
+        if expected_missing_headers is not None:
+            header_names = [header[0] for header in crt_http_request.headers]
+            for expected_missing_header in expected_missing_headers:
+                self.assertNotIn(expected_missing_header, header_names)
 
     def _assert_subscribers_called(self, expected_future=None):
         self.assertTrue(self.record_subscriber.on_queued_called)
@@ -99,47 +150,125 @@ class TestCRTTransferManager(unittest.TestCase):
         on_done(error=None)
 
     def _simulate_file_download(self, recv_filepath):
-        self.files.create_file(recv_filepath, "fake response")
+        self.files.create_file(
+            recv_filepath, self.expected_download_content, mode='wb'
+        )
+
+    def _simulate_on_body_download(self, on_body_callback):
+        on_body_callback(chunk=self.expected_download_content, offset=0)
 
     def _simulate_make_request_side_effect(self, **kwargs):
         if kwargs.get('recv_filepath'):
             self._simulate_file_download(kwargs['recv_filepath'])
+        if kwargs.get('on_body'):
+            self._simulate_on_body_download(kwargs['on_body'])
         self._invoke_done_callbacks()
-        return mock.DEFAULT
+        return self.s3_request
 
     def test_upload(self):
-        self.s3_crt_client.make_request.side_effect = (
-            self._simulate_make_request_side_effect
-        )
         future = self.transfer_manager.upload(
             self.filename, self.bucket, self.key, {}, [self.record_subscriber]
         )
         future.result()
 
-        callargs = self.s3_crt_client.make_request.call_args
-        callargs_kwargs = callargs[1]
-        self.assertEqual(callargs_kwargs["send_filepath"], self.filename)
-        self.assertIsNone(callargs_kwargs["recv_filepath"])
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
         self.assertEqual(
-            callargs_kwargs["type"], awscrt.s3.S3RequestType.PUT_OBJECT
+            callargs_kwargs,
+            {
+                'request': mock.ANY,
+                'type': awscrt.s3.S3RequestType.PUT_OBJECT,
+                'send_filepath': self.filename,
+                'on_progress': mock.ANY,
+                'on_done': mock.ANY,
+            },
         )
-        crt_request = callargs_kwargs["request"]
-        self.assertEqual("PUT", crt_request.method)
-        self.assertEqual(self.expected_path, crt_request.path)
-        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='PUT',
+            expected_content_length=len(self.expected_content),
+            expected_missing_headers=['Content-MD5'],
+        )
+        self._assert_subscribers_called(future)
+
+    def test_upload_from_seekable_stream(self):
+        with open(self.filename, 'rb') as f:
+            future = self.transfer_manager.upload(
+                f, self.bucket, self.key, {}, [self.record_subscriber]
+            )
+            future.result()
+
+            callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+            self.assertEqual(
+                callargs_kwargs,
+                {
+                    'request': mock.ANY,
+                    'type': awscrt.s3.S3RequestType.PUT_OBJECT,
+                    'send_filepath': None,
+                    'on_progress': mock.ANY,
+                    'on_done': mock.ANY,
+                },
+            )
+            self._assert_expected_crt_http_request(
+                callargs_kwargs["request"],
+                expected_http_method='PUT',
+                expected_body_content=self.expected_content,
+                expected_content_length=len(self.expected_content),
+                expected_missing_headers=['Content-MD5'],
+            )
+            self._assert_subscribers_called(future)
+
+    def test_upload_from_nonseekable_stream(self):
+        nonseekable_stream = NonSeekableReader(self.expected_content)
+        future = self.transfer_manager.upload(
+            nonseekable_stream,
+            self.bucket,
+            self.key,
+            {},
+            [self.record_subscriber],
+        )
+        future.result()
+
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+        self.assertEqual(
+            callargs_kwargs,
+            {
+                'request': mock.ANY,
+                'type': awscrt.s3.S3RequestType.PUT_OBJECT,
+                'send_filepath': None,
+                'on_progress': mock.ANY,
+                'on_done': mock.ANY,
+            },
+        )
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='PUT',
+            expected_body_content=self.expected_content,
+            expected_missing_headers=[
+                'Content-MD5',
+                'Content-Length',
+                'Transfer-Encoding',
+            ],
+        )
         self._assert_subscribers_called(future)
 
     def test_download(self):
-        self.s3_crt_client.make_request.side_effect = (
-            self._simulate_make_request_side_effect
-        )
         future = self.transfer_manager.download(
             self.bucket, self.key, self.filename, {}, [self.record_subscriber]
         )
         future.result()
 
-        callargs = self.s3_crt_client.make_request.call_args
-        callargs_kwargs = callargs[1]
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+        self.assertEqual(
+            callargs_kwargs,
+            {
+                'request': mock.ANY,
+                'type': awscrt.s3.S3RequestType.GET_OBJECT,
+                'recv_filepath': mock.ANY,
+                'on_progress': mock.ANY,
+                'on_done': mock.ANY,
+                'on_body': None,
+            },
+        )
         # the recv_filepath will be set to a temporary file path with some
         # random suffix
         self.assertTrue(
@@ -148,42 +277,109 @@ class TestCRTTransferManager(unittest.TestCase):
                 f'{self.filename}.*',
             )
         )
-        self.assertIsNone(callargs_kwargs["send_filepath"])
-        self.assertEqual(
-            callargs_kwargs["type"], awscrt.s3.S3RequestType.GET_OBJECT
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='GET',
+            expected_content_length=0,
         )
-        crt_request = callargs_kwargs["request"]
-        self.assertEqual("GET", crt_request.method)
-        self.assertEqual(self.expected_path, crt_request.path)
-        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
         self._assert_subscribers_called(future)
         with open(self.filename, 'rb') as f:
             # Check the fake response overwrites the file because of download
-            self.assertEqual(f.read(), b'fake response')
+            self.assertEqual(f.read(), self.expected_download_content)
+
+    def test_download_to_seekable_stream(self):
+        with open(self.filename, 'wb') as f:
+            future = self.transfer_manager.download(
+                self.bucket, self.key, f, {}, [self.record_subscriber]
+            )
+            future.result()
+
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+        self.assertEqual(
+            callargs_kwargs,
+            {
+                'request': mock.ANY,
+                'type': awscrt.s3.S3RequestType.GET_OBJECT,
+                'recv_filepath': None,
+                'on_progress': mock.ANY,
+                'on_done': mock.ANY,
+                'on_body': mock.ANY,
+            },
+        )
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='GET',
+            expected_content_length=0,
+        )
+        self._assert_subscribers_called(future)
+        with open(self.filename, 'rb') as f:
+            # Check the fake response overwrites the file because of download
+            self.assertEqual(f.read(), self.expected_download_content)
+
+    def test_download_to_nonseekable_stream(self):
+        underlying_stream = io.BytesIO()
+        nonseekable_stream = NonSeekableWriter(underlying_stream)
+        future = self.transfer_manager.download(
+            self.bucket,
+            self.key,
+            nonseekable_stream,
+            {},
+            [self.record_subscriber],
+        )
+        future.result()
+
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+        self.assertEqual(
+            callargs_kwargs,
+            {
+                'request': mock.ANY,
+                'type': awscrt.s3.S3RequestType.GET_OBJECT,
+                'recv_filepath': None,
+                'on_progress': mock.ANY,
+                'on_done': mock.ANY,
+                'on_body': mock.ANY,
+            },
+        )
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='GET',
+            expected_content_length=0,
+        )
+        self._assert_subscribers_called(future)
+        self.assertEqual(
+            underlying_stream.getvalue(), self.expected_download_content
+        )
 
     def test_delete(self):
-        self.s3_crt_client.make_request.side_effect = (
-            self._simulate_make_request_side_effect
-        )
         future = self.transfer_manager.delete(
             self.bucket, self.key, {}, [self.record_subscriber]
         )
         future.result()
 
-        callargs = self.s3_crt_client.make_request.call_args
-        callargs_kwargs = callargs[1]
-        self.assertIsNone(callargs_kwargs["send_filepath"])
-        self.assertIsNone(callargs_kwargs["recv_filepath"])
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
         self.assertEqual(
-            callargs_kwargs["type"], awscrt.s3.S3RequestType.DEFAULT
+            callargs_kwargs,
+            {
+                'request': mock.ANY,
+                'type': awscrt.s3.S3RequestType.DEFAULT,
+                'on_progress': mock.ANY,
+                'on_done': mock.ANY,
+            },
         )
-        crt_request = callargs_kwargs["request"]
-        self.assertEqual("DELETE", crt_request.method)
-        self.assertEqual(self.expected_path, crt_request.path)
-        self.assertEqual(self.expected_host, crt_request.headers.get("host"))
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='DELETE',
+            expected_content_length=0,
+        )
         self._assert_subscribers_called(future)
 
     def test_blocks_when_max_requests_processes_reached(self):
+        self.s3_crt_client.make_request.return_value = self.s3_request
+        # We simulate blocking by not invoking the on_done callbacks for
+        # all of the requests we send. The default side effect invokes all
+        # callbacks so we need to unset the side effect to avoid on_done from
+        # being called in the child threads.
+        self.s3_crt_client.make_request.side_effect = None
         futures = []
         callargs = (self.bucket, self.key, self.filename, {}, [])
         max_request_processes = 128  # the hard coded max processes

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -11,11 +11,18 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import glob
+import io
 import os
 
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
-from tests import HAS_CRT, assert_files_equal, requires_crt
+from tests import (
+    HAS_CRT,
+    NonSeekableReader,
+    NonSeekableWriter,
+    assert_files_equal,
+    requires_crt,
+)
 from tests.integration import BaseTransferManagerIntegTest
 
 if HAS_CRT:
@@ -44,19 +51,58 @@ class RecordingSubscriber(BaseSubscriber):
 class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     """Tests for the high level s3transfer based on CRT implementation."""
 
+    def setUp(self):
+        super().setUp()
+        self.s3_key = 's3key.txt'
+        self.download_path = os.path.join(self.files.rootdir, 'download.txt')
+
     def _create_s3_transfer(self):
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
-            self.session
+            self.session, client_kwargs={'region_name': self.region}
         )
         credetial_resolver = self.session.get_component('credential_provider')
         self.s3_crt_client = s3transfer.crt.create_s3_crt_client(
-            self.session.get_config_variable("region"), credetial_resolver
+            self.region, credetial_resolver
         )
         self.record_subscriber = RecordingSubscriber()
         self.osutil = OSUtils()
         return s3transfer.crt.CRTTransferManager(
             self.s3_crt_client, self.request_serializer
         )
+
+    def _upload_with_crt_transfer_manager(self, fileobj, key=None):
+        if key is None:
+            key = self.s3_key
+        self.addCleanup(self.delete_object, key)
+        with self._create_s3_transfer() as transfer:
+            future = transfer.upload(
+                fileobj,
+                self.bucket_name,
+                key,
+                subscribers=[self.record_subscriber],
+            )
+            future.result()
+
+    def _download_with_crt_transfer_manager(self, fileobj, key=None):
+        if key is None:
+            key = self.s3_key
+        self.addCleanup(self.delete_object, key)
+        with self._create_s3_transfer() as transfer:
+            future = transfer.download(
+                self.bucket_name,
+                key,
+                fileobj,
+                subscribers=[self.record_subscriber],
+            )
+            future.result()
+
+    def _assert_expected_s3_object(self, key, expected_size=None):
+        self.assertTrue(self.object_exists(key))
+        if expected_size is not None:
+            response = self.client.head_object(
+                Bucket=self.bucket_name, Key=key
+            )
+            self.assertEqual(response['ContentLength'], expected_size)
 
     def _assert_has_public_read_acl(self, response):
         grants = response['Grants']
@@ -176,6 +222,43 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         self.assertEqual(response['SSECustomerAlgorithm'], 'AES256')
         self._assert_subscribers_called(file_size)
 
+    def test_upload_seekable_stream(self):
+        size = 1024 * 1024
+        self._upload_with_crt_transfer_manager(io.BytesIO(b'0' * size))
+        self._assert_expected_s3_object(self.s3_key, expected_size=size)
+        self._assert_subscribers_called(size)
+
+    def test_multipart_upload_seekable_stream(self):
+        size = 20 * 1024 * 1024
+        self._upload_with_crt_transfer_manager(io.BytesIO(b'0' * size))
+        self._assert_expected_s3_object(self.s3_key, expected_size=size)
+        self._assert_subscribers_called(size)
+
+    def test_upload_nonseekable_stream(self):
+        size = 1024 * 1024
+        self._upload_with_crt_transfer_manager(NonSeekableReader(b'0' * size))
+        self._assert_expected_s3_object(self.s3_key, expected_size=size)
+        self._assert_subscribers_called(size)
+
+    def test_multipart_upload_nonseekable_stream(self):
+        size = 20 * 1024 * 1024
+        self._upload_with_crt_transfer_manager(NonSeekableReader(b'0' * size))
+        self._assert_expected_s3_object(self.s3_key, expected_size=size)
+        self._assert_subscribers_called(size)
+
+    def test_upload_empty_file(self):
+        size = 0
+        filename = self.files.create_file_with_size(self.s3_key, filesize=size)
+        self._upload_with_crt_transfer_manager(filename)
+        self._assert_expected_s3_object(self.s3_key, expected_size=size)
+        self._assert_subscribers_called(size)
+
+    def test_upload_empty_stream(self):
+        size = 0
+        self._upload_with_crt_transfer_manager(io.BytesIO(b''))
+        self._assert_expected_s3_object(self.s3_key, expected_size=size)
+        self._assert_subscribers_called(size)
+
     def test_can_send_extra_params_on_download(self):
         # We're picking the customer provided sse feature
         # of S3 to test the extra_args functionality of
@@ -243,6 +326,65 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         assert_files_equal(filename, download_path)
         file_size = self.osutil.get_file_size(download_path)
         self._assert_subscribers_called(file_size)
+
+    def test_download_seekable_stream(self):
+        size = 1024 * 1024
+        filename = self.files.create_file_with_size(self.s3_key, filesize=size)
+        self.upload_file(filename, self.s3_key)
+
+        with open(self.download_path, 'wb') as f:
+            self._download_with_crt_transfer_manager(f)
+        self._assert_subscribers_called(size)
+        assert_files_equal(filename, self.download_path)
+
+    def test_multipart_download_seekable_stream(self):
+        size = 20 * 1024 * 1024
+        filename = self.files.create_file_with_size(self.s3_key, filesize=size)
+        self.upload_file(filename, self.s3_key)
+
+        with open(self.download_path, 'wb') as f:
+            self._download_with_crt_transfer_manager(f)
+        self._assert_subscribers_called(size)
+        assert_files_equal(filename, self.download_path)
+
+    def test_download_nonseekable_stream(self):
+        size = 1024 * 1024
+        filename = self.files.create_file_with_size(self.s3_key, filesize=size)
+        self.upload_file(filename, self.s3_key)
+
+        with open(self.download_path, 'wb') as f:
+            self._download_with_crt_transfer_manager(NonSeekableWriter(f))
+        self._assert_subscribers_called(size)
+        assert_files_equal(filename, self.download_path)
+
+    def test_multipart_download_nonseekable_stream(self):
+        size = 20 * 1024 * 1024
+        filename = self.files.create_file_with_size(self.s3_key, filesize=size)
+        self.upload_file(filename, self.s3_key)
+
+        with open(self.download_path, 'wb') as f:
+            self._download_with_crt_transfer_manager(NonSeekableWriter(f))
+        self._assert_subscribers_called(size)
+        assert_files_equal(filename, self.download_path)
+
+    def test_download_empty_file(self):
+        size = 0
+        filename = self.files.create_file_with_size(self.s3_key, filesize=size)
+        self.upload_file(filename, self.s3_key)
+
+        self._download_with_crt_transfer_manager(self.download_path)
+        self._assert_subscribers_called(size)
+        assert_files_equal(filename, self.download_path)
+
+    def test_download_empty_stream(self):
+        size = 0
+        filename = self.files.create_file_with_size(self.s3_key, filesize=size)
+        self.upload_file(filename, self.s3_key)
+
+        with open(self.download_path, 'wb') as f:
+            self._download_with_crt_transfer_manager(f)
+        self._assert_subscribers_called(size)
+        assert_files_equal(filename, self.download_path)
 
     def test_delete(self):
         transfer = self._create_s3_transfer()

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
+
 from botocore.credentials import CredentialResolver, ReadOnlyCredentials
 from botocore.session import Session
 
@@ -171,3 +173,12 @@ class TestCRTTransferFuture(unittest.TestCase):
         self.future.set_exception(CustomFutureException())
         with self.assertRaises(CustomFutureException):
             self.future.result()
+
+
+@requires_crt
+class TestOnBodyFileObjWriter(unittest.TestCase):
+    def test_call(self):
+        fileobj = io.BytesIO()
+        writer = s3transfer.crt.OnBodyFileObjWriter(fileobj)
+        writer(chunk=b'content')
+        self.assertEqual(fileobj.getvalue(), b'content')


### PR DESCRIPTION
This is a backport of this pull request: https://github.com/aws/aws-cli/pull/8291, which was implemented based off this pull request: https://github.com/boto/s3transfer/pull/277. Also note that the integration tests do not pass using the current version of CRT that is pinned in `botocore`. They do however pass if you update to the latest version of `awscrt`. I don't think that should block merging this PR as it will be merged into a feature branch. However, we will need to update the `awscrt` pin in `botocore` before merging the feature branch.