### PR TITLE
Raise TypeError on bare test decorator usage, fix bare @requires_crt usages, and add regression tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,7 +23,6 @@ from unittest import mock  # noqa: F401
 
 import botocore.session
 from botocore.stub import Stubber
-
 from s3transfer.futures import (
     IN_MEMORY_DOWNLOAD_TAG,
     IN_MEMORY_UPLOAD_TAG,
@@ -100,6 +99,11 @@ def skip_if_windows(reason):
             self.assertEqual(...)
 
     """
+    if callable(reason):
+        raise TypeError(
+            "Use @skip_if_windows('reason') with parentheses, "
+            "not bare @skip_if_windows"
+        )
 
     def decorator(func):
         return unittest.skipIf(
@@ -111,6 +115,11 @@ def skip_if_windows(reason):
 
 def skip_if_using_serial_implementation(reason):
     """Decorator to skip tests when running as the serial implementation"""
+    if callable(reason):
+        raise TypeError(
+            "Use @skip_if_using_serial_implementation('reason') with parentheses, "
+            "not bare @skip_if_using_serial_implementation"
+        )
 
     def decorator(func):
         return unittest.skipIf(is_serial_implementation(), reason)(func)
@@ -118,10 +127,18 @@ def skip_if_using_serial_implementation(reason):
     return decorator
 
 
-def requires_crt(cls, reason=None):
+def requires_crt(reason=None):
+    if callable(reason):
+        raise TypeError(
+            "Use @requires_crt() with parentheses, not bare @requires_crt"
+        )
     if reason is None:
         reason = "Test requires awscrt to be installed."
-    return unittest.skipIf(not HAS_CRT, reason)(cls)
+
+    def decorator(func):
+        return unittest.skipIf(not HAS_CRT, reason)(func)
+
+    return decorator
 
 
 class StreamWithError:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,6 +23,7 @@ from unittest import mock  # noqa: F401
 
 import botocore.session
 from botocore.stub import Stubber
+
 from s3transfer.futures import (
     IN_MEMORY_DOWNLOAD_TAG,
     IN_MEMORY_UPLOAD_TAG,

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -17,6 +17,7 @@ import time
 from concurrent.futures import Future
 
 from botocore.session import Session
+
 from s3transfer.constants import MB
 from s3transfer.manager import TransferConfig
 from s3transfer.subscribers import BaseSubscriber

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -17,7 +17,6 @@ import time
 from concurrent.futures import Future
 
 from botocore.session import Session
-
 from s3transfer.constants import MB
 from s3transfer.manager import TransferConfig
 from s3transfer.subscribers import BaseSubscriber
@@ -65,7 +64,7 @@ class RecordingSubscriber(BaseSubscriber):
         self.on_done_future = future
 
 
-@requires_crt
+@requires_crt()
 class TestCRTTransferManager(unittest.TestCase):
     def setUp(self):
         self.region = 'us-west-2'

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -16,7 +16,6 @@ import os
 from uuid import uuid4
 
 from botocore.exceptions import ClientError
-
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
 from tests import (
@@ -50,7 +49,7 @@ class RecordingSubscriber(BaseSubscriber):
         self.on_done_called = True
 
 
-@requires_crt
+@requires_crt()
 class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     """Tests for the high level s3transfer based on CRT implementation."""
 

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -16,6 +16,7 @@ import os
 from uuid import uuid4
 
 from botocore.exceptions import ClientError
+
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
 from tests import (

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -13,10 +13,10 @@
 import io
 
 import pytest
+
 from botocore.credentials import Credentials, ReadOnlyCredentials
 from botocore.exceptions import ClientError, NoCredentialsError
 from botocore.session import Session
-
 from s3transfer.exceptions import TransferNotDoneError
 from s3transfer.utils import CallArgs
 from tests import HAS_CRT, FileCreator, mock, requires_crt, unittest
@@ -89,7 +89,7 @@ class TestCRTProcessLock:
         mock_crt_process_lock.return_value.acquire.assert_called_once_with()
 
 
-@requires_crt
+@requires_crt()
 class TestBotocoreCRTRequestSerializer(unittest.TestCase):
     def setUp(self):
         self.region = 'us-west-2'
@@ -291,7 +291,7 @@ class TestBotocoreCRTCredentialsWrapper:
         self.assert_crt_credentials(crt_credentials)
 
 
-@requires_crt
+@requires_crt()
 class TestCRTTransferFuture(unittest.TestCase):
     def setUp(self):
         self.mock_s3_request = mock.Mock(awscrt.s3.S3RequestType)
@@ -320,7 +320,7 @@ class TestCRTTransferFuture(unittest.TestCase):
             self.future.result()
 
 
-@requires_crt
+@requires_crt()
 class TestOnBodyFileObjWriter(unittest.TestCase):
     def test_call(self):
         fileobj = io.BytesIO()

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -13,10 +13,10 @@
 import io
 
 import pytest
-
 from botocore.credentials import Credentials, ReadOnlyCredentials
 from botocore.exceptions import ClientError, NoCredentialsError
 from botocore.session import Session
+
 from s3transfer.exceptions import TransferNotDoneError
 from s3transfer.utils import CallArgs
 from tests import HAS_CRT, FileCreator, mock, requires_crt, unittest

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -1,0 +1,108 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from unittest import mock
+
+import pytest
+
+from tests import (
+    requires_crt,
+    skip_if_using_serial_implementation,
+    skip_if_windows,
+)
+
+
+class TestSkipIfWindows:
+    def test_bare_skip_if_windows_fails_immediately(self):
+        with pytest.raises(TypeError):
+
+            @skip_if_windows
+            def my_test():
+                pass
+
+    def test_skip_if_windows_skips_on_windows(self):
+        with mock.patch('tests.platform') as mock_platform:
+            mock_platform.system.return_value = 'Windows'
+
+            @skip_if_windows('Not supported on Windows')
+            def my_test():
+                assert False
+
+            assert getattr(my_test, '__unittest_skip__', False) is True
+
+    def test_skip_if_windows_runs_on_non_windows(self):
+        with mock.patch('tests.platform') as mock_platform:
+            mock_platform.system.return_value = 'Linux'
+
+            @skip_if_windows('Not supported on Windows')
+            def my_test():
+                pass
+
+            assert getattr(my_test, '__unittest_skip__', False) is False
+
+
+class TestSkipIfUsingSerialImplementation:
+    def test_bare_skip_if_using_serial_implementation_fails_immediately(self):
+        with pytest.raises(TypeError):
+
+            @skip_if_using_serial_implementation
+            def my_test():
+                pass
+
+    def test_skip_if_using_serial_implementation_skips_when_serial(self):
+        with mock.patch('tests.is_serial_implementation', return_value=True):
+
+            @skip_if_using_serial_implementation(
+                'Not supported in serial mode'
+            )
+            def my_test():
+                assert False
+
+            assert getattr(my_test, '__unittest_skip__', False) is True
+
+    def test_skip_if_using_serial_implementation_runs_when_not_serial(self):
+        with mock.patch('tests.is_serial_implementation', return_value=False):
+
+            @skip_if_using_serial_implementation(
+                'Not supported in serial mode'
+            )
+            def my_test():
+                pass
+
+            assert getattr(my_test, '__unittest_skip__', False) is False
+
+
+class TestRequiresCrt:
+    def test_bare_requires_crt_fails_immediately(self):
+        with pytest.raises(TypeError):
+
+            @requires_crt
+            def my_test():
+                pass
+
+    def test_requires_crt_skips_when_no_crt(self):
+        with mock.patch('tests.HAS_CRT', False):
+
+            @requires_crt()
+            def my_test():
+                assert False
+
+            assert getattr(my_test, '__unittest_skip__', False) is True
+
+    def test_requires_crt_runs_when_crt_available(self):
+        with mock.patch('tests.HAS_CRT', True):
+
+            @requires_crt()
+            def my_test():
+                pass
+
+            assert getattr(my_test, '__unittest_skip__', False) is False

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -1,15 +1,16 @@
-# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the 'License'). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# http://aws.amazon.com/apache2.0/
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# or in the 'license' file accompanying this file. This file is
-# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from unittest import mock
 
 import pytest


### PR DESCRIPTION
*Background:*
`@skip_if_windows` and `@skip_if_using_serial_implementation` are decorator factories that require parentheses. If they are used without parentheses (e.g., bare `@skip_if_windows`), this is unsafe because Python passes the test function as the first argument, causing the real test body to never run. Assertions are never evaluated, but the test may still appear to pass or skip silently. However, these two did not raise an error on bare usage.

On the other hand, `@requires_crt` in s3transfer only worked correctly with bare usage, while botocore and boto3 already required the parenthesized form `@requires_crt()`. This cross-repo inconsistency creates a maintainer footgun because contributors move between repos and assume the decorator behaves the same way everywhere. It needs to be standardized to only accept the parenthesized form and all existing bare usages need to be updated.

*Description of changes:*
`@skip_if_windows` and `@skip_if_using_serial_implementation` now raise a `TypeError` on bare usage. `@requires_crt` is updated to only accept the parenthesized form for consistency with the other two decorators in this repo as well as botocore and boto3. It also raises a `TypeError` on bare usage. Five existing bare `@requires_crt` usages across test files are updated to `@requires_crt()`.

*Testing:*
Regression tests are added in `tests/unit/test_decorators.py` to verify correct behavior for all three decorators. All tests including the new tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
