### PR TITLE
Add missing permissions for CRT tests GHA

### DIFF
--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches-ignore: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Description of changes:*
Another small finding on GHA audits where we previously missed setting permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
