### PR TITLE
Preserve source object metadata for multipart copies

### DIFF
--- a/.changes/next-release/feature-Copy-93112.json
+++ b/.changes/next-release/feature-Copy-93112.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Copy",
+  "description": "By default, preserve source object metadata during multipart copies to match single CopyObject behavior."
+}

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -72,6 +72,17 @@ class CopySubmissionTask(SubmissionTask):
         'TaggingDirective',
     ]
 
+    # Metadata fields to preserve for multipart copies.
+    PRESERVED_METADATA_FIELDS = [
+        'CacheControl',
+        'ContentDisposition',
+        'ContentEncoding',
+        'ContentLanguage',
+        'ContentType',
+        'Expires',
+        'Metadata',
+    ]
+
     COMPLETE_MULTIPART_ARGS = [
         'SSECustomerKey',
         'SSECustomerAlgorithm',
@@ -101,6 +112,7 @@ class CopySubmissionTask(SubmissionTask):
         :param transfer_future: The transfer future associated with the
             transfer request that tasks are being submitted for
         """
+        preserved_metadata = {}
         if (
             transfer_future.meta.size is None
             or transfer_future.meta.etag is None
@@ -135,6 +147,7 @@ class CopySubmissionTask(SubmissionTask):
             # Provide an etag to ensure a stored object is not modified
             # during a multipart copy.
             transfer_future.meta.provide_object_etag(response.get('ETag'))
+            preserved_metadata = self._extract_preserved_metadata(response)
 
         # If it is greater than threshold do a multipart copy, otherwise
         # do a regular copy object.
@@ -144,7 +157,12 @@ class CopySubmissionTask(SubmissionTask):
             )
         else:
             self._submit_multipart_request(
-                client, config, osutil, request_executor, transfer_future
+                client,
+                config,
+                osutil,
+                request_executor,
+                transfer_future,
+                preserved_metadata,
             )
 
     def _submit_copy_request(
@@ -174,14 +192,23 @@ class CopySubmissionTask(SubmissionTask):
         )
 
     def _submit_multipart_request(
-        self, client, config, osutil, request_executor, transfer_future
+        self,
+        client,
+        config,
+        osutil,
+        request_executor,
+        transfer_future,
+        preserved_metadata=None,
     ):
         call_args = transfer_future.meta.call_args
+        merged_extra_args = self._merge_preserved_metadata(
+            call_args.extra_args, preserved_metadata or {}
+        )
 
         # Submit the request to create a multipart upload and make sure it
         # does not include any of the arguments used for copy part.
         create_multipart_extra_args = {}
-        for param, val in call_args.extra_args.items():
+        for param, val in merged_extra_args.items():
             if param not in self.CREATE_MULTIPART_ARGS_BLACKLIST:
                 create_multipart_extra_args[param] = val
 
@@ -284,6 +311,23 @@ class CopySubmissionTask(SubmissionTask):
                 is_final=True,
             ),
         )
+
+    def _extract_preserved_metadata(self, head_object_response):
+        preserved = {}
+        for field in self.PRESERVED_METADATA_FIELDS:
+            if field in head_object_response:
+                preserved[field] = head_object_response[field]
+        return preserved
+
+    def _merge_preserved_metadata(self, extra_args, preserved_metadata):
+        if not preserved_metadata:
+            return extra_args
+        if extra_args.get('MetadataDirective') == 'REPLACE':
+            return extra_args
+        merged = dict(extra_args)
+        for field, value in preserved_metadata.items():
+            merged.setdefault(field, value)
+        return merged
 
     def _get_head_object_request_from_copy_source(self, copy_source):
         if isinstance(copy_source, dict):

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -326,7 +326,7 @@ class CopySubmissionTask(SubmissionTask):
             return extra_args
         merged = dict(extra_args)
         for field, value in preserved_metadata.items():
-            merged.setdefault(field, value)
+            merged[field] = value
         return merged
 
     def _get_head_object_request_from_copy_source(self, copy_source):

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import copy
+import datetime
 
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
@@ -452,6 +453,21 @@ class TestMultipartCopy(BaseCopyTest):
     def add_create_multipart_upload_response(self):
         self.stubber.add_response(**self.create_stubbed_responses()[1])
 
+    def add_head_object_response_with_metadata(self, head_metadata):
+        service_response = {
+            'ContentLength': len(self.content),
+            'ETag': self.etag,
+        }
+        service_response.update(head_metadata)
+        self.stubber.add_response(
+            'head_object',
+            service_response=service_response,
+            expected_params={
+                'Bucket': 'mysourcebucket',
+                'Key': 'mysourcekey',
+            },
+        )
+
     def _get_expected_params(self):
         # Add expected parameters to the head object
         expected_head_params = {
@@ -710,6 +726,72 @@ class TestMultipartCopy(BaseCopyTest):
         future = self.manager.copy(
             self.copy_source, self.bucket, self.key, extra_args
         )
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_multipart_copy_preserves_source_metadata(self):
+        head_metadata = {
+            'CacheControl': 'no-cache',
+            'ContentDisposition': 'attachment; filename="x.json"',
+            'ContentEncoding': 'gzip',
+            'ContentLanguage': 'en-US',
+            'ContentType': 'application/json',
+            'Expires': datetime.datetime(
+                2030, 1, 1, tzinfo=datetime.timezone.utc
+            ),
+            'Metadata': {'foo': 'bar'},
+        }
+        self.add_head_object_response_with_metadata(head_metadata)
+
+        _, add_copy_kwargs = self._get_expected_params()
+        add_copy_kwargs['expected_create_mpu_params'].update(head_metadata)
+        self.add_successful_copy_responses(**add_copy_kwargs)
+
+        future = self.manager.copy(**self.create_call_kwargs())
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_multipart_copy_merges_metadata_fields(self):
+        head_metadata = {
+            'ContentType': 'application/octet-stream',
+            'CacheControl': 'no-cache',
+            'Metadata': {'foo': 'bar'},
+        }
+        self.add_head_object_response_with_metadata(head_metadata)
+
+        _, add_copy_kwargs = self._get_expected_params()
+        expected_create_mpu = add_copy_kwargs['expected_create_mpu_params']
+        expected_create_mpu['ContentType'] = 'application/json'
+        expected_create_mpu['CacheControl'] = 'no-cache'
+        expected_create_mpu['Metadata'] = {'foo': 'bar'}
+        self.add_successful_copy_responses(**add_copy_kwargs)
+
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = {'ContentType': 'application/json'}
+        future = self.manager.copy(**call_kwargs)
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_multipart_copy_metadata_directive_replace_opts_out(self):
+        head_metadata = {
+            'ContentType': 'application/octet-stream',
+            'CacheControl': 'no-cache',
+            'Metadata': {'foo': 'bar'},
+        }
+        self.add_head_object_response_with_metadata(head_metadata)
+
+        _, add_copy_kwargs = self._get_expected_params()
+        add_copy_kwargs['expected_create_mpu_params']['ContentType'] = (
+            'application/json'
+        )
+        self.add_successful_copy_responses(**add_copy_kwargs)
+
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = {
+            'ContentType': 'application/json',
+            'MetadataDirective': 'REPLACE',
+        }
+        future = self.manager.copy(**call_kwargs)
         future.result()
         self.stubber.assert_no_pending_responses()
 

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -751,7 +751,7 @@ class TestMultipartCopy(BaseCopyTest):
         future.result()
         self.stubber.assert_no_pending_responses()
 
-    def test_multipart_copy_merges_metadata_fields(self):
+    def test_multipart_copy_caller_metadata_ignored_when_preserving(self):
         head_metadata = {
             'ContentType': 'application/octet-stream',
             'CacheControl': 'no-cache',
@@ -760,10 +760,7 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response_with_metadata(head_metadata)
 
         _, add_copy_kwargs = self._get_expected_params()
-        expected_create_mpu = add_copy_kwargs['expected_create_mpu_params']
-        expected_create_mpu['ContentType'] = 'application/json'
-        expected_create_mpu['CacheControl'] = 'no-cache'
-        expected_create_mpu['Metadata'] = {'foo': 'bar'}
+        add_copy_kwargs['expected_create_mpu_params'].update(head_metadata)
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()


### PR DESCRIPTION
Extract metadata fields (that get copied automatically for single `CopyObject` requests) from initial `HeadObject` call and pass them into multipart copies.

https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html