### PR TITLE
feat: Add IfMatch and IfNoneMatch to ALLOWED_UPLOAD_ARGS

### DIFF
--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -699,6 +699,8 @@ class S3Transfer:
         'GrantRead',
         'GrantReadACP',
         'GrantWriteACL',
+        'IfMatch',
+        'IfNoneMatch',
         'Metadata',
         'RequestPayer',
         'ServerSideEncryption',

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -185,6 +185,8 @@ class TransferManager:
         'GrantRead',
         'GrantReadACP',
         'GrantWriteACP',
+        'IfMatch',
+        'IfNoneMatch',
         'Metadata',
         'ObjectLockLegalHoldStatus',
         'ObjectLockMode',

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -515,7 +515,11 @@ class UploadSubmissionTask(SubmissionTask):
 
     PUT_OBJECT_BLOCKLIST = ["ChecksumType", "MpuObjectSize"]
 
-    CREATE_MULTIPART_BLOCKLIST = FULL_OBJECT_CHECKSUM_ARGS + ["MpuObjectSize"]
+    CREATE_MULTIPART_BLOCKLIST = FULL_OBJECT_CHECKSUM_ARGS + [
+        "MpuObjectSize",
+        "IfMatch",
+        "IfNoneMatch",
+    ]
 
     UPLOAD_PART_ARGS = [
         'ChecksumAlgorithm',
@@ -534,6 +538,8 @@ class UploadSubmissionTask(SubmissionTask):
         'ExpectedBucketOwner',
         'ChecksumType',
         'MpuObjectSize',
+        'IfMatch',
+        'IfNoneMatch',
     ] + FULL_OBJECT_CHECKSUM_ARGS
 
     def _get_upload_input_manager_cls(self, transfer_future):

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -177,6 +177,30 @@ class TestNonMultipartUpload(BaseUploadTest):
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
 
+    def test_upload_with_if_match(self):
+        self.extra_args['IfMatch'] = 'my-etag'
+        self.add_put_object_response_with_default_expected_params(
+            extra_expected_params={'IfMatch': 'my-etag'}
+        )
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_put_object_body_was_correct()
+
+    def test_upload_with_if_none_match(self):
+        self.extra_args['IfNoneMatch'] = '*'
+        self.add_put_object_response_with_default_expected_params(
+            extra_expected_params={'IfNoneMatch': '*'}
+        )
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_put_object_body_was_correct()
+
     def test_upload_with_checksum(self):
         self.extra_args['ChecksumAlgorithm'] = 'sha256'
         self.add_put_object_response_with_default_expected_params(
@@ -651,6 +675,32 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_upload_part_responses_with_default_expected_params()
         self.add_complete_multipart_response_with_default_expected_params()
 
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+
+    def test_multipart_upload_with_if_match(self):
+        self.extra_args['IfMatch'] = 'my-etag'
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params(
+            extra_expected_params={'IfMatch': 'my-etag'}
+        )
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+
+    def test_multipart_upload_with_if_none_match(self):
+        self.extra_args['IfNoneMatch'] = '*'
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params(
+            extra_expected_params={'IfNoneMatch': '*'}
+        )
         future = self.manager.upload(
             self.filename, self.bucket, self.key, self.extra_args
         )


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/boto/boto3/issues/4366

*Description of changes:*

Adds `IfMatch` and `IfNoneMatch` to the list of allowed arguments for S3 uploads. This enables users to perform conditional uploads, such as preventing the overwrite of existing files by using `IfNoneMatch: "*"`.

These parameters are not supported by the `CreateMultipartUpload` API call, so they are added to the blocklist for that specific operation to prevent validation errors. For multipart uploads, these parameters are passed to the `CompleteMultipartUpload` operation.

Functional tests have been added for both single-part and multipart uploads to verify that the arguments are passed correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
