### PR TITLE
Allow SSEC bucket decryption in s3 integ tests

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -61,6 +61,21 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
             CreateBucketConfiguration={'LocationConstraint': cls.region},
             ObjectOwnership='ObjectWriter',
         )
+        cls.client.put_bucket_encryption(
+            Bucket=cls.bucket_name,
+            ServerSideEncryptionConfiguration={
+                'Rules': [
+                    {
+                        'ApplyServerSideEncryptionByDefault': {
+                            'SSEAlgorithm': 'AES256',
+                        },
+                        'BlockedEncryptionTypes': {
+                            'EncryptionType': ['NONE'],
+                        },
+                    }
+                ],
+            },
+        )
         cls.client.delete_public_access_block(Bucket=cls.bucket_name)
 
     def setUp(self):


### PR DESCRIPTION
Explicitly re-enable SSE-C on S3 integration test buckets after creation so SSE-C tests continue to pass after the April 2026 default bucket-setting rollout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
