### PR TITLE
Update legacy documentation links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,4 @@ This project is maintained and published by Amazon Web Services.
   This project is not currently GA. If you are planning to use this code in
   production, make sure to lock to a minor version as interfaces may break
   from minor version to minor version. For a basic, stable interface of
-  s3transfer, try the interfaces exposed in `boto3 <https://boto3.readthedocs.io/en/latest/guide/s3.html#using-the-transfer-manager>`__
+  s3transfer, try the interfaces exposed in `boto3 <https://docs.aws.amazon.com/boto3/latest/guide/s3.html#using-the-transfer-manager>`__

--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,4 @@ This project is maintained and published by Amazon Web Services.
   This project is not currently GA. If you are planning to use this code in
   production, make sure to lock to a minor version as interfaces may break
   from minor version to minor version. For a basic, stable interface of
-  s3transfer, try the interfaces exposed in `boto3 <https://docs.aws.amazon.com/boto3/latest/guide/s3.html#using-the-transfer-manager>`__
+  s3transfer, try the interfaces exposed in `boto3 <https://docs.aws.amazon.com/boto3/latest/guide/s3.html>`__

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -73,7 +73,7 @@ Additional parameters can be provided to the ``download_file`` method:
 
 * ``extra_args``: A dictionary containing any additional client arguments
   to include in the
-  `GetObject <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object>`_
+  `GetObject <https://docs.aws.amazon.com/botocore/latest/reference/services/s3.html#S3.Client.get_object>`_
   API request. For example:
 
   .. code:: python

--- a/s3transfer/processpool.py
+++ b/s3transfer/processpool.py
@@ -73,7 +73,7 @@ Additional parameters can be provided to the ``download_file`` method:
 
 * ``extra_args``: A dictionary containing any additional client arguments
   to include in the
-  `GetObject <https://docs.aws.amazon.com/botocore/latest/reference/services/s3.html#S3.Client.get_object>`_
+  `GetObject <https://docs.aws.amazon.com/botocore/latest/reference/services/s3/client/get_object.html>`_
   API request. For example:
 
   .. code:: python


### PR DESCRIPTION
### Overview
As part of the migration to `docs.aws.amazon.com`, this PR updates all legacy botocore and boto3 documentation links to the new domain.

#### Changes
- Updated botocore links from `botocore.amazonaws.com/v1/documentation/api/latest/` to `docs.aws.amazon.com/botocore/latest/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
