### PR TITLE
Add zizmor GitHub Actions workflow for CI security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: "Checkout repository"
       uses: "actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8"
+      with:
+        persist-credentials: false
 
     - name: "Run CodeQL init"
       uses: "github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      with:
+        persist-credentials: false
     - name: Set up Python 3.9
       uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
       with:

--- a/.github/workflows/run-crt-test.yml
+++ b/.github/workflows/run-crt-test.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
       with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["develop"]
+  pull_request:
+    branches: ["develop"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
> This is the S3transfer version of https://github.com/boto/botocore/pull/3665

## Overview

This PR adds a `zizmor` GitHub Actions workflow to scan this repository's workflows for common security issues.

`zizmor` is a static analysis tool for GitHub Actions. It helps detect insecure workflow patterns such as overly broad permissions, unsafe triggers, and unpinned or risky action usage.

## References

Quote from [PyPI blog](https://blog.pypi.org/posts/2026-04-02-incident-report-litellm-telnyx-supply-chain-attack/):
> *"If you are using GitHub Actions as your continuous deployment provider, we highly recommend the tool "Zizmor" for detecting and fixing insecure workflows."*

- [Zizmor](https://github.com/zizmorcore/zizmor/)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
