### PR TITLE
Output max CPU utilization on summarize-benchmark script JSON output format

### DIFF
--- a/scripts/performance/benchmark
+++ b/scripts/performance/benchmark
@@ -79,9 +79,9 @@ def run_benchmark(pid, output_file, data_interval):
                 memory_used = process_to_measure.memory_info().rss
                 cpu_percent = process_to_measure.cpu_percent()
                 current_net = psutil.net_io_counters(pernic=True)[INTERFACE]
-            except psutil.AccessDenied:
-                # Trying to get process information from a closed process will
-                # result in AccessDenied.
+            except (psutil.AccessDenied, psutil.ZombieProcess):
+                # Trying to get process information from a closed or zombie process will
+                # result in corresponding exceptions.
                 break
 
             # Collect data on the in/out network io.

--- a/scripts/performance/summarize
+++ b/scripts/performance/summarize
@@ -211,6 +211,8 @@ class Summarizer:
                 'std_dev_max_memory': self.std_dev_max_memory,
                 'average_memory': self.average_memory,
                 'std_dev_average_memory': self.std_dev_average_memory,
+                'std_dev_max_cpu': self.std_dev_max_cpu,
+                'max_cpu': self.max_cpu,
                 'average_cpu': self.average_cpu,
                 'std_dev_average_cpu': self.std_dev_average_cpu,
             },


### PR DESCRIPTION
*Description of changes:*
- Add max cpu and standard deviation of max cpu to the JSON output format. This is already included in the table output format.
- Fix a rare bug in the benchmark script where the process is non-zombie during the if-check on line 72, but becomes a zombie in the try-block in lines 79-81.

*Description of tests:*
- Ran the benchmark and summarize scripts and confirmed the max CPU metric (and standard deviation) are now output in JSON output mode.
- After many executions of the benchmark script, I no longer observe the rare bug of an unhandled ZombieProcess exception thrown in the try block.