### PR TITLE
Enable Dependabot updates for GitHub Actions and pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 exclude: ^(.changes/|CHANGELOG.rst|s3transfer/compat.py)
 repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
-    rev: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: d1b833175a5d08a925900115526febd8fe71c98e  # frozen: v0.15.11
     hooks:
       - id: ruff-check
         args: [ --fix ]


### PR DESCRIPTION
## Summary

Add a Dependabot configuration for GitHub Actions and `pre-commit`, and refresh the current hook pins in `.pre-commit-config.yaml`.

## Why

This repo did not have a Dependabot configuration yet, so updates to GitHub Actions and `pre-commit` hooks were not being tracked automatically.

GitHub now supports Dependabot updates for `pre-commit` hooks, which means we can manage both workflow action versions and pre-commit hook revisions through Dependabot PRs instead of handling them manually.

## Changes

- Add a new `.github/dependabot.yml` configuration
- Enable Dependabot updates for `github-actions`
- Enable Dependabot updates for `pre-commit`
- Update `.pre-commit-config.yaml` to the latest hook revisions
- Keep hooks pinned using frozen SHAs for reproducibility

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

