### PR TITLE
Implement combine function for CRC32

### DIFF
--- a/s3transfer/checksums.py
+++ b/s3transfer/checksums.py
@@ -1,0 +1,89 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+NOTE: All classes and functions in this module are considered private and are
+subject to abrupt breaking changes. Please do not use them directly.
+"""
+
+
+def combine_crc32(crc1, crc2, len2):
+    """Combine two CRC32 values.
+
+    :type crc1: int
+    :param crc1: Current CRC32 integer value.
+
+    :type crc2: int
+    :param crc2: Second CRC32 integer value to combine.
+
+    :type len2: int
+    :param len2: Length of data that produced `crc2`.
+
+    :rtype: int
+    :returns: Combined CRC32 integer value.
+    """
+
+    POLY = 0xEDB88320
+
+    def gf2_matrix_multiply(mat, vec):
+        """Multiply a matrix by a vector in GF(2)"""
+        result = 0
+        for i in range(32):
+            if vec & 1:
+                result ^= mat[i]
+            vec >>= 1
+        return result
+
+    def gf2_matrix_square(mat):
+        """Square a matrix in GF(2)"""
+        result = [0] * 32
+        for i in range(32):
+            result[i] = gf2_matrix_multiply(mat, mat[i])
+        return result
+
+    def crc32_matrix_power(length):
+        """Generate transformation matrix for CRC32 over given length"""
+        # Base transformation matrix (multiply by x)
+        mat = [0] * 32
+        mat[0] = POLY
+        for i in range(1, 32):
+            mat[i] = 1 << (i - 1)
+
+        # Compute mat^length using binary exponentiation
+        result = [0] * 32
+        for i in range(32):
+            result[i] = 1 << i
+
+        n = length
+        while n > 0:
+            if n & 1:
+                result = [
+                    gf2_matrix_multiply(mat, result[i]) for i in range(32)
+                ]
+            mat = gf2_matrix_square(mat)
+            n >>= 1
+
+        return result
+
+    if len2 == 0:
+        return crc1
+
+    transform_matrix = crc32_matrix_power(len2 * 8)
+    transformed_crc1 = gf2_matrix_multiply(transform_matrix, crc1)
+    combined = transformed_crc1 ^ crc2
+
+    return combined & 0xFFFFFFFF
+
+
+_CRC_CHECKSUM_TO_COMBINE_FUNCTION = {
+    "ChecksumCRC32": combine_crc32,
+}

--- a/tests/unit/test_checksums.py
+++ b/tests/unit/test_checksums.py
@@ -1,0 +1,76 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from binascii import crc32
+
+import pytest
+
+from s3transfer.checksums import combine_crc32
+
+
+class TestCombineCrc32:
+    def _calculate_crc32_serial(self, data):
+        return crc32(data) & 0xFFFFFFFF
+
+    def _calculate_crc32_combined(self, data1, data2):
+        crc1 = crc32(data1)
+        crc2 = crc32(data2)
+        return combine_crc32(crc1, crc2, len(data2))
+
+    @pytest.mark.parametrize(
+        "data1,data2",
+        [
+            (b"foo", b"bar"),
+            (b"", b""),
+            (b"", b"foobar"),
+            (b"foobar", b""),
+            (b"foobar", b"foobar"),
+            (b"foo" * 10000, b"bar" * 10000),
+            (b"\x00", b"\x00"),
+        ],
+    )
+    def test_combine_crc32(self, data1, data2):
+        serial_crc = self._calculate_crc32_serial(data1 + data2)
+        combined_crc = self._calculate_crc32_combined(data1, data2)
+        assert combined_crc == serial_crc
+
+    def test_combine_crc32_many_parts(self):
+        parts = [f"Part{i}".encode() for i in range(1000)]
+
+        serial_crc = self._calculate_crc32_serial(b"".join(parts))
+        combined_crc = self._calculate_crc32_serial(parts[0])
+        for i in range(1, len(parts)):
+            part_crc = self._calculate_crc32_serial(parts[i])
+            combined_crc = combine_crc32(combined_crc, part_crc, len(parts[i]))
+
+        assert combined_crc == serial_crc
+
+    def test_combine_crc32_associative_property(self):
+        data_a = b"foo"
+        data_b = b"bar"
+        data_c = b"baz"
+
+        serial_crc = self._calculate_crc32_serial(data_a + data_b + data_c)
+
+        crc_a = self._calculate_crc32_serial(data_a)
+        crc_b = self._calculate_crc32_serial(data_b)
+        crc_c = self._calculate_crc32_serial(data_c)
+
+        # (a+b) + c
+        crc_ab = combine_crc32(crc_a, crc_b, len(data_b))
+        crc_ab_c = combine_crc32(crc_ab, crc_c, len(data_c))
+
+        # a + (b+c)
+        crc_bc = combine_crc32(crc_b, crc_c, len(data_c))
+        crc_a_bc = combine_crc32(crc_a, crc_bc, len(data_b + data_c))
+
+        assert serial_crc == crc_ab_c == crc_a_bc


### PR DESCRIPTION
This PR implements a function to combine 2 CRC32-computed values (ie CRC32(A) + CRC32(B)) to produce a single CRC32 value that is equal to CRC32(A+B). For example, the combination CRC32(foo) + CRC32(bar) would be equal to CRC32(foobar).

The purpose of this function is to enable parallel checksum calculation when uploading/downloading an object across multiple parts. Using a single running checksum object that all parts must update would cause head-of-line blocking, forcing already uploaded/downloaded parts to persist in memory while waiting to update the checksum object. Instead, the combine function allows each part to have its own checksum object, which are then serially combined at the end to produce a single full object checksum.

`combine_crc32` takes as input CRC32 integer values that are available in botocore's `Crc32Checksum` class: https://github.com/boto/botocore/blob/d3ade36d635a2b6a89229b199234afc52f9bcf55/botocore/httpchecksum.py#L82, which will be exposed in followup PRs.

Example usage of this function can be seen in a draft PR: https://github.com/aws/aws-cli/pull/9660