### PR TITLE
Fix Argument order in TransferManager shutdown method

### DIFF
--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -641,7 +641,7 @@ class TransferManager:
         :param cancel_msg: The message to specify if canceling all in-progress
             transfers.
         """
-        self._shutdown(cancel, cancel_msg, cancel)
+        self._shutdown(cancel, cancel_msg)
 
     def _shutdown(self, cancel, cancel_msg, exc_type=CancelledError):
         if cancel:


### PR DESCRIPTION
Calling `shutdown` from a TransferManager object throws an error further down the line, since the argument order passed to `_shutdown` is incorrect. Calling the function results in an exception being thrown like below

``` 
 File "/repos/test/app/clients/aws/s3.py", line 42, in shutdown_transfer 
   self.transfer_manager.shutdown(cancel=True)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/repos/test/.venv/lib/python3.13/site-packages/s3transfer/manager.py", line 626, in shutdown
    self._shutdown(cancel, cancel, cancel_msg)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/repos/test/.venv/lib/python3.13/site-packages/s3transfer/manager.py", line 632, in _shutdown
    self._coordinator_controller.cancel(cancel_msg, exc_type)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/repos/test/.venv/lib/python3.13/site-packages/s3transfer/manager.py", line 707, in cancel
    transfer_coordinator.cancel(msg, exc_type)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/repos/test/.venv/lib/python3.13/site-packages/s3transfer/futures.py", line 277, in cancel
    self._exception = exc_type(msg)
                      ~~~~~~~~^^^^^
TypeError: 'str' object is not callable
```

