### PR TITLE
Implement memory performance fixes for downloads to non-seekable streams

### DIFF
--- a/.changes/next-release/enhancement-s3-32825.json
+++ b/.changes/next-release/enhancement-s3-32825.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``s3``",
+  "description": "Implement memory performance fixes for downloads to non-seekable streams"
+}

--- a/s3transfer/download.py
+++ b/s3transfer/download.py
@@ -750,7 +750,7 @@ class DeferQueue:
 
     def __init__(self):
         self._writes = []
-        self._pending_offsets = set()
+        self._pending_offsets = {}
         self._next_offset = 0
 
     def request_writes(self, offset, data):
@@ -766,23 +766,49 @@ class DeferQueue:
         each method call.
 
         """
-        if offset < self._next_offset:
+        if offset + len(data) <= self._next_offset:
             # This is a request for a write that we've already
             # seen.  This can happen in the event of a retry
             # where if we retry at at offset N/2, we'll requeue
             # offsets 0-N/2 again.
             return []
         writes = []
+        if offset < self._next_offset:
+            # This is a special case where the write request contains
+            # both seen AND unseen data. This can happen in the case
+            # that we queue part of a chunk due to an incomplete read,
+            # then pop the incomplete data for writing, then we receive the retry
+            # for the incomplete read which contains both the previously-seen
+            # partial chunk followed by the rest of the chunk (unseen).
+            #
+            # In this case, we discard the bytes of the data we've already
+            # queued before, and only queue the unseen bytes.
+            seen_bytes = self._next_offset - offset
+            data = data[seen_bytes:]
+            offset = self._next_offset
         if offset in self._pending_offsets:
-            # We've already queued this offset so this request is
-            # a duplicate.  In this case we should ignore
-            # this request and prefer what's already queued.
-            return []
-        heapq.heappush(self._writes, (offset, data))
-        self._pending_offsets.add(offset)
-        while self._writes and self._writes[0][0] == self._next_offset:
-            next_write = heapq.heappop(self._writes)
-            writes.append({'offset': next_write[0], 'data': next_write[1]})
-            self._pending_offsets.remove(next_write[0])
-            self._next_offset += len(next_write[1])
+            queued_data = self._pending_offsets[offset]
+            if len(data) <= len(queued_data):
+                # We already have a write request queued with the same offset
+                # with at least as much data that is present in this
+                # request. In this case we should ignore this request
+                # and prefer what's already queued.
+                return []
+            else:
+                # We have a write request queued with the same offset,
+                # but this request contains more data. This can happen
+                # in the case of a retried request due to an incomplete
+                # read, followed by a retry containing the full response
+                # body. In this case, we should overwrite the queued
+                # request with this one since it contains more data.
+                self._pending_offsets[offset] = data
+        else:
+            heapq.heappush(self._writes, offset)
+            self._pending_offsets[offset] = data
+        while self._writes and self._writes[0] == self._next_offset:
+            next_write_offset = heapq.heappop(self._writes)
+            next_write = self._pending_offsets[next_write_offset]
+            writes.append({'offset': next_write_offset, 'data': next_write})
+            del self._pending_offsets[next_write_offset]
+            self._next_offset += len(next_write)
         return writes

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -978,12 +978,12 @@ class TestDeferQueue(unittest.TestCase):
             [{'offset': 3, 'data': 'd'}],
         )
 
-    def test_writes_below_min_offset_with_last_byte_above_min_offset_are_queued(self):
+    def test_writes_below_min_offset_with_last_byte_above_min_offset_are_queued(
+        self,
+    ):
         self.assertEqual(
             self.q.request_writes(offset=0, data='foo'),
-            [
-                {'offset': 0, 'data': 'foo'}
-            ]
+            [{'offset': 0, 'data': 'foo'}],
         )
 
         # Even though a partial write of 'foo' was completed at offset 0,
@@ -1039,4 +1039,3 @@ class TestDeferQueue(unittest.TestCase):
                 {'offset': 1, 'data': 'bar'},
             ],
         )
-

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -963,7 +963,7 @@ class TestDeferQueue(unittest.TestCase):
         writes = self.q.request_writes(offset=11, data='hello again')
         self.assertEqual(writes, [{'offset': 11, 'data': 'hello again'}])
 
-    def test_writes_below_min_offset_are_ignored(self):
+    def test_writes_with_last_byte_below_min_offset_are_ignored(self):
         self.q.request_writes(offset=0, data='a')
         self.q.request_writes(offset=1, data='b')
         self.q.request_writes(offset=2, data='c')
@@ -978,13 +978,36 @@ class TestDeferQueue(unittest.TestCase):
             [{'offset': 3, 'data': 'd'}],
         )
 
-    def test_duplicate_writes_are_ignored(self):
+    def test_writes_below_min_offset_with_last_byte_above_min_offset_are_queued(self):
+        self.assertEqual(
+            self.q.request_writes(offset=0, data='foo'),
+            [
+                {'offset': 0, 'data': 'foo'}
+            ]
+        )
+
+        # Even though a partial write of 'foo' was completed at offset 0,
+        # a subsequent request to the same offset with a longer
+        # length will write a substring of the data starting at
+        # index next_offset.
+        self.assertEqual(
+            self.q.request_writes(offset=0, data='foo bar'),
+            [
+                # Note we are writing a substring of the data starting at
+                # index 3 since the previous write to index 0 had length 3.
+                {'offset': 3, 'data': ' bar'},
+            ],
+        )
+
+    def test_duplicate_writes_same_length_are_ignored(self):
         self.q.request_writes(offset=2, data='c')
         self.q.request_writes(offset=1, data='b')
 
         # We're still waiting for offset=0, but if
-        # a duplicate write comes in for offset=2/offset=1
-        # it's ignored.  This gives "first one wins" behavior.
+        # a duplicate write with the same length comes in
+        # for offset=2/offset=1 it's ignored.
+        # This gives "largest one wins" behavior with ties
+        # broken via "first one wins".
         self.assertEqual(self.q.request_writes(offset=2, data='X'), [])
         self.assertEqual(self.q.request_writes(offset=1, data='Y'), [])
 
@@ -997,3 +1020,23 @@ class TestDeferQueue(unittest.TestCase):
                 {'offset': 2, 'data': 'c'},
             ],
         )
+
+    def test_duplicate_writes_longer_length_update_queue(self):
+        self.q.request_writes(offset=1, data='b')
+
+        # We're still waiting for offset=0, but if
+        # a write comes in for the same offset=2/offset=1
+        # it updates the queue if the request contains more data.
+        # This gives "largest one wins" behavior with ties
+        # broken via "first one wins".
+        self.assertEqual(self.q.request_writes(offset=1, data='bar'), [])
+
+        self.assertEqual(
+            self.q.request_writes(offset=0, data='a'),
+            [
+                {'offset': 0, 'data': 'a'},
+                # Note we're seeing 'bar', and not 'b', since len(bar) > len(b).
+                {'offset': 1, 'data': 'bar'},
+            ],
+        )
+


### PR DESCRIPTION
*Issue #, if available:*
- Possibly related: https://github.com/aws/aws-cli/issues/8910 

# Context

This PR aims to address a bug that occurs when an `IncompleteReadError` is encountered while downloading a multipart AWS S3 object to a non-seekable stream (e.g. stdout). In this case, all bytes of the object with offset larger than the offset of the incomplete read get queued in a buffer, and the CLI terminates before the buffer is flushed. 

The results of this are (1) the object does not fully get written to the stream, and (2) the memory usage of the CLI grows linearly with respect to the amount of object bytes with offset larger than the offset of the incomplete read. This means that most of the object may be stored in memory no matter how large the object is.

The scope of the changes in this PR to s3transfer will _only_ impact users downloading multi-part AWS S3 objects to a non-seekable stream (e.g. stdout).

# Description of changes

## s3transfer

- Fix bug that occurs when an `IncompleteReadError` is encountered while downloading a multipart AWS S3 object to a non-seekable stream (e.g. stdout).
 - Changed `DeferQueue` so that it will overwrite pending writes to the same offset with whichever write request has the most data. So, when the request with the incomplete read is retried, it will overwrite the incomplete data in the queue assuming the retry contains more data (e.g. the full part).
 - Changed `DeferQueue` so that if it has already dequeued an incomplete part, it will queue the subset of the bytes in the retry that were not previously dequeued.

# Description of tests

## Correctness

- Added 2 new unit tests to cover the 2 main modifications of `DeferQueue`. Also updated names/documentation of existing related tests.
- Verified that the new benchmark that simulates an incomplete read successfully writes the entire object to stdout by piping the output to a file and checking its size. 
  - Before the changes to `DeferQueue` contained in this PR, I verified that the full object does NOT successfully get written. 
- Ran and passed all existing tests (unit, functional, integration, etc.)
- Manually used this CLI build to successfully download a 10GB object from S3 to stdout using the default concurrency options.

### Summary

(Results below collected via Performance tests using AWS CLI v2)

![max_mem_issue](https://github.com/user-attachments/assets/e34923fe-4a64-44c8-8443-bd4f2be89743)
![execution_time_mem_issue](https://github.com/user-attachments/assets/700f0970-f1a0-4715-87ea-30fe3ace1c28)

### Raw Data

(Results below collected via Performance tests using AWS CLI v2)

Each cell in the table below is the average value of the metric taken over 5 iterations.
| - | 2.24.14 | 2.24.14 | 2.24.14 (w/ DeferQueue improvements) |  2.24.14 (w/ DeferQueue improvements) |
| -- | -- | -- | -- | -- |
| - | Happy Path | IncompleteReadError | Happy Path | IncompleteReadError |
| Max Memory (GB) | 0.7246 | 5.242 | 0.207 | 0.20836 |
| p95 Memory (GB) | 0.7101 | 5.025 | 0.207 | 0.19397 |
| Max CPU (%) | 19.72 | 11.82 | 18.42 | 18.42 |
| p95 CPU (%) | 1.5 | 1.5 | 2.5 | 2.5 |
| Total Time (s) | 179.4 | 9.848 | 111.7 | 110.18 |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
