### PR TITLE
Ignore .venv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,13 @@ pip-log.txt
 .idea*
 src/
 
+
+# Virtualenvs
+.venv
+venv
+env
+env2
+env3
+
 # Completions Index
 completions.idx


### PR DESCRIPTION
Add .venv and venv to our .gitignore file to avoid accidental inclusion.
