### PR TITLE
Use lru_cache on costly validation function.

### DIFF
--- a/s3transfer/subscribers.py
+++ b/s3transfer/subscribers.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from functools import lru_cache
+
 from s3transfer.compat import accepts_kwargs
 from s3transfer.exceptions import InvalidSubscriberMethodError
 
@@ -28,6 +30,7 @@ class BaseSubscriber:
         return super().__new__(cls)
 
     @classmethod
+    @lru_cache()
     def _validate_subscriber_methods(cls):
         for subscriber_type in cls.VALID_SUBSCRIBER_TYPES:
             subscriber_method = getattr(cls, 'on_' + subscriber_type)


### PR DESCRIPTION
This gave me a 24% speedup when downloading a folder with 30,000 small files using `aws s3 cp` with `preferred_transfer_client=crt` on a 100Gbps machine. It speeds up the `classic` transfer client as well.

When profiling this workload, `_validate_subscriber_methods()` had a big presence in the flame graph. Commenting out the validate function gave a huge speedup. But the validation is useful, so we didn't want to remove it. Using lru_cache provides the same speedup for the 30,000 file workload. It runs 6 times (once per subscriber class) instead of 180,000 times (6 times per file).