### PR TITLE
Update throughput target defaults

### DIFF
--- a/.changes/next-release/enhancement-crt-28261.json
+++ b/.changes/next-release/enhancement-crt-28261.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``crt``",
+  "description": "Update ``target_throughput`` defaults. If not configured, s3transfer will use the AWS CRT to attempt to determine a recommended target throughput to use based on the system. If there is no recommended throughput, s3transfer now falls back to ten gigabits per second."
+}


### PR DESCRIPTION
Instead of defaulting to five gigabits per second when no target throughput is configured, s3transfer will use the CRT to determine if there is a recommended target throughput to use. If it is unable, to determine a recommended target throughput, it will default to ten gigabits per second, which is the current throughput default for the CRT S3 client.

This behavior was updated to help minimize the amount of configuration required to get the fastest throughputs from the CRT transfer client. The fallback throughput was updated from five to ten gigabits so that the CRT S3 integration is consistent with the underlying CRT S3 client's defaults.

This a port of this AWS CLI v2 PR: https://github.com/aws/aws-cli/pull/8327/