### PR TITLE
Zombie process bugfix

### DIFF
--- a/.changes/next-release/bugfix-performance-7156.json
+++ b/.changes/next-release/bugfix-performance-7156.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "performance",
+  "description": "Fixes a bug that occurs when the underlying Python process is a zombie.\""
+}

--- a/.changes/next-release/bugfix-performance-7156.json
+++ b/.changes/next-release/bugfix-performance-7156.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "performance",
-  "description": "Fixes a bug that occurs when the underlying Python process is a zombie.\""
+  "description": "Fixes a bug that occurs when the underlying Python process is a zombie."
 }

--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -79,9 +79,9 @@ def run_benchmark(pid, output_file, data_interval):
                 memory_used = process_to_measure.memory_info().rss
                 cpu_percent = process_to_measure.cpu_percent()
                 current_net = psutil.net_io_counters(pernic=True)[INTERFACE]
-            except psutil.AccessDenied:
-                # Trying to get process information from a closed process will
-                # result in AccessDenied.
+            except (psutil.AccessDenied, psutil.ZombieProcess):
+                # Trying to get process information from a closed or zombie process will
+                # result in corresponding exceptions.
                 break
 
             # Collect data on the in/out network io.


### PR DESCRIPTION
Fixed a bug in performance test script in the edge case that the child process is a zombie, but the parent is not. 