### PR TITLE
Honor "request_checksum_calculation = WHEN_REQUIRED" in config (#327)

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -519,7 +519,8 @@ class TransferManager:
                 )
 
     def _add_operation_defaults(self, extra_args):
-        set_default_checksum_algorithm(extra_args)
+        if self.client.meta.config.request_checksum_calculation == "when_supported":
+            set_default_checksum_algorithm(extra_args)
 
     def _submit_transfer(
         self, call_args, submission_task_cls, extra_main_kwargs=None


### PR DESCRIPTION
As mentioned in #327, `aws s3 cp` does not honor the `request_checksum_calculation` configuration, sending an `x-amz-sdk-checksum-algorithm` header even when `request_checksum_calculation` is set to `WHEN_REQUIRED`.

This change adds a check to `TransferManager._add_operation_defaults()` so that it only calls `set_default_checksum_algorithm()` if `request_checksum_calculation` is set to `WHEN_SUPPORTED`.