### PR TITLE
Replace bespoke NullHandler with Python's implementation

### DIFF
--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -134,6 +134,7 @@ import random
 import socket
 import string
 import threading
+from logging import NullHandler
 
 from botocore.compat import six  # noqa: F401
 from botocore.exceptions import IncompleteReadError, ResponseStreamingError
@@ -146,11 +147,6 @@ from s3transfer.exceptions import RetriesExceededError, S3UploadFailedError
 
 __author__ = 'Amazon Web Services'
 __version__ = '0.13.0'
-
-
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
[NullHandler](https://github.com/python/cpython/blob/c44070b2d51d59f608577b1f6c55c0168d8e416b/Lib/logging/__init__.py#L2265-L2285) was added in Python 3.1 which does effectively the same thing our current custom one does. They both inherit from the same parent `logging.Handler` class so it should be safe to replace all usages of this.