### PR TITLE
Skip HEAD for multipart check when multipart_threshold is 0

### DIFF
--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -747,6 +747,7 @@ class S3Transfer:
             unique_id='s3upload-callback-enable',
         )
         if (
+            self._config.multipart_threshold is not None and
             self._osutil.get_file_size(filename)
             >= self._config.multipart_threshold
         ):
@@ -803,7 +804,7 @@ class S3Transfer:
     def _download_file(
         self, bucket, key, filename, object_size, extra_args, callback
     ):
-        if object_size >= self._config.multipart_threshold:
+        if self._config.multipart_threshold is not None and object_size >= self._config.multipart_threshold:
             self._ranged_download(
                 bucket, key, filename, object_size, extra_args, callback
             )

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -130,7 +130,7 @@ class CopySubmissionTask(SubmissionTask):
 
         # If it is greater than threshold do a multipart copy, otherwise
         # do a regular copy object.
-        if transfer_future.meta.size < config.multipart_threshold:
+        if config.multipart_threshold is None or transfer_future.meta.size < config.multipart_threshold:
             self._submit_copy_request(
                 client, config, osutil, request_executor, transfer_future
             )

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -346,7 +346,7 @@ class DownloadSubmissionTask(SubmissionTask):
         :param bandwidth_limiter: The bandwidth limiter to use when
             downloading streams
         """
-        if transfer_future.meta.size is None:
+        if transfer_future.meta.size is None and config.multipart_threshold is not None:
             # If a size was not provided figure out the size for the
             # user.
             response = client.head_object(
@@ -364,7 +364,7 @@ class DownloadSubmissionTask(SubmissionTask):
 
         # If it is greater than threshold do a ranged download, otherwise
         # do a regular GetObject download.
-        if transfer_future.meta.size < config.multipart_threshold:
+        if config.multipart_threshold is None or transfer_future.meta.size < config.multipart_threshold:
             self._submit_download_request(
                 client,
                 config,

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -816,7 +816,7 @@ class GetObjectSubmitter(BaseS3TransferProcess):
     def _submit_get_object_jobs(self, download_file_request):
         size = self._get_size(download_file_request)
         temp_filename = self._allocate_temp_file(download_file_request, size)
-        if size < self._transfer_config.multipart_threshold:
+        if self._transfer_config.multiparth_threshold is None or size < self._transfer_config.multipart_threshold:
             self._submit_single_get_object_job(
                 download_file_request, temp_filename
             )


### PR DESCRIPTION
Each download does a `HEAD` before the `GET`, but unless the file is possible a very large file that would benefit from multipart download, then this is just adding unneeded operations and delay. This PR changes it so that `multipart_threshold` being 0 will skip the `HEAD` call and I'd argue that this should be the changed to the default behavior as well

Related to https://github.com/boto/boto3/issues/3083