### PR TITLE
Pass operation name to awscrt.s3

### DIFF
--- a/.changes/next-release/bugfix-awscrt-54174.json
+++ b/.changes/next-release/bugfix-awscrt-54174.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
-  "category": "awscrt",
-  "description": "Pass operation name to awscrt.s3, to improve error handling"
+  "category": "``awscrt``",
+  "description": "Pass operation name to awscrt.s3 to improve error handling."
 }

--- a/.changes/next-release/bugfix-awscrt-54174.json
+++ b/.changes/next-release/bugfix-awscrt-54174.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "awscrt",
+  "description": "Pass operation name to awscrt.s3, to improve error handling"
+}

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -818,13 +818,22 @@ class S3ClientArgsCreator:
         on_done_before_calls,
         on_done_after_calls,
     ):
+        crt_request_type = getattr(
+            S3RequestType, request_type.upper(), S3RequestType.DEFAULT
+        )
+
+        # For DEFAULT requests, CRT requires the official S3 operation name.
+        # So transform string like "delete_object" -> "DeleteObject".
+        operation_name = None
+        if crt_request_type == S3RequestType.DEFAULT:
+            operation_name = ''.join(x.title() for x in request_type.split('_'))
+
         make_request_args = {
             'request': self._request_serializer.serialize_http_request(
                 request_type, future
             ),
-            'type': getattr(
-                S3RequestType, request_type.upper(), S3RequestType.DEFAULT
-            ),
+            'type': crt_request_type,
+            'operation_name': operation_name,
             'on_done': self.get_crt_callback(
                 future, 'done', on_done_before_calls, on_done_after_calls
             ),

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -826,7 +826,9 @@ class S3ClientArgsCreator:
         # So transform string like "delete_object" -> "DeleteObject".
         operation_name = None
         if crt_request_type == S3RequestType.DEFAULT:
-            operation_name = ''.join(x.title() for x in request_type.split('_'))
+            operation_name = ''.join(
+                x.title() for x in request_type.split('_')
+            )
 
         make_request_args = {
             'request': self._request_serializer.serialize_http_request(

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -515,6 +515,7 @@ class TestCRTTransferManager(unittest.TestCase):
             {
                 'request': mock.ANY,
                 'type': awscrt.s3.S3RequestType.DEFAULT,
+                'operation_name': "DeleteObject",
                 'on_progress': mock.ANY,
                 'on_done': mock.ANY,
             },

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -13,6 +13,9 @@
 import glob
 import io
 import os
+from uuid import uuid4
+
+from botocore.exceptions import ClientError
 
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
@@ -403,6 +406,15 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
             future = transfer.delete(self.bucket_name, 'foo.txt')
             future.result()
         self.assertTrue(self.object_not_exists('foo.txt'))
+
+    def test_delete_exception_no_such_bucket(self):
+        # delete() uses awscrt.s3.S3RequestType.DEFAULT under the hood.
+        # Test that CRT exceptions translate properly into the botocore exceptions.
+        transfer = self._create_s3_transfer()
+        with self.assertRaises(ClientError) as ctx:
+            future = transfer.delete(f"{self.bucket_name}-NONEXISTENT-{uuid4()}", "foo.txt")
+            future.result()
+        self.assertEqual(ctx.exception.__class__.__name__, 'NoSuchBucket')
 
     def test_many_files_download(self):
         transfer = self._create_s3_transfer()

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -412,7 +412,9 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         # Test that CRT exceptions translate properly into the botocore exceptions.
         transfer = self._create_s3_transfer()
         with self.assertRaises(ClientError) as ctx:
-            future = transfer.delete(f"{self.bucket_name}-NONEXISTENT-{uuid4()}", "foo.txt")
+            future = transfer.delete(
+                f"{self.bucket_name}-NONEXISTENT-{uuid4()}", "foo.txt"
+            )
             future.result()
         self.assertEqual(ctx.exception.__class__.__name__, 'NoSuchBucket')
 


### PR DESCRIPTION
`awscrt.s3` will soon require that `operation_name` be passed for `S3RequestType.DEFAULT` (see: https://github.com/awslabs/aws-c-s3/pull/439, https://github.com/awslabs/aws-crt-python/pull/574)

Only `CRTTransferManager.delete()` uses `S3RequestType.DEFAULT`. Fix it to pass along `operation_name="DeleteObject"`