### PR TITLE
Update test_futures.py

### DIFF
--- a/tests/unit/test_futures.py
+++ b/tests/unit/test_futures.py
@@ -474,7 +474,7 @@ class TestBoundedExecutor(unittest.TestCase):
     def get_task(self, task_cls, main_kwargs=None):
         return task_cls(self.coordinator, main_kwargs=main_kwargs)
 
-    def get_sleep_task(self, sleep_time=0.01):
+    def get_sleep_task(self, sleep_time=0.03):
         return self.get_task(SleepTask, main_kwargs={'sleep_time': sleep_time})
 
     def add_semaphore(self, task_tag, count):


### PR DESCRIPTION
The get_sleep_task method is currently called seven times between five unit tests.  All of these tests rely on the sleep task to still be running at a later point in the test's execution.  In a highly resource constrained environment, these tests can occasionally fail due to the thread completing too early during the execution of the test.

This PR will add 0.15 seconds to each test run and aims to eliminate these failures due to resource contention.  A follow-up PR in the future