### PR TITLE
Create nested client method

### DIFF
--- a/.changes/next-release/enhancement-ClientCreation-50936.json
+++ b/.changes/next-release/enhancement-ClientCreation-50936.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Client Creation",
+  "description": "Adds a utility method to create nested clients by calling a utility method in botocore"
+}

--- a/.changes/next-release/enhancement-ClientCreation-50936.json
+++ b/.changes/next-release/enhancement-ClientCreation-50936.json
@@ -1,5 +1,0 @@
-{
-  "type": "enhancement",
-  "category": "Client Creation",
-  "description": "Adds a utility method to create nested clients by calling a utility method in botocore"
-}

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -46,6 +46,7 @@ from s3transfer.manager import TransferManager
 from s3transfer.utils import (
     CallArgs,
     OSUtils,
+    create_nested_client,
     get_callbacks,
     is_s3express_bucket,
 )
@@ -481,7 +482,7 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
         if client_kwargs is None:
             client_kwargs = {}
         self._resolve_client_config(session, client_kwargs)
-        self._client = session.create_client(**client_kwargs)
+        self._client = create_nested_client(session, **client_kwargs)
         self._client.meta.events.register(
             'request-created.s3.*', self._capture_http_request
         )

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -214,6 +214,7 @@ from s3transfer.utils import (
     OSUtils,
     calculate_num_parts,
     calculate_range_parameter,
+    create_nested_client,
 )
 
 logger = logging.getLogger(__name__)
@@ -577,9 +578,8 @@ class ClientFactory:
 
     def create_client(self):
         """Create a botocore S3 client"""
-        return botocore.session.Session().create_client(
-            's3', **self._client_kwargs
-        )
+        session = botocore.session.Session()
+        return create_nested_client(session, 's3', **self._client_kwargs)
 
 
 class TransferMonitor:

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -27,9 +27,6 @@ from botocore.exceptions import (
     ResponseStreamingError,
 )
 from botocore.httpchecksum import DEFAULT_CHECKSUM_ALGORITHM, AwsChunkedWrapper
-from botocore.utils import (
-    create_nested_client as botocore_create_nested_client,
-)
 from botocore.utils import is_s3express_bucket
 
 from s3transfer.compat import SOCKET_ERROR, fallocate, rename_file

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -27,6 +27,9 @@ from botocore.exceptions import (
     ResponseStreamingError,
 )
 from botocore.httpchecksum import DEFAULT_CHECKSUM_ALGORITHM, AwsChunkedWrapper
+from botocore.utils import (
+    create_nested_client as botocore_create_nested_client,
+)
 from botocore.utils import is_s3express_bucket
 
 from s3transfer.compat import SOCKET_ERROR, fallocate, rename_file
@@ -831,3 +834,7 @@ def set_default_checksum_algorithm(extra_args):
     if any(checksum in extra_args for checksum in FULL_OBJECT_CHECKSUM_ARGS):
         return
     extra_args.setdefault("ChecksumAlgorithm", DEFAULT_CHECKSUM_ALGORITHM)
+
+
+def create_nested_client(session, service_name, **kwargs):
+    return botocore_create_nested_client(session, service_name, **kwargs)

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -836,8 +836,10 @@ def set_default_checksum_algorithm(extra_args):
 try:
     from botocore.utils import create_nested_client as create_client
 except ImportError:
+
     def create_client(session, *args, **kwargs):
         return session.create_client(*args, **kwargs)
+
 
 def create_nested_client(session, service_name, **kwargs):
     return create_client(session, service_name, **kwargs)

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -833,6 +833,9 @@ def set_default_checksum_algorithm(extra_args):
     extra_args.setdefault("ChecksumAlgorithm", DEFAULT_CHECKSUM_ALGORITHM)
 
 
+# NOTE: The following interfaces are considered private and are subject
+# to abrupt breaking changes. Please do not use them directly.
+
 try:
     from botocore.utils import create_nested_client as create_client
 except ImportError:

--- a/s3transfer/utils.py
+++ b/s3transfer/utils.py
@@ -836,5 +836,11 @@ def set_default_checksum_algorithm(extra_args):
     extra_args.setdefault("ChecksumAlgorithm", DEFAULT_CHECKSUM_ALGORITHM)
 
 
+try:
+    from botocore.utils import create_nested_client as create_client
+except ImportError:
+    def create_client(session, *args, **kwargs):
+        return session.create_client(*args, **kwargs)
+
 def create_nested_client(session, service_name, **kwargs):
-    return botocore_create_nested_client(session, service_name, **kwargs)
+    return create_client(session, service_name, **kwargs)


### PR DESCRIPTION
Adds a nested client method for creating clients from within other clients in botocore.  This is part of a new experimental plugins interface that we are intending to touch as little surface area as possible to start with; this will cause clients created internally from within s3transfer to not make use of the experimental interface.

