### PR TITLE
Don't use VersionId from HeadObject for multipart copies

### DIFF
--- a/.changes/next-release/bugfix-s3-85484.json
+++ b/.changes/next-release/bugfix-s3-85484.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Only pin VersionId if supplied by caller instead of automatically using value from HeadObject response"
+}

--- a/s3transfer/copies.py
+++ b/s3transfer/copies.py
@@ -130,8 +130,10 @@ class CopySubmissionTask(SubmissionTask):
             transfer request that tasks are being submitted for
         """
         preserved_metadata = {}
-        source_version_id = None
         call_args = transfer_future.meta.call_args
+        source_version_id = None
+        if isinstance(call_args.copy_source, dict):
+            source_version_id = call_args.copy_source.get('VersionId')
         if (
             transfer_future.meta.size is None
             or transfer_future.meta.etag is None
@@ -166,9 +168,6 @@ class CopySubmissionTask(SubmissionTask):
             # during a multipart copy.
             transfer_future.meta.provide_object_etag(response.get('ETag'))
             preserved_metadata = self._extract_preserved_metadata(response)
-            # Pin the source version so all subsequent reads (tags, annotations)
-            # are consistent with the object from the head call
-            source_version_id = response.get('VersionId')
 
         # If it is greater than threshold do a multipart copy, otherwise
         # do a regular copy object.

--- a/tests/functional/test_copy.py
+++ b/tests/functional/test_copy.py
@@ -764,7 +764,7 @@ class TestMultipartCopy(BaseCopyTest):
             future.result()
         self.stubber.assert_no_pending_responses()
 
-    def test_mp_copy_tagging_copy_pins_source_version_id(self):
+    def test_mp_copy_tagging_copy_does_not_pin_discovered_version_id(self):
         source_version_id = 'abc123version'
         source_tags = [{'Key': 'env', 'Value': 'prod'}]
         self.stubber.add_response(
@@ -777,6 +777,36 @@ class TestMultipartCopy(BaseCopyTest):
             expected_params={
                 'Bucket': 'mysourcebucket',
                 'Key': 'mysourcekey',
+            },
+        )
+        _, add_copy_kwargs = self._get_expected_params()
+        self.add_successful_copy_responses(**add_copy_kwargs)
+        self.add_get_object_tagging_response(source_tags)
+        self.add_put_object_tagging_response(source_tags)
+        future = self.manager.copy(
+            self.copy_source,
+            self.bucket,
+            self.key,
+            {'TaggingDirective': 'COPY'},
+        )
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_mp_copy_tagging_copy_pins_user_supplied_source_version_id(self):
+        source_version_id = 'abc123version'
+        source_tags = [{'Key': 'env', 'Value': 'prod'}]
+        self.copy_source['VersionId'] = source_version_id
+        self.stubber.add_response(
+            'head_object',
+            service_response={
+                'ContentLength': len(self.content),
+                'ETag': self.etag,
+                'VersionId': source_version_id,
+            },
+            expected_params={
+                'Bucket': 'mysourcebucket',
+                'Key': 'mysourcekey',
+                'VersionId': source_version_id,
             },
         )
         _, add_copy_kwargs = self._get_expected_params()


### PR DESCRIPTION
Only pin VersionId for multipart copies if explicitly provided by caller. This prevents permission issues for identities that lack `s3:GetObjectVersion`.