### PR TITLE
Add content-idempotent path upload coordinator

### DIFF
--- a/.changes/next-release/feature-s3-content-idempotent-upload.json
+++ b/.changes/next-release/feature-s3-content-idempotent-upload.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``",
+  "description": "Add coordination support for content-idempotent path uploads using full-object SHA-256 checksums and conditional writes.",
+  "type": "feature"
+}

--- a/s3transfer/__init__.py
+++ b/s3transfer/__init__.py
@@ -698,6 +698,8 @@ class S3Transfer:
         'GrantRead',
         'GrantReadACP',
         'GrantWriteACL',
+        'IfMatch',
+        'IfNoneMatch',
         'Metadata',
         'RequestPayer',
         'ServerSideEncryption',

--- a/s3transfer/exceptions.py
+++ b/s3transfer/exceptions.py
@@ -47,3 +47,13 @@ class FatalError(CancelledError):
 
 class S3ValidationError(Exception):
     pass
+
+
+class S3ObjectChecksumUnavailableError(Exception):
+    """Raised when an S3 object has no comparable full-object checksum."""
+
+    def __init__(self, bucket, key):
+        super().__init__(
+            f'S3 object s3://{bucket}/{key} does not have a comparable '
+            'full-object SHA-256 checksum.'
+        )

--- a/s3transfer/idempotency.py
+++ b/s3transfer/idempotency.py
@@ -1,0 +1,148 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import base64
+import hashlib
+
+from botocore.exceptions import ClientError
+
+from s3transfer.constants import FULL_OBJECT_CHECKSUM_ARGS
+from s3transfer.exceptions import (
+    S3ObjectChecksumUnavailableError,
+    S3ValidationError,
+)
+from s3transfer.utils import OSUtils
+
+
+class IdempotentUploader:
+    """Coordinates a content-idempotent path upload."""
+
+    _HASH_CHUNK_SIZE = 1024 * 1024
+    _HEAD_ARGS = {
+        'ExpectedBucketOwner',
+        'RequestPayer',
+        'SSECustomerAlgorithm',
+        'SSECustomerKey',
+        'SSECustomerKeyMD5',
+    }
+    _RESERVED_UPLOAD_ARGS = {
+        'ChecksumAlgorithm',
+        'ChecksumType',
+        'IfMatch',
+        'IfNoneMatch',
+        *FULL_OBJECT_CHECKSUM_ARGS,
+    }
+
+    def __init__(self, client, transfer_manager, osutil=None):
+        self._client = client
+        self._transfer_manager = transfer_manager
+        self._osutil = osutil or OSUtils()
+
+    def upload(
+        self,
+        filename,
+        bucket,
+        key,
+        extra_args=None,
+        subscribers=None,
+    ):
+        """Upload a path only when its bytes differ from the S3 object."""
+        upload_args = extra_args.copy() if extra_args else {}
+        self._validate_extra_args(upload_args)
+        checksum = self._calculate_checksum(filename)
+        head_args = {
+            arg: upload_args[arg]
+            for arg in self._HEAD_ARGS
+            if arg in upload_args
+        }
+
+        try:
+            response = self._client.head_object(
+                Bucket=bucket,
+                Key=key,
+                ChecksumMode='ENABLED',
+                **head_args,
+            )
+        except ClientError as error:
+            if not self._is_missing_object(error):
+                raise
+            upload_args['IfNoneMatch'] = '*'
+        else:
+            current_checksum = self._get_full_object_checksum(
+                response, bucket, key
+            )
+            if current_checksum == checksum:
+                return False
+            etag = response.get('ETag')
+            if etag is None:
+                raise S3ValidationError(
+                    f'S3 object s3://{bucket}/{key} has no ETag for a '
+                    'conditional upload.'
+                )
+            upload_args['IfMatch'] = etag
+
+        upload_args['ChecksumSHA256'] = checksum
+        future = self._transfer_manager.upload(
+            filename,
+            bucket,
+            key,
+            upload_args,
+            subscribers,
+        )
+        future.result()
+        return True
+
+    def _calculate_checksum(self, filename):
+        checksum = hashlib.sha256()
+        with self._osutil.open(filename, 'rb') as fileobj:
+            while chunk := fileobj.read(self._HASH_CHUNK_SIZE):
+                checksum.update(chunk)
+        return base64.b64encode(checksum.digest()).decode('ascii')
+
+    def _validate_extra_args(self, extra_args):
+        reserved_args = self._RESERVED_UPLOAD_ARGS.intersection(extra_args)
+        if reserved_args:
+            formatted_args = ', '.join(sorted(reserved_args))
+            raise ValueError(
+                'upload_file_idempotent manages these ExtraArgs: '
+                f'{formatted_args}'
+            )
+
+    def _get_full_object_checksum(self, response, bucket, key):
+        checksum = response.get('ChecksumSHA256')
+        checksum_type = response.get('ChecksumType')
+        if (
+            checksum is None
+            or checksum_type == 'COMPOSITE'
+            or (checksum_type is not None and checksum_type != 'FULL_OBJECT')
+            or self._has_composite_suffix(checksum)
+        ):
+            raise S3ObjectChecksumUnavailableError(bucket, key)
+        return checksum
+
+    def _has_composite_suffix(self, checksum):
+        separator, _, part_count = checksum.rpartition('-')
+        return bool(separator and part_count.isdigit())
+
+    def _is_missing_object(self, error):
+        response = error.response
+        status_code = response.get('ResponseMetadata', {}).get(
+            'HTTPStatusCode'
+        )
+        error_code = response.get('Error', {}).get('Code')
+        if status_code == 403:
+            return False
+        return status_code == 404 or error_code in {
+            '404',
+            'NoSuchKey',
+            'NotFound',
+        }

--- a/s3transfer/manager.py
+++ b/s3transfer/manager.py
@@ -185,6 +185,8 @@ class TransferManager:
         'GrantRead',
         'GrantReadACP',
         'GrantWriteACP',
+        'IfMatch',
+        'IfNoneMatch',
         'Metadata',
         'ObjectLockLegalHoldStatus',
         'ObjectLockMode',

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -515,7 +515,11 @@ class UploadSubmissionTask(SubmissionTask):
 
     PUT_OBJECT_BLOCKLIST = ["ChecksumType", "MpuObjectSize"]
 
-    CREATE_MULTIPART_BLOCKLIST = FULL_OBJECT_CHECKSUM_ARGS + ["MpuObjectSize"]
+    CREATE_MULTIPART_BLOCKLIST = FULL_OBJECT_CHECKSUM_ARGS + [
+        "MpuObjectSize",
+        "IfMatch",
+        "IfNoneMatch",
+    ]
 
     UPLOAD_PART_ARGS = [
         'ChecksumAlgorithm',
@@ -534,6 +538,8 @@ class UploadSubmissionTask(SubmissionTask):
         'ExpectedBucketOwner',
         'ChecksumType',
         'MpuObjectSize',
+        'IfMatch',
+        'IfNoneMatch',
     ] + FULL_OBJECT_CHECKSUM_ARGS
 
     def _get_upload_input_manager_cls(self, transfer_future):

--- a/tests/functional/test_crt.py
+++ b/tests/functional/test_crt.py
@@ -496,6 +496,54 @@ class TestCRTTransferManager(unittest.TestCase):
         )
         self._assert_subscribers_called(future)
 
+    def test_upload_with_full_checksum_and_if_none_match(self):
+        future = self.transfer_manager.upload(
+            self.filename,
+            self.bucket,
+            self.key,
+            {
+                "ChecksumSHA256": "abc123",
+                "IfNoneMatch": "*",
+            },
+            [self.record_subscriber],
+        )
+        future.result()
+
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='PUT',
+            expected_extra_headers={
+                "If-None-Match": "*",
+                "x-amz-checksum-sha256": "abc123",
+            },
+        )
+        self._assert_subscribers_called(future)
+
+    def test_upload_with_full_checksum_and_if_match(self):
+        future = self.transfer_manager.upload(
+            self.filename,
+            self.bucket,
+            self.key,
+            {
+                "ChecksumSHA256": "abc123",
+                "IfMatch": '"etag"',
+            },
+            [self.record_subscriber],
+        )
+        future.result()
+
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+        self._assert_expected_crt_http_request(
+            callargs_kwargs["request"],
+            expected_http_method='PUT',
+            expected_extra_headers={
+                "If-Match": '"etag"',
+                "x-amz-checksum-sha256": "abc123",
+            },
+        )
+        self._assert_subscribers_called(future)
+
     def test_download(self):
         future = self.transfer_manager.download(
             self.bucket, self.key, self.filename, {}, [self.record_subscriber]

--- a/tests/functional/test_idempotency.py
+++ b/tests/functional/test_idempotency.py
@@ -1,0 +1,208 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import base64
+import hashlib
+
+from botocore.exceptions import ClientError
+from botocore.stub import ANY
+
+from s3transfer.idempotency import IdempotentUploader
+from s3transfer.manager import TransferConfig, TransferManager
+from s3transfer.utils import ChunksizeAdjuster
+from tests import FileCreator, StubbedClientTest, mock
+
+
+class BaseIdempotentUploadTest(StubbedClientTest):
+    def setUp(self):
+        super().setUp()
+        self.file_creator = FileCreator()
+        self.contents = b'my content'
+        self.filename = self.file_creator.create_file(
+            'my-file', self.contents, mode='wb'
+        )
+        self.bucket = 'my-bucket'
+        self.key = 'my-key'
+        self.checksum = self._sha256(self.contents)
+
+    def tearDown(self):
+        self.manager.shutdown()
+        self.file_creator.remove_all()
+        super().tearDown()
+
+    def _sha256(self, contents):
+        digest = hashlib.sha256(contents).digest()
+        return base64.b64encode(digest).decode('ascii')
+
+    def _add_head_response(self, checksum, etag='"etag"'):
+        self.stubber.add_response(
+            'head_object',
+            {
+                'ChecksumSHA256': checksum,
+                'ChecksumType': 'FULL_OBJECT',
+                'ETag': etag,
+            },
+            {
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'ChecksumMode': 'ENABLED',
+            },
+        )
+
+    def _add_missing_head_response(self):
+        self.stubber.add_client_error(
+            'head_object',
+            service_error_code='404',
+            service_message='Not Found',
+            http_status_code=404,
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'ChecksumMode': 'ENABLED',
+            },
+        )
+
+    def _upload(self):
+        uploader = IdempotentUploader(self.client, self.manager)
+        return uploader.upload(self.filename, self.bucket, self.key)
+
+
+class TestNonMultipartIdempotentUpload(BaseIdempotentUploadTest):
+    def setUp(self):
+        super().setUp()
+        config = TransferConfig(multipart_threshold=1024)
+        self.manager = TransferManager(self.client, config)
+
+    def test_missing_object_puts_with_full_checksum_and_condition(self):
+        self._add_missing_head_response()
+        self.stubber.add_response(
+            'put_object',
+            {},
+            {
+                'Body': ANY,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'ChecksumSHA256': self.checksum,
+                'IfNoneMatch': '*',
+            },
+        )
+
+        self.assertTrue(self._upload())
+
+        self.stubber.assert_no_pending_responses()
+
+    def test_matching_object_skips_put(self):
+        self._add_head_response(self.checksum)
+
+        self.assertFalse(self._upload())
+
+        self.stubber.assert_no_pending_responses()
+
+    def test_conditional_failure_surfaces(self):
+        self._add_missing_head_response()
+        self.stubber.add_client_error(
+            'put_object',
+            service_error_code='PreconditionFailed',
+            service_message='At least one precondition failed',
+            http_status_code=412,
+            expected_params={
+                'Body': ANY,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'ChecksumSHA256': self.checksum,
+                'IfNoneMatch': '*',
+            },
+        )
+
+        with self.assertRaises(ClientError):
+            self._upload()
+
+        self.stubber.assert_no_pending_responses()
+
+
+class TestMultipartIdempotentUpload(BaseIdempotentUploadTest):
+    def setUp(self):
+        super().setUp()
+        self.adjuster_patch = mock.patch(
+            's3transfer.upload.ChunksizeAdjuster',
+            lambda: ChunksizeAdjuster(min_size=1),
+        )
+        self.adjuster_patch.start()
+        config = TransferConfig(
+            multipart_threshold=1,
+            multipart_chunksize=5,
+            max_request_concurrency=1,
+        )
+        self.manager = TransferManager(self.client, config)
+
+    def tearDown(self):
+        self.adjuster_patch.stop()
+        super().tearDown()
+
+    def test_changed_object_conditions_multipart_completion(self):
+        self._add_head_response(self._sha256(b'old content'))
+        self.stubber.add_response(
+            'create_multipart_upload',
+            {'UploadId': 'upload-id'},
+            {
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'ChecksumAlgorithm': 'SHA256',
+                'ChecksumType': 'FULL_OBJECT',
+            },
+        )
+        for part_number in (1, 2):
+            self.stubber.add_response(
+                'upload_part',
+                {
+                    'ETag': f'"etag-{part_number}"',
+                    'ChecksumSHA256': f'part-{part_number}-checksum',
+                },
+                {
+                    'Body': ANY,
+                    'Bucket': self.bucket,
+                    'Key': self.key,
+                    'UploadId': 'upload-id',
+                    'PartNumber': part_number,
+                    'ChecksumAlgorithm': 'SHA256',
+                },
+            )
+        self.stubber.add_response(
+            'complete_multipart_upload',
+            {},
+            {
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'UploadId': 'upload-id',
+                'MultipartUpload': {
+                    'Parts': [
+                        {
+                            'ETag': '"etag-1"',
+                            'PartNumber': 1,
+                            'ChecksumSHA256': 'part-1-checksum',
+                        },
+                        {
+                            'ETag': '"etag-2"',
+                            'PartNumber': 2,
+                            'ChecksumSHA256': 'part-2-checksum',
+                        },
+                    ]
+                },
+                'ChecksumSHA256': self.checksum,
+                'ChecksumType': 'FULL_OBJECT',
+                'IfMatch': '"etag"',
+            },
+        )
+
+        self.assertTrue(self._upload())
+
+        self.stubber.assert_no_pending_responses()

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -177,6 +177,30 @@ class TestNonMultipartUpload(BaseUploadTest):
         self.assert_expected_client_calls_were_correct()
         self.assert_put_object_body_was_correct()
 
+    def test_upload_with_if_match(self):
+        self.extra_args['IfMatch'] = 'my-etag'
+        self.add_put_object_response_with_default_expected_params(
+            extra_expected_params={'IfMatch': 'my-etag'}
+        )
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_put_object_body_was_correct()
+
+    def test_upload_with_if_none_match(self):
+        self.extra_args['IfNoneMatch'] = '*'
+        self.add_put_object_response_with_default_expected_params(
+            extra_expected_params={'IfNoneMatch': '*'}
+        )
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+        self.assert_put_object_body_was_correct()
+
     def test_upload_with_checksum(self):
         self.extra_args['ChecksumAlgorithm'] = 'sha256'
         self.add_put_object_response_with_default_expected_params(
@@ -651,6 +675,32 @@ class TestMultipartUpload(BaseUploadTest):
         self.add_upload_part_responses_with_default_expected_params()
         self.add_complete_multipart_response_with_default_expected_params()
 
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+
+    def test_multipart_upload_with_if_match(self):
+        self.extra_args['IfMatch'] = 'my-etag'
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params(
+            extra_expected_params={'IfMatch': 'my-etag'}
+        )
+        future = self.manager.upload(
+            self.filename, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assert_expected_client_calls_were_correct()
+
+    def test_multipart_upload_with_if_none_match(self):
+        self.extra_args['IfNoneMatch'] = '*'
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params(
+            extra_expected_params={'IfNoneMatch': '*'}
+        )
         future = self.manager.upload(
             self.filename, self.bucket, self.key, self.extra_args
         )

--- a/tests/integration/test_crt.py
+++ b/tests/integration/test_crt.py
@@ -11,12 +11,15 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import glob
+import hashlib
 import io
 import os
+from base64 import b64encode
 from uuid import uuid4
 
 from botocore.exceptions import ClientError
 
+from s3transfer.idempotency import IdempotentUploader
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
 from tests import (
@@ -169,6 +172,62 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
             future.result()
         self.assertTrue(self.object_exists('20mb.txt'))
         self._assert_subscribers_called(file_size)
+
+    def test_idempotent_upload_creates_missing_object(self):
+        key = 'idempotent-small.txt'
+        filename = self.files.create_file(
+            key, b'idempotent content', mode='wb'
+        )
+        self.addCleanup(self.delete_object, key)
+
+        with self._create_s3_transfer() as transfer:
+            uploader = IdempotentUploader(self.client, transfer)
+            uploaded = uploader.upload(filename, self.bucket_name, key)
+
+        self.assertTrue(uploaded)
+        response = self.client.head_object(
+            Bucket=self.bucket_name,
+            Key=key,
+            ChecksumMode='ENABLED',
+        )
+        expected_checksum = b64encode(
+            hashlib.sha256(b'idempotent content').digest()
+        ).decode('ascii')
+        self.assertEqual(response['ChecksumSHA256'], expected_checksum)
+
+    def test_idempotent_multipart_upload_replaces_changed_object(self):
+        key = 'idempotent-multipart.txt'
+        old_contents = b'old content'
+        old_checksum = b64encode(hashlib.sha256(old_contents).digest()).decode(
+            'ascii'
+        )
+        self.client.put_object(
+            Bucket=self.bucket_name,
+            Key=key,
+            Body=old_contents,
+            ChecksumSHA256=old_checksum,
+        )
+        self.addCleanup(self.delete_object, key)
+        file_size = 20 * 1024 * 1024
+        filename = self.files.create_file_with_size(key, filesize=file_size)
+
+        with self._create_s3_transfer() as transfer:
+            uploader = IdempotentUploader(self.client, transfer)
+            uploaded = uploader.upload(filename, self.bucket_name, key)
+
+        self.assertTrue(uploaded)
+        response = self.client.head_object(
+            Bucket=self.bucket_name,
+            Key=key,
+            ChecksumMode='ENABLED',
+        )
+        checksum = hashlib.sha256()
+        with open(filename, 'rb') as fileobj:
+            for chunk in iter(lambda: fileobj.read(1024 * 1024), b''):
+                checksum.update(chunk)
+        expected_checksum = b64encode(checksum.digest()).decode('ascii')
+        self.assertEqual(response['ChecksumSHA256'], expected_checksum)
+        self.assertEqual(response['ChecksumType'], 'FULL_OBJECT')
 
     def test_upload_file_above_threshold_with_acl(self):
         transfer = self._create_s3_transfer()

--- a/tests/unit/test_idempotency.py
+++ b/tests/unit/test_idempotency.py
@@ -1,0 +1,299 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# https://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import base64
+import hashlib
+
+from botocore.exceptions import ClientError
+
+from s3transfer.exceptions import (
+    S3ObjectChecksumUnavailableError,
+    S3ValidationError,
+)
+from s3transfer.idempotency import IdempotentUploader
+from tests import FileCreator, mock, unittest
+
+
+class TestIdempotentUploader(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+        self.manager = mock.Mock()
+        self.future = self.manager.upload.return_value
+        self.file_creator = FileCreator()
+        self.contents = b'my content'
+        self.filename = self.file_creator.create_file(
+            'my-file', self.contents, mode='wb'
+        )
+        self.bucket = 'my-bucket'
+        self.key = 'my-key'
+        self.checksum = self._sha256(self.contents)
+        self.uploader = IdempotentUploader(self.client, self.manager)
+
+    def tearDown(self):
+        self.file_creator.remove_all()
+
+    def _sha256(self, contents):
+        digest = hashlib.sha256(contents).digest()
+        return base64.b64encode(digest).decode('ascii')
+
+    def _client_error(self, code, status_code):
+        return ClientError(
+            {
+                'Error': {'Code': code, 'Message': 'error'},
+                'ResponseMetadata': {'HTTPStatusCode': status_code},
+            },
+            'HeadObject',
+        )
+
+    def _upload(self, extra_args=None, subscribers=None):
+        return self.uploader.upload(
+            self.filename,
+            self.bucket,
+            self.key,
+            extra_args,
+            subscribers,
+        )
+
+    def test_missing_object_uploads_with_if_none_match(self):
+        self.client.head_object.side_effect = self._client_error('404', 404)
+        extra_args = {
+            'Metadata': {'purpose': 'test'},
+            'RequestPayer': 'requester',
+        }
+        subscribers = [mock.sentinel.SUBSCRIBER]
+
+        result = self._upload(extra_args, subscribers)
+
+        self.assertTrue(result)
+        self.client.head_object.assert_called_once_with(
+            Bucket=self.bucket,
+            Key=self.key,
+            ChecksumMode='ENABLED',
+            RequestPayer='requester',
+        )
+        self.manager.upload.assert_called_once_with(
+            self.filename,
+            self.bucket,
+            self.key,
+            {
+                'Metadata': {'purpose': 'test'},
+                'RequestPayer': 'requester',
+                'IfNoneMatch': '*',
+                'ChecksumSHA256': self.checksum,
+            },
+            subscribers,
+        )
+        self.future.result.assert_called_once_with()
+
+    def test_matching_checksum_skips_upload(self):
+        self.client.head_object.return_value = {
+            'ChecksumSHA256': self.checksum,
+            'ChecksumType': 'FULL_OBJECT',
+            'ETag': '"etag"',
+        }
+
+        result = self._upload({'Metadata': {'changed': 'but ignored'}})
+
+        self.assertFalse(result)
+        self.manager.upload.assert_not_called()
+
+    def test_checksum_without_type_is_treated_as_full_object(self):
+        self.client.head_object.return_value = {
+            'ChecksumSHA256': self.checksum,
+            'ETag': '"etag"',
+        }
+
+        result = self._upload()
+
+        self.assertFalse(result)
+        self.manager.upload.assert_not_called()
+
+    def test_different_checksum_uploads_with_if_match(self):
+        self.client.head_object.return_value = {
+            'ChecksumSHA256': self._sha256(b'old content'),
+            'ChecksumType': 'FULL_OBJECT',
+            'ETag': '"etag"',
+        }
+
+        result = self._upload()
+
+        self.assertTrue(result)
+        self.manager.upload.assert_called_once_with(
+            self.filename,
+            self.bucket,
+            self.key,
+            {'IfMatch': '"etag"', 'ChecksumSHA256': self.checksum},
+            None,
+        )
+
+    def test_empty_file_checksum(self):
+        self.filename = self.file_creator.create_file(
+            'empty-file', b'', mode='wb'
+        )
+        self.checksum = self._sha256(b'')
+        self.client.head_object.side_effect = self._client_error(
+            'NoSuchKey', 404
+        )
+
+        result = self._upload()
+
+        self.assertTrue(result)
+        upload_args = self.manager.upload.call_args.args[3]
+        self.assertEqual(upload_args['ChecksumSHA256'], self.checksum)
+
+    def test_caller_extra_args_are_not_modified(self):
+        self.client.head_object.side_effect = self._client_error(
+            'NotFound', 404
+        )
+        extra_args = {'Metadata': {'purpose': 'test'}}
+
+        self._upload(extra_args)
+
+        self.assertEqual(extra_args, {'Metadata': {'purpose': 'test'}})
+
+    def test_only_supported_extra_args_are_sent_to_head_object(self):
+        self.client.head_object.side_effect = self._client_error('404', 404)
+        extra_args = {
+            'ACL': 'private',
+            'ExpectedBucketOwner': '123456789012',
+            'RequestPayer': 'requester',
+            'SSECustomerAlgorithm': 'AES256',
+            'SSECustomerKey': 'secret',
+            'SSECustomerKeyMD5': 'checksum',
+        }
+
+        self._upload(extra_args)
+
+        self.client.head_object.assert_called_once_with(
+            Bucket=self.bucket,
+            Key=self.key,
+            ChecksumMode='ENABLED',
+            ExpectedBucketOwner='123456789012',
+            RequestPayer='requester',
+            SSECustomerAlgorithm='AES256',
+            SSECustomerKey='secret',
+            SSECustomerKeyMD5='checksum',
+        )
+
+    def test_non_404_head_error_is_propagated(self):
+        error = self._client_error('AccessDenied', 403)
+        self.client.head_object.side_effect = error
+
+        with self.assertRaises(ClientError) as raised:
+            self._upload()
+
+        self.assertIs(raised.exception, error)
+        self.manager.upload.assert_not_called()
+
+    def test_ambiguous_403_not_found_error_is_propagated(self):
+        error = self._client_error('NotFound', 403)
+        self.client.head_object.side_effect = error
+
+        with self.assertRaises(ClientError) as raised:
+            self._upload()
+
+        self.assertIs(raised.exception, error)
+        self.manager.upload.assert_not_called()
+
+    def test_missing_checksum_is_rejected(self):
+        self.client.head_object.return_value = {'ETag': '"etag"'}
+
+        with self.assertRaises(S3ObjectChecksumUnavailableError):
+            self._upload()
+
+        self.manager.upload.assert_not_called()
+
+    def test_composite_checksum_type_is_rejected(self):
+        self.client.head_object.return_value = {
+            'ChecksumSHA256': f'{self.checksum}-2',
+            'ChecksumType': 'COMPOSITE',
+            'ETag': '"etag"',
+        }
+
+        with self.assertRaises(S3ObjectChecksumUnavailableError):
+            self._upload()
+
+        self.manager.upload.assert_not_called()
+
+    def test_composite_checksum_suffix_is_rejected_without_type(self):
+        self.client.head_object.return_value = {
+            'ChecksumSHA256': f'{self.checksum}-2',
+            'ETag': '"etag"',
+        }
+
+        with self.assertRaises(S3ObjectChecksumUnavailableError):
+            self._upload()
+
+    def test_unknown_checksum_type_is_rejected(self):
+        self.client.head_object.return_value = {
+            'ChecksumSHA256': self.checksum,
+            'ChecksumType': 'UNKNOWN',
+            'ETag': '"etag"',
+        }
+
+        with self.assertRaises(S3ObjectChecksumUnavailableError):
+            self._upload()
+
+    def test_missing_etag_is_rejected_for_changed_object(self):
+        self.client.head_object.return_value = {
+            'ChecksumSHA256': self._sha256(b'old content'),
+            'ChecksumType': 'FULL_OBJECT',
+        }
+
+        with self.assertRaises(S3ValidationError):
+            self._upload()
+
+        self.manager.upload.assert_not_called()
+
+    def test_reserved_extra_args_are_rejected(self):
+        reserved_args = [
+            'ChecksumAlgorithm',
+            'ChecksumCRC32',
+            'ChecksumCRC32C',
+            'ChecksumCRC64NVME',
+            'ChecksumSHA1',
+            'ChecksumSHA256',
+            'ChecksumType',
+            'IfMatch',
+            'IfNoneMatch',
+        ]
+        for extra_arg in reserved_args:
+            with self.subTest(extra_arg=extra_arg):
+                with self.assertRaisesRegex(
+                    ValueError, 'upload_file_idempotent manages'
+                ):
+                    self._upload({extra_arg: 'value'})
+
+        self.client.head_object.assert_not_called()
+        self.manager.upload.assert_not_called()
+
+    def test_transfer_error_is_propagated_without_retry(self):
+        self.client.head_object.side_effect = self._client_error('404', 404)
+        error = self._client_error('PreconditionFailed', 412)
+        self.future.result.side_effect = error
+
+        with self.assertRaises(ClientError) as raised:
+            self._upload()
+
+        self.assertIs(raised.exception, error)
+        self.manager.upload.assert_called_once()
+
+    def test_transfer_conflict_is_propagated_without_retry(self):
+        self.client.head_object.side_effect = self._client_error('404', 404)
+        error = self._client_error('ConditionalRequestConflict', 409)
+        self.future.result.side_effect = error
+
+        with self.assertRaises(ClientError) as raised:
+            self._upload()
+
+        self.assertIs(raised.exception, error)
+        self.manager.upload.assert_called_once()


### PR DESCRIPTION
## Summary

Add a small synchronous coordinator for path uploads that compares full-object SHA-256 content before submitting an existing classic or CRT managed transfer.

The coordinator:

- hashes the local file in bounded chunks;
- calls `HeadObject` with checksum mode enabled;
- returns `False` without starting a transfer when content matches;
- creates a missing key with `IfNoneMatch='*'`;
- replaces changed content with `IfMatch` set to the observed ETag;
- supplies the computed `ChecksumSHA256` to the transfer;
- rejects caller-provided checksum and conditional-write arguments;
- propagates conditional conflicts without hidden retries; and
- raises a dedicated exception when an existing object has no comparable full-object SHA-256.

This PR intentionally supports paths only. It does not add a file-object API.

## Stacked dependency

This draft is stacked on #371. The first commit is a rebase of that PR's conditional-write patch onto current `develop`; it is not a separate implementation of, or claim of authorship over, #371. After #371 merges, this branch should be rebased so the upstream diff contains only the coordinator and its tests.

The proposed Boto3 API is tracked in boto/boto3#4823.

## Tests

- `python -m pytest tests/unit tests/functional -q` — 758 passed
- `pre-commit run --all-files` — passed
- Classic single-part and multipart requests assert the exact HEAD, PUT, and multipart completion parameters.
- CRT functional coverage verifies full-checksum conditional headers.
- Live CRT single-part and multipart integration tests are included but were not run locally because AWS credentials were unavailable.

The supported Python matrix and live AWS coverage remain CI/reviewer gates.

## Development note

AI tools assisted with implementation and test iteration. Human review is pending while this PR remains a draft.
