### PR TITLE
Update interface for providing credentials to CRT

### DIFF
--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -60,15 +60,21 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
             self.session, client_kwargs={'region_name': self.region}
         )
-        credetial_resolver = self.session.get_component('credential_provider')
         self.s3_crt_client = s3transfer.crt.create_s3_crt_client(
-            self.region, credetial_resolver
+            self.region, self._get_crt_credentials_provider()
         )
         self.record_subscriber = RecordingSubscriber()
         self.osutil = OSUtils()
         return s3transfer.crt.CRTTransferManager(
             self.s3_crt_client, self.request_serializer
         )
+
+    def _get_crt_credentials_provider(self):
+        botocore_credentials = self.session.get_credentials()
+        wrapper = s3transfer.crt.BotocoreCRTCredentialsWrapper(
+            botocore_credentials
+        )
+        return wrapper.to_crt_credentials_provider()
 
     def _upload_with_crt_transfer_manager(self, fileobj, key=None):
         if key is None:


### PR DESCRIPTION
This is a port of this PR: https://github.com/aws/aws-cli/pull/8334

The two main changes are:
* Update the CRT S3 client factory to accept a CRT credential provider instead of a botocore credential provider. Under the hood, the S3 client only accepts a CRT credential provider. So, this provides more flexibility in being able to provide other CRT credenital providers directly instead of being forced to the botocore credential provider interface
* Update the botocore to CRT credentials adapter interface to only accept botocore credential objects instead of credential providers. In general, the credentials object is more accessible than the provider; it can be retrieved at the session level and is what is passed into clients. Also, this change avoids a limitation where the load_credentials() method on the credential provider cannot be called more than twice for some configurations (e.g. assume role from profile), which can be an issue if you create both a botocore client and CRT S3 client.