### PR TITLE
Update CODEOWNERS to shared Python SDK and CLI team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Python SDK core team - all PRs require team review
-* @boto/sync-team-aws-sdk-python
+# Python SDK and CLI shared team - all PRs require team review
+* @boto/sync-team-aws-python-sdk-cli-team


### PR DESCRIPTION
## Summary
Update CODEOWNERS to reference the shared Python SDK and CLI team.

The Python SDK and CLI currently share repository ownership, so CODEOWNERS references the shared team (`@boto/sync-team-aws-python-sdk-cli-team`).

Part of Python-8717.