### PR TITLE
Raise error on empty CA bundle value

### DIFF
--- a/.changes/next-release/bugfix-TLS-36922.json
+++ b/.changes/next-release/bugfix-TLS-36922.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "TLS",
+  "description": "Return a configuration error when the CA bundle value (ca_bundle, AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolves to an empty string."
+}

--- a/.changes/next-release/bugfix-TLS-36922.json
+++ b/.changes/next-release/bugfix-TLS-36922.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "TLS",
-  "description": "Return a configuration error when the CA bundle value (ca_bundle, AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolves to an empty string."
+  "description": "Return a configuration error when the CA bundle value (ca_bundle, AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolves to an empty or whitespace-only string."
 }

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -37,7 +37,7 @@ from awscrt.s3 import S3Client, S3RequestTlsMode, S3RequestType
 from botocore import UNSIGNED
 from botocore.compat import urlsplit
 from botocore.config import Config
-from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import InvalidConfigError, NoCredentialsError
 from botocore.utils import ArnParser, InvalidArnException
 
 from s3transfer.constants import FULL_OBJECT_CHECKSUM_ARGS, MB
@@ -143,6 +143,15 @@ def create_s3_crt_client(
         S3RequestTlsMode.ENABLED if use_ssl else S3RequestTlsMode.DISABLED
     )
     if verify is not None:
+        if isinstance(verify, str) and not verify:
+            raise InvalidConfigError(
+                error_msg=(
+                    'Invalid CA bundle: the configured value (ca_bundle, '
+                    'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
+                    'to an empty string. Provide a valid path to a CA bundle '
+                    'file.'
+                )
+            )
         tls_ctx_options = TlsContextOptions()
         if verify:
             tls_ctx_options.override_default_trust_store_from_path(

--- a/s3transfer/crt.py
+++ b/s3transfer/crt.py
@@ -143,13 +143,13 @@ def create_s3_crt_client(
         S3RequestTlsMode.ENABLED if use_ssl else S3RequestTlsMode.DISABLED
     )
     if verify is not None:
-        if isinstance(verify, str) and not verify:
+        if isinstance(verify, str) and not verify.strip():
             raise InvalidConfigError(
                 error_msg=(
                     'Invalid CA bundle: the configured value (ca_bundle, '
                     'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
-                    'to an empty string. Provide a valid path to a CA bundle '
-                    'file.'
+                    'to an empty or whitespace-only string. Provide a valid '
+                    'path to a CA bundle file.'
                 )
             )
         tls_ctx_options = TlsContextOptions()

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -375,6 +375,10 @@ class TestCreateS3CRTClient:
         with pytest.raises(InvalidConfigError):
             s3transfer.crt.create_s3_crt_client('us-west-2', verify='')
 
+    def test_whitespace_verify_value_raises(self, mock_s3_crt_client):
+        with pytest.raises(InvalidConfigError):
+            s3transfer.crt.create_s3_crt_client('us-west-2', verify='   ')
+
     def test_verify_false_disables_verification(self, mock_s3_crt_client):
         with (
             mock.patch('s3transfer.crt.TlsContextOptions') as mock_tls_options,

--- a/tests/unit/test_crt.py
+++ b/tests/unit/test_crt.py
@@ -14,7 +14,11 @@ import io
 
 import pytest
 from botocore.credentials import Credentials, ReadOnlyCredentials
-from botocore.exceptions import ClientError, NoCredentialsError
+from botocore.exceptions import (
+    ClientError,
+    InvalidConfigError,
+    NoCredentialsError,
+)
 from botocore.session import Session
 
 from s3transfer.exceptions import TransferNotDoneError
@@ -366,3 +370,15 @@ class TestCreateS3CRTClient:
     def test_always_enables_s3express(self, mock_s3_crt_client):
         s3transfer.crt.create_s3_crt_client('us-west-2')
         assert mock_s3_crt_client.call_args[1]['enable_s3express'] is True
+
+    def test_empty_verify_value_raises(self, mock_s3_crt_client):
+        with pytest.raises(InvalidConfigError):
+            s3transfer.crt.create_s3_crt_client('us-west-2', verify='')
+
+    def test_verify_false_disables_verification(self, mock_s3_crt_client):
+        with (
+            mock.patch('s3transfer.crt.TlsContextOptions') as mock_tls_options,
+            mock.patch('s3transfer.crt.ClientTlsContext'),
+        ):
+            s3transfer.crt.create_s3_crt_client('us-west-2', verify=False)
+        assert mock_tls_options.return_value.verify_peer is False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a CA bundle value (`ca_bundle`, `AWS_CA_BUNDLE`, `REQUESTS_CA_BUNDLE`, or the `verify` parameter) resolves to an empty string, `create_s3_crt_client` will now raise an error.

An empty string is not a valid value for these settings, which are defined as paths to a CA bundle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
