### PR TITLE
fix the signing config

### DIFF
--- a/.changes/next-release/bugfix-awscrt-11663.json
+++ b/.changes/next-release/bugfix-awscrt-11663.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``awscrt``",
+  "description": "Fix urlencoding issues for request signing with the awscrt."
+}

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -895,14 +895,22 @@ class S3ClientArgsCreator:
         ) and accesspoint_arn_details['region'] == "":
             # Configure our region to `*` to propogate in `x-amz-region-set`
             # for multi-region support in MRAP accesspoints.
+            # use_double_uri_encode and should_normalize_uri_path are defaulted to be True
+            # But SDK already encoded the URI, and it's for S3, so set both to False
             make_request_args['signing_config'] = AwsSigningConfig(
                 algorithm=AwsSigningAlgorithm.V4_ASYMMETRIC,
                 region="*",
+                use_double_uri_encode=False,
+                should_normalize_uri_path=False
             )
             call_args.bucket = accesspoint_arn_details['resource_name']
         elif is_s3express_bucket(call_args.bucket):
+            # use_double_uri_encode and should_normalize_uri_path are defaulted to be True
+            # But SDK already encoded the URI, and it's for S3, so set both to False
             make_request_args['signing_config'] = AwsSigningConfig(
-                algorithm=AwsSigningAlgorithm.V4_S3EXPRESS
+                algorithm=AwsSigningAlgorithm.V4_S3EXPRESS,
+                use_double_uri_encode=False,
+                should_normalize_uri_path=False
             )
         return make_request_args
 

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -901,7 +901,7 @@ class S3ClientArgsCreator:
                 algorithm=AwsSigningAlgorithm.V4_ASYMMETRIC,
                 region="*",
                 use_double_uri_encode=False,
-                should_normalize_uri_path=False
+                should_normalize_uri_path=False,
             )
             call_args.bucket = accesspoint_arn_details['resource_name']
         elif is_s3express_bucket(call_args.bucket):
@@ -910,7 +910,7 @@ class S3ClientArgsCreator:
             make_request_args['signing_config'] = AwsSigningConfig(
                 algorithm=AwsSigningAlgorithm.V4_S3EXPRESS,
                 use_double_uri_encode=False,
-                should_normalize_uri_path=False
+                should_normalize_uri_path=False,
             )
         return make_request_args
 

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -163,6 +163,12 @@ class TestCRTTransferManager(unittest.TestCase):
             make_request_kwargs['signing_config'].algorithm,
             awscrt.auth.AwsSigningAlgorithm.V4_S3EXPRESS,
         )
+        self.assertFalse(
+            make_request_kwargs['signing_config'].use_double_uri_encode,
+        )
+        self.assertFalse(
+            make_request_kwargs['signing_config'].should_normalize_uri_path,
+        )
 
     def _assert_expected_mrap_request(
         self, make_request_kwargs, expected_http_method='GET'
@@ -179,6 +185,12 @@ class TestCRTTransferManager(unittest.TestCase):
             awscrt.auth.AwsSigningAlgorithm.V4_ASYMMETRIC,
         )
         self.assertEqual(make_request_kwargs['signing_config'].region, "*")
+        self.assertFalse(
+            make_request_kwargs['signing_config'].use_double_uri_encode,
+        )
+        self.assertFalse(
+            make_request_kwargs['signing_config'].should_normalize_uri_path,
+        )
 
     def _assert_subscribers_called(self, expected_future=None):
         self.assertTrue(self.record_subscriber.on_queued_called)


### PR DESCRIPTION
https://github.com/awslabs/aws-crt-python/blob/main/awscrt/auth.py#L608-L609

The `AwsSigningConfig` has default values.
```
        use_double_uri_encode (bool): Whether to double-encode the resource path
            when constructing the canonical request (assuming the path is already
            encoded). Default is True. All services except S3 use double encoding.

        should_normalize_uri_path (bool): Whether the resource paths are
            normalized when building the canonical request. Default is True.
```

But, the signing config is for s3, and SDK will encode the URI before pass into CRT, so, set them to false.