### PR TITLE
Update floor for botocore

### DIFF
--- a/.changes/next-release/bugfix-Dependencies-68171.json
+++ b/.changes/next-release/bugfix-Dependencies-68171.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Dependencies",
+  "description": "Update the floor version of botocore to 1.36.0 to match imports."
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 0
 
 [metadata]
 requires_dist =
-    botocore>=1.33.2,<2.0a.0
+    botocore>=1.36.0,<2.0a.0
 
 [options.extras_require]
-crt = botocore[crt]>=1.33.2,<2.0a0
+crt = botocore[crt]>=1.36.0,<2.0a0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ VERSION_RE = re.compile(r'''__version__ = ['"]([0-9.]+)['"]''')
 
 
 requires = [
-    'botocore>=1.33.2,<2.0a.0',
+    'botocore>=1.36.0,<2.0a.0',
 ]
 
 
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     install_requires=requires,
     extras_require={
-        'crt': 'botocore[crt]>=1.33.2,<2.0a.0',
+        'crt': 'botocore[crt]>=1.36.0,<2.0a.0',
     },
     license="Apache License 2.0",
     python_requires=">= 3.8",


### PR DESCRIPTION
This fixes conflicts with imports when using older versions of botocore. With the recent changes in 0.11.0, botocore 1.36.0+ is now required.