### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     extras_require={
         'crt': 'botocore[crt]>=1.37.4,<2.0a.0',
     },
-    license="Apache License 2.0",
+    license="Apache-2.0",
     python_requires=">= 3.10",
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Natural Language :: English',
-        'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
The SPDX ID for the Apache 2 is Apache-2.0. This would help compliance and license scanners to determine the correct license.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
