### PR TITLE
Add back 3.7 lru_cache syntax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - '--py38-plus'
+          - '--py37-plus'
   - repo: 'https://github.com/PyCQA/isort'
     rev: 5.12.0
     hooks:

--- a/s3transfer/subscribers.py
+++ b/s3transfer/subscribers.py
@@ -30,7 +30,7 @@ class BaseSubscriber:
         return super().__new__(cls)
 
     @classmethod
-    @lru_cache
+    @lru_cache()
     def _validate_subscriber_methods(cls):
         for subscriber_type in cls.VALID_SUBSCRIBER_TYPES:
             subscriber_method = getattr(cls, 'on_' + subscriber_type)


### PR DESCRIPTION
This is an intentional downgrading of the pyupgrade bump to avoid unnecessary churn in the initial cutover. `pip` _should_ save us from mismatches, but as we've seen recently there are some creative packaging strategies that are circumventing most standard tooling.