### PR TITLE
Scope awscrt.s3 imports to functions

### DIFF
--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -54,7 +54,7 @@ def mock_s3_crt_client():
 @pytest.fixture
 def mock_get_recommended_throughput_target_gbps():
     with mock.patch(
-        's3transfer.crt.get_recommended_throughput_target_gbps'
+        'awscrt.s3.get_recommended_throughput_target_gbps'
     ) as mock_get_target_gbps:
         yield mock_get_target_gbps
 


### PR DESCRIPTION
Defer CRT import references until used in a function for cases where an unexpected CRT version exists in the environment.