### PR TITLE
Lint new copy updates

### DIFF
--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -352,7 +352,8 @@ class CopySubmissionTask(SubmissionTask):
         if extra_args.get('MetadataDirective') == 'REPLACE':
             return extra_args
         result = {
-            k: v for k, v in extra_args.items()
+            k: v
+            for k, v in extra_args.items()
             if k not in self.PRESERVED_METADATA_FIELDS
         }
         result.update(preserved_metadata)
@@ -418,7 +419,9 @@ class CopyCompleteMultipartUploadTask(CompleteMultipartUploadTask):
             client, call_args, source_version_id, dest_version_id, dest_etag
         )
 
-    def _apply_tags(self, client, call_args, source_version_id, dest_version_id):
+    def _apply_tags(
+        self, client, call_args, source_version_id, dest_version_id
+    ):
         extra_args = call_args.extra_args
         directive = extra_args.get('TaggingDirective')
         if directive not in ('COPY', 'REPLACE'):
@@ -506,7 +509,9 @@ class CopyCompleteMultipartUploadTask(CompleteMultipartUploadTask):
                 'Bucket': call_args.bucket,
                 'Key': call_args.key,
                 'AnnotationName': name,
-                'AnnotationPayload': payload_response['AnnotationPayload'].read(),
+                'AnnotationPayload': payload_response[
+                    'AnnotationPayload'
+                ].read(),
                 **put_passthrough,
             }
             if dest_version_id:

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -462,14 +462,20 @@ class TransferManager:
         # ignored unless the corresponding directive is set to 'REPLACE'. The
         # warning surfaces this so callers don't get blindsided when their
         # input has no effect.
-        if extra_args.get('Metadata') and extra_args.get('MetadataDirective') is None:
+        if (
+            extra_args.get('Metadata')
+            and extra_args.get('MetadataDirective') is None
+        ):
             logger.warning(
                 "Metadata was supplied without a metadata directive. The "
                 "supplied metadata will be ignored and source metadata will "
                 "be preserved. Set the metadata directive to 'REPLACE' to "
                 "apply the supplied metadata."
             )
-        if extra_args.get('Tagging') and extra_args.get('TaggingDirective') is None:
+        if (
+            extra_args.get('Tagging')
+            and extra_args.get('TaggingDirective') is None
+        ):
             logger.warning(
                 "Tagging was supplied without a tagging directive. The "
                 "supplied tagging will be ignored and source tags will be "

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -792,7 +792,9 @@ class TestMultipartCopy(BaseCopyTest):
         )
         self.add_put_object_tagging_response(source_tags)
         future = self.manager.copy(
-            self.copy_source, self.bucket, self.key,
+            self.copy_source,
+            self.bucket,
+            self.key,
             {'TaggingDirective': 'COPY'},
         )
         future.result()
@@ -823,13 +825,17 @@ class TestMultipartCopy(BaseCopyTest):
             },
         )
         future = self.manager.copy(
-            self.copy_source, self.bucket, self.key,
+            self.copy_source,
+            self.bucket,
+            self.key,
             {'Tagging': 'env=prod', 'TaggingDirective': 'REPLACE'},
         )
         future.result()
         self.stubber.assert_no_pending_responses()
 
-    def test_mp_copy_forwards_passthrough_args_to_tag_and_annotation_calls(self):
+    def test_mp_copy_forwards_passthrough_args_to_tag_and_annotation_calls(
+        self,
+    ):
         # RequestPayer/ExpectedBucketOwner go to all five tag/annotation ops;
         # ChecksumAlgorithm only to the put ops. Stubber's expected_params
         # asserts each call carries the right subset.
@@ -882,13 +888,15 @@ class TestMultipartCopy(BaseCopyTest):
         self.stubber.add_response(
             'list_object_annotations',
             service_response={
-                'Annotations': [{
-                    'AnnotationName': 'note',
-                    'LastModified': datetime.datetime(
-                        2026, 1, 1, tzinfo=datetime.timezone.utc
-                    ),
-                    'Size': len(annotation_payload),
-                }],
+                'Annotations': [
+                    {
+                        'AnnotationName': 'note',
+                        'LastModified': datetime.datetime(
+                            2026, 1, 1, tzinfo=datetime.timezone.utc
+                        ),
+                        'Size': len(annotation_payload),
+                    }
+                ],
             },
             expected_params={
                 'Bucket': 'mysourcebucket',
@@ -920,7 +928,9 @@ class TestMultipartCopy(BaseCopyTest):
             },
         )
         future = self.manager.copy(
-            self.copy_source, self.bucket, self.key,
+            self.copy_source,
+            self.bucket,
+            self.key,
             {
                 'TaggingDirective': 'COPY',
                 'AnnotationDirective': 'COPY',
@@ -938,7 +948,9 @@ class TestMultipartCopy(BaseCopyTest):
         future.result()
         self.stubber.assert_no_pending_responses()
 
-    def test_mp_copy_metadata_supplied_without_directive_preserves_source(self):
+    def test_mp_copy_metadata_supplied_without_directive_preserves_source(
+        self,
+    ):
         head_metadata = {
             'ContentType': 'application/octet-stream',
             'Metadata': {'original': 'value'},

--- a/tests/unit/test_copies.py
+++ b/tests/unit/test_copies.py
@@ -50,7 +50,9 @@ class RecordingClient:
 
 
 class FakeCallArgs:
-    def __init__(self, copy_source, bucket, key, extra_args=None, source_client=None):
+    def __init__(
+        self, copy_source, bucket, key, extra_args=None, source_client=None
+    ):
         self.copy_source = copy_source
         self.bucket = bucket
         self.key = key
@@ -69,11 +71,16 @@ class TestApplyTags(unittest.TestCase):
 
     def _make_call_args(self, extra_args, source_client=None):
         return FakeCallArgs(
-            self.copy_source, self.bucket, self.key, extra_args,
+            self.copy_source,
+            self.bucket,
+            self.key,
+            extra_args,
             source_client=source_client,
         )
 
-    def _apply(self, client, call_args, source_version_id=None, dest_version_id=None):
+    def _apply(
+        self, client, call_args, source_version_id=None, dest_version_id=None
+    ):
         # Default source_client to the same client unless test overrode it
         if call_args.source_client is None:
             call_args.source_client = client
@@ -92,39 +99,55 @@ class TestApplyTags(unittest.TestCase):
             {'TaggingDirective': 'REPLACE', 'Tagging': 'env=prod&team=sdk'}
         )
         self._apply(client, call_args)
-        self.assertEqual(client.calls, [
-            ('put_object_tagging', {
-                'Bucket': self.bucket,
-                'Key': self.key,
-                'Tagging': {'TagSet': [
-                    {'Key': 'env', 'Value': 'prod'},
-                    {'Key': 'team', 'Value': 'sdk'},
-                ]},
-            })
-        ])
+        self.assertEqual(
+            client.calls,
+            [
+                (
+                    'put_object_tagging',
+                    {
+                        'Bucket': self.bucket,
+                        'Key': self.key,
+                        'Tagging': {
+                            'TagSet': [
+                                {'Key': 'env', 'Value': 'prod'},
+                                {'Key': 'team', 'Value': 'sdk'},
+                            ]
+                        },
+                    },
+                )
+            ],
+        )
 
     def test_copy_directive_fetches_and_applies_source_tags(self):
         source_tags = [{'Key': 'env', 'Value': 'prod'}]
-        client = RecordingClient(responses={
-            'get_object_tagging': {'TagSet': source_tags},
-        })
+        client = RecordingClient(
+            responses={
+                'get_object_tagging': {'TagSet': source_tags},
+            }
+        )
         call_args = self._make_call_args({'TaggingDirective': 'COPY'})
         self._apply(client, call_args)
         methods = [c[0] for c in client.calls]
         self.assertEqual(methods, ['get_object_tagging', 'put_object_tagging'])
-        self.assertEqual(client.calls[1], (
-            'put_object_tagging', {
-                'Bucket': self.bucket,
-                'Key': self.key,
-                'Tagging': {'TagSet': source_tags},
-            }
-        ))
+        self.assertEqual(
+            client.calls[1],
+            (
+                'put_object_tagging',
+                {
+                    'Bucket': self.bucket,
+                    'Key': self.key,
+                    'Tagging': {'TagSet': source_tags},
+                },
+            ),
+        )
 
     def test_copy_directive_passes_version_id_to_get_object_tagging(self):
         source_tags = [{'Key': 'env', 'Value': 'prod'}]
-        client = RecordingClient(responses={
-            'get_object_tagging': {'TagSet': source_tags},
-        })
+        client = RecordingClient(
+            responses={
+                'get_object_tagging': {'TagSet': source_tags},
+            }
+        )
         call_args = self._make_call_args({'TaggingDirective': 'COPY'})
         self._apply(client, call_args, source_version_id='v123')
         _, kwargs = client.calls[0]
@@ -132,22 +155,28 @@ class TestApplyTags(unittest.TestCase):
 
     def test_replace_directive_pins_dest_version_id_on_put(self):
         client = RecordingClient()
-        call_args = self._make_call_args({'TaggingDirective': 'REPLACE', 'Tagging': 'k=v'})
+        call_args = self._make_call_args(
+            {'TaggingDirective': 'REPLACE', 'Tagging': 'k=v'}
+        )
         self._apply(client, call_args, dest_version_id='dest-v1')
         _, kwargs = client.calls[0]
         self.assertEqual(kwargs.get('VersionId'), 'dest-v1')
 
     def test_replace_directive_omits_dest_version_id_when_none(self):
         client = RecordingClient()
-        call_args = self._make_call_args({'TaggingDirective': 'REPLACE', 'Tagging': 'k=v'})
+        call_args = self._make_call_args(
+            {'TaggingDirective': 'REPLACE', 'Tagging': 'k=v'}
+        )
         self._apply(client, call_args, dest_version_id=None)
         _, kwargs = client.calls[0]
         self.assertNotIn('VersionId', kwargs)
 
     def test_copy_directive_omits_version_id_when_none(self):
-        client = RecordingClient(responses={
-            'get_object_tagging': {'TagSet': []},
-        })
+        client = RecordingClient(
+            responses={
+                'get_object_tagging': {'TagSet': []},
+            }
+        )
         call_args = self._make_call_args({'TaggingDirective': 'COPY'})
         self._apply(client, call_args, source_version_id=None)
         _, kwargs = client.calls[0]
@@ -172,6 +201,7 @@ class TestApplyAnnotations(unittest.TestCase):
 
         class AnnotationListClient(RecordingClient):
             """RecordingClient whose list_object_annotations returns a single 'note' annotation."""
+
             def list_object_annotations(self, **kwargs):
                 self.calls.append(('list_object_annotations', kwargs))
                 return {'Annotations': [{'AnnotationName': 'note'}]}
@@ -180,7 +210,10 @@ class TestApplyAnnotations(unittest.TestCase):
 
     def _make_call_args(self, extra_args, source_client=None):
         return FakeCallArgs(
-            self.copy_source, self.bucket, self.key, extra_args,
+            self.copy_source,
+            self.bucket,
+            self.key,
+            extra_args,
             source_client=source_client,
         )
 
@@ -205,25 +238,33 @@ class TestApplyAnnotations(unittest.TestCase):
 
     def test_exclude_directive_makes_no_calls(self):
         client = RecordingClient()
-        self._apply(client, self._make_call_args({'AnnotationDirective': 'EXCLUDE'}))
+        self._apply(
+            client, self._make_call_args({'AnnotationDirective': 'EXCLUDE'})
+        )
         self.assertEqual(client.calls, [])
 
     def test_copy_directive_copies_annotations(self):
         annotation_payload = b'hello annotation'
-        client = RecordingClient(responses={
-            'list_object_annotations': {
-                'Annotations': [{'AnnotationName': 'my-note'}]
-            },
-            'get_object_annotation': {
-                'AnnotationPayload': io.BytesIO(annotation_payload)
-            },
-        })
+        client = RecordingClient(
+            responses={
+                'list_object_annotations': {
+                    'Annotations': [{'AnnotationName': 'my-note'}]
+                },
+                'get_object_annotation': {
+                    'AnnotationPayload': io.BytesIO(annotation_payload)
+                },
+            }
+        )
         call_args = self._make_call_args({'AnnotationDirective': 'COPY'})
         self._apply(client, call_args)
         methods = [c[0] for c in client.calls]
         self.assertEqual(
             methods,
-            ['list_object_annotations', 'get_object_annotation', 'put_object_annotation'],
+            [
+                'list_object_annotations',
+                'get_object_annotation',
+                'put_object_annotation',
+            ],
         )
         _, put_kwargs = client.calls[2]
         self.assertEqual(put_kwargs['Bucket'], self.bucket)
@@ -232,9 +273,11 @@ class TestApplyAnnotations(unittest.TestCase):
         self.assertEqual(put_kwargs['AnnotationPayload'], annotation_payload)
 
     def test_copy_directive_with_no_source_annotations_skips_put(self):
-        client = RecordingClient(responses={
-            'list_object_annotations': {'Annotations': []},
-        })
+        client = RecordingClient(
+            responses={
+                'list_object_annotations': {'Annotations': []},
+            }
+        )
         call_args = self._make_call_args({'AnnotationDirective': 'COPY'})
         self._apply(client, call_args)
         methods = [c[0] for c in client.calls]
@@ -242,52 +285,79 @@ class TestApplyAnnotations(unittest.TestCase):
         self.assertNotIn('put_object_annotation', methods)
 
     def test_copy_directive_pins_dest_version_and_etag_on_put(self):
-        client = self.AnnotationListClient(responses={
-            'get_object_annotation': {'AnnotationPayload': io.BytesIO(b'data')},
-        })
+        client = self.AnnotationListClient(
+            responses={
+                'get_object_annotation': {
+                    'AnnotationPayload': io.BytesIO(b'data')
+                },
+            }
+        )
         call_args = self._make_call_args({'AnnotationDirective': 'COPY'})
         self._apply(
-            client, call_args, dest_version_id='dest-v1', dest_etag='"destetag"'
+            client,
+            call_args,
+            dest_version_id='dest-v1',
+            dest_etag='"destetag"',
         )
-        _, put_kwargs = next((m, k) for m, k in client.calls if m == 'put_object_annotation')
+        _, put_kwargs = next(
+            (m, k) for m, k in client.calls if m == 'put_object_annotation'
+        )
         self.assertEqual(put_kwargs.get('VersionId'), 'dest-v1')
         self.assertEqual(put_kwargs.get('ObjectIfMatch'), '"destetag"')
 
     def test_copy_directive_omits_dest_pins_when_not_in_result(self):
-        client = self.AnnotationListClient(responses={
-            'get_object_annotation': {'AnnotationPayload': io.BytesIO(b'data')},
-        })
+        client = self.AnnotationListClient(
+            responses={
+                'get_object_annotation': {
+                    'AnnotationPayload': io.BytesIO(b'data')
+                },
+            }
+        )
         call_args = self._make_call_args({'AnnotationDirective': 'COPY'})
         self._apply(client, call_args)
-        _, put_kwargs = next((m, k) for m, k in client.calls if m == 'put_object_annotation')
+        _, put_kwargs = next(
+            (m, k) for m, k in client.calls if m == 'put_object_annotation'
+        )
         self.assertNotIn('VersionId', put_kwargs)
         self.assertNotIn('ObjectIfMatch', put_kwargs)
 
     def test_copy_directive_passes_version_id_to_annotation_reads(self):
         annotation_payload = b'data'
-        client = self.AnnotationListClient(responses={
-            'get_object_annotation': {
-                'AnnotationPayload': io.BytesIO(annotation_payload)
-            },
-        })
+        client = self.AnnotationListClient(
+            responses={
+                'get_object_annotation': {
+                    'AnnotationPayload': io.BytesIO(annotation_payload)
+                },
+            }
+        )
         call_args = self._make_call_args({'AnnotationDirective': 'COPY'})
         self._apply(client, call_args, source_version_id='v456')
-        list_kwargs = next(k for m, k in client.calls if m == 'list_object_annotations')
-        get_kwargs = next(k for m, k in client.calls if m == 'get_object_annotation')
+        list_kwargs = next(
+            k for m, k in client.calls if m == 'list_object_annotations'
+        )
+        get_kwargs = next(
+            k for m, k in client.calls if m == 'get_object_annotation'
+        )
         self.assertEqual(list_kwargs.get('VersionId'), 'v456')
         self.assertEqual(get_kwargs.get('VersionId'), 'v456')
 
     def test_copy_directive_omits_version_id_from_annotations_when_none(self):
         annotation_payload = b'data'
-        client = self.AnnotationListClient(responses={
-            'get_object_annotation': {
-                'AnnotationPayload': io.BytesIO(annotation_payload)
-            },
-        })
+        client = self.AnnotationListClient(
+            responses={
+                'get_object_annotation': {
+                    'AnnotationPayload': io.BytesIO(annotation_payload)
+                },
+            }
+        )
         call_args = self._make_call_args({'AnnotationDirective': 'COPY'})
         self._apply(client, call_args, source_version_id=None)
-        list_kwargs = next(k for m, k in client.calls if m == 'list_object_annotations')
-        get_kwargs = next(k for m, k in client.calls if m == 'get_object_annotation')
+        list_kwargs = next(
+            k for m, k in client.calls if m == 'list_object_annotations'
+        )
+        get_kwargs = next(
+            k for m, k in client.calls if m == 'get_object_annotation'
+        )
         self.assertNotIn('VersionId', list_kwargs)
         self.assertNotIn('VersionId', get_kwargs)
 
@@ -297,14 +367,20 @@ class TestApplyAnnotations(unittest.TestCase):
         class FailingPutClient(RecordingClient):
             def list_object_annotations(self, **kwargs):
                 self.calls.append(('list_object_annotations', kwargs))
-                return {'Annotations': [
-                    {'AnnotationName': 'note-a'},
-                    {'AnnotationName': 'note-b'},
-                ]}
+                return {
+                    'Annotations': [
+                        {'AnnotationName': 'note-a'},
+                        {'AnnotationName': 'note-b'},
+                    ]
+                }
 
             def get_object_annotation(self, **kwargs):
                 self.calls.append(('get_object_annotation', kwargs))
-                return {'AnnotationPayload': io.BytesIO(payloads[kwargs['AnnotationName']])}
+                return {
+                    'AnnotationPayload': io.BytesIO(
+                        payloads[kwargs['AnnotationName']]
+                    )
+                }
 
             def put_object_annotation(self, **kwargs):
                 self.calls.append(('put_object_annotation', kwargs))
@@ -330,24 +406,36 @@ class TestApplyAnnotations(unittest.TestCase):
         class MultiAnnotationClient(RecordingClient):
             def get_object_annotation(self, **kwargs):
                 self.calls.append(('get_object_annotation', kwargs))
-                return {'AnnotationPayload': io.BytesIO(payloads[kwargs['AnnotationName']])}
+                return {
+                    'AnnotationPayload': io.BytesIO(
+                        payloads[kwargs['AnnotationName']]
+                    )
+                }
 
-        client = MultiAnnotationClient(responses={
-            'list_object_annotations': {
-                'Annotations': [
-                    {'AnnotationName': 'note-a'},
-                    {'AnnotationName': 'note-b'},
-                ]
-            },
-        })
+        client = MultiAnnotationClient(
+            responses={
+                'list_object_annotations': {
+                    'Annotations': [
+                        {'AnnotationName': 'note-a'},
+                        {'AnnotationName': 'note-b'},
+                    ]
+                },
+            }
+        )
         call_args = self._make_call_args({'AnnotationDirective': 'COPY'})
         self._apply(client, call_args)
-        put_calls = [(c[1]['AnnotationName'], c[1]['AnnotationPayload'])
-                     for c in client.calls if c[0] == 'put_object_annotation']
-        self.assertEqual(put_calls, [
-            ('note-a', b'payload-a'),
-            ('note-b', b'payload-b'),
-        ])
+        put_calls = [
+            (c[1]['AnnotationName'], c[1]['AnnotationPayload'])
+            for c in client.calls
+            if c[0] == 'put_object_annotation'
+        ]
+        self.assertEqual(
+            put_calls,
+            [
+                ('note-a', b'payload-a'),
+                ('note-b', b'payload-b'),
+            ],
+        )
 
 
 class BaseCopyTaskTest(BaseTaskTest):


### PR DESCRIPTION
*Description of changes:*
Runs the linter over the new code released with s3transfer today in version 0.19.0.  No functional changes have been introduced.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
