### PR TITLE
Do not close a caller-provided file object after a nonmultipart upload

### DIFF
--- a/.changes/next-release/bugfix-upload-84213.json
+++ b/.changes/next-release/bugfix-upload-84213.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fix issue where a nonmultipart upload closed the file-like object provided by the caller.",
+  "type": "bugfix",
+  "category": "upload"
+}

--- a/s3transfer/upload.py
+++ b/s3transfer/upload.py
@@ -75,11 +75,18 @@ class InterruptReader:
     :type transfer_coordinator: s3transfer.futures.TransferCoordinator
     :param transfer_coordinator: The transfer coordinator to use if the
         reader needs to be interrupted.
+
+    :type close_fileobj: bool
+    :param close_fileobj: Whether closing this reader should also close the
+        underlying file-like object. Set this to False when the underlying
+        object was supplied by the caller instead of being opened by
+        s3transfer, since closing it is then not this reader's to do.
     """
 
-    def __init__(self, fileobj, transfer_coordinator):
+    def __init__(self, fileobj, transfer_coordinator, close_fileobj=True):
         self._fileobj = fileobj
         self._transfer_coordinator = transfer_coordinator
+        self._close_fileobj = close_fileobj
 
     def read(self, amount=None):
         # If there is an exception, then raise the exception.
@@ -98,7 +105,8 @@ class InterruptReader:
         return self._fileobj.tell()
 
     def close(self):
-        self._fileobj.close()
+        if self._close_fileobj:
+            self._fileobj.close()
 
     def __enter__(self):
         return self
@@ -209,8 +217,10 @@ class UploadInputManager:
         """
         raise NotImplementedError('must implement yield_upload_part_bodies()')
 
-    def _wrap_fileobj(self, fileobj):
-        fileobj = InterruptReader(fileobj, self._transfer_coordinator)
+    def _wrap_fileobj(self, fileobj, close_fileobj=True):
+        fileobj = InterruptReader(
+            fileobj, self._transfer_coordinator, close_fileobj=close_fileobj
+        )
         if self._bandwidth_limiter:
             fileobj = self._bandwidth_limiter.get_bandwith_limited_stream(
                 fileobj, self._transfer_coordinator, enabled=False
@@ -232,6 +242,10 @@ class UploadInputManager:
 
 class UploadFilenameInputManager(UploadInputManager):
     """Upload utility for filenames"""
+
+    # PutObject reads from a DeferredOpenFile that this manager opened, so
+    # the wrapper owns that file object and is responsible for closing it.
+    _CLOSE_PUT_OBJECT_FILEOBJ = True
 
     @classmethod
     def is_compatible(cls, upload_source):
@@ -257,7 +271,9 @@ class UploadFilenameInputManager(UploadInputManager):
         # Wrap fileobj with interrupt reader that will quickly cancel
         # uploads if needed instead of having to wait for the socket
         # to completely read all of the data.
-        fileobj = self._wrap_fileobj(fileobj)
+        fileobj = self._wrap_fileobj(
+            fileobj, close_fileobj=self._CLOSE_PUT_OBJECT_FILEOBJ
+        )
 
         callbacks = self._get_progress_callbacks(transfer_future)
         close_callbacks = self._get_close_callbacks(callbacks)
@@ -325,6 +341,12 @@ class UploadFilenameInputManager(UploadInputManager):
 
 class UploadSeekableInputManager(UploadFilenameInputManager):
     """Upload utility for an open file object"""
+
+    # Unlike the filename case, PutObject reads directly from the file object
+    # the caller handed to the transfer manager (see
+    # _get_put_object_fileobj_with_full_size below). s3transfer did not open
+    # it, so s3transfer must not close it.
+    _CLOSE_PUT_OBJECT_FILEOBJ = False
 
     @classmethod
     def is_compatible(cls, upload_source):

--- a/tests/functional/test_upload.py
+++ b/tests/functional/test_upload.py
@@ -275,6 +275,24 @@ class TestNonMultipartUpload(BaseUploadTest):
         self.assert_expected_client_calls_were_correct()
         self.assertEqual(b''.join(self.sent_bodies), self.content[seek_pos:])
 
+    def test_upload_does_not_close_provided_seekable_filelike_obj(self):
+        self.add_put_object_response_with_default_expected_params()
+        bytes_io = BytesIO(self.content)
+        future = self.manager.upload(
+            bytes_io, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assertFalse(bytes_io.closed)
+
+    def test_upload_does_not_close_provided_non_seekable_filelike_obj(self):
+        self.add_put_object_response_with_default_expected_params()
+        body = NonSeekableReader(self.content)
+        future = self.manager.upload(
+            body, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assertFalse(body.closed)
+
     def test_upload_for_non_seekable_filelike_obj(self):
         self.add_put_object_response_with_default_expected_params()
         body = NonSeekableReader(self.content)
@@ -551,6 +569,17 @@ class TestMultipartUpload(BaseUploadTest):
         future.result()
         self.assert_expected_client_calls_were_correct()
         self.assertEqual(b''.join(self.sent_bodies), self.content[seek_pos:])
+
+    def test_upload_does_not_close_provided_seekable_filelike_obj(self):
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_responses_with_default_expected_params()
+        self.add_complete_multipart_response_with_default_expected_params()
+        bytes_io = BytesIO(self.content)
+        future = self.manager.upload(
+            bytes_io, self.bucket, self.key, self.extra_args
+        )
+        future.result()
+        self.assertFalse(bytes_io.closed)
 
     def test_upload_for_non_seekable_filelike_obj(self):
         self.add_create_multipart_response_with_default_expected_params()

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -156,6 +156,20 @@ class TestInterruptReader(BaseUploadTest):
             reader.seek(1)
             self.assertEqual(reader.tell(), 1)
 
+    def test_close_closes_fileobj(self):
+        with open(self.filename, 'rb') as f:
+            reader = InterruptReader(f, self.transfer_coordinator)
+            reader.close()
+            self.assertTrue(f.closed)
+
+    def test_close_does_not_close_fileobj_when_not_owned(self):
+        with open(self.filename, 'rb') as f:
+            reader = InterruptReader(
+                f, self.transfer_coordinator, close_fileobj=False
+            )
+            reader.close()
+            self.assertFalse(f.closed)
+
 
 class BaseUploadInputManagerTest(BaseUploadTest):
     def setUp(self):
@@ -246,6 +260,28 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
             self.recording_subscriber.calculate_bytes_seen(), len(self.content)
         )
 
+    def test_put_object_body_close_closes_file_it_opened(self):
+        opened_files = []
+        original_open = self.osutil.open
+
+        def recording_open(filename, mode):
+            fileobj = original_open(filename, mode)
+            opened_files.append(fileobj)
+            return fileobj
+
+        self.osutil.open = recording_open
+        self.future.meta.provide_transfer_size(len(self.content))
+        read_file_chunk = self.upload_input_manager.get_put_object_body(
+            self.future
+        )
+        with read_file_chunk:
+            read_file_chunk.read()
+        # s3transfer opened these files itself, so it is responsible for
+        # closing them.
+        self.assertTrue(opened_files)
+        for fileobj in opened_files:
+            self.assertTrue(fileobj.closed)
+
     def test_get_put_object_body_is_interruptable(self):
         self.future.meta.provide_transfer_size(len(self.content))
         read_file_chunk = self.upload_input_manager.get_put_object_body(
@@ -327,6 +363,22 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
     def test_is_compatible_bytes_io(self):
         self.assertTrue(self.upload_input_manager.is_compatible(BytesIO()))
 
+    def test_put_object_body_close_closes_file_it_opened(self):
+        # Unlike the filename case, this manager reads directly from the
+        # file-like object the caller provided. It opens nothing itself, so
+        # it has nothing of its own to close and must leave the caller's
+        # object open.
+        opened_files = []
+        self.osutil.open = lambda *args, **kwargs: opened_files.append(args)
+        self.future.meta.provide_transfer_size(len(self.content))
+        read_file_chunk = self.upload_input_manager.get_put_object_body(
+            self.future
+        )
+        with read_file_chunk:
+            read_file_chunk.read()
+        self.assertEqual(opened_files, [])
+        self.assertFalse(self.fileobj.closed)
+
     def test_not_compatible_for_non_filelike_obj(self):
         self.assertFalse(self.upload_input_manager.is_compatible(object()))
 
@@ -366,6 +418,21 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
             fileobj=self.fileobj, subscribers=self.subscribers
         )
         self.future = self.get_transfer_future(self.call_args)
+
+    def test_put_object_body_close_closes_file_it_opened(self):
+        # This manager buffers the stream into BytesIO objects of its own and
+        # opens no files, so there is nothing of its own to close and the
+        # caller's stream must be left open.
+        opened_files = []
+        self.osutil.open = lambda *args, **kwargs: opened_files.append(args)
+        self.future.meta.provide_transfer_size(len(self.content))
+        read_file_chunk = self.upload_input_manager.get_put_object_body(
+            self.future
+        )
+        with read_file_chunk:
+            read_file_chunk.read()
+        self.assertEqual(opened_files, [])
+        self.assertFalse(self.fileobj.closed)
 
     def assert_multipart_parts(self):
         """


### PR DESCRIPTION
Fixes #80.

`upload_fileobj` on a seekable file-like object below the multipart threshold
closes the caller's object. `UploadSeekableInputManager._get_put_object_fileobj_with_full_size`
returns the caller's object itself, `_wrap_fileobj` hands it to `InterruptReader`,
whose `close()` delegates straight through, and `PutObjectTask._main` uses the body
as a context manager.

Only that one path does it. Measured on `develop` (`.closed` after the transfer):

```
                        put_object   multipart
BytesIO                 True         False
open() file             True         False
SpooledTemporaryFile    True         False
non-seekable stream     False        False
```

The three that behave wrap something s3transfer made — a `DeferredOpenFile` for
filenames, a `BytesIO` copy for multipart parts and for non-seekable streams.
All eight cells read `False` with this change. This matches @kyleknap's read in
2016: "it will only happen for the non-multipart upload case because the provided
file object is used".

`InterruptReader` gets a `close_fileobj` flag and `UploadSeekableInputManager`
opts out for the PutObject path only. Gating there rather than in `ReadFileChunk`
keeps `ReadFileChunk`'s progress-flush callbacks and `BandwidthLimitedStream.close()`'s
leaky-bucket accounting running.

The obvious one-liner — make `InterruptReader.close()` a no-op — is wrong, and the
new tests catch it: the filename path then never closes the `DeferredOpenFile` it
opened, so `TestUploadFilenameInputManager::test_put_object_body_close_closes_file_it_opened`
fails. The flag is about ownership, not about never closing.

684 passed / 55 skipped (`tests/unit` + `tests/functional`), 676 before. Of the 8
new tests, 3 fail on unmodified `develop`; the other 5 pin the cells that were
already correct. Every one of the 676 existing tests passes unmodified, with the
no-op mutant, and with this change — nothing in the suite asserts `.closed` today,
and `TestUploadSeekableInputManager.tearDown` closes `self.fileobj` itself, so
double-closing is invisible there.

Not tested: no integration tests were run (no AWS credentials), and CRT transfers
are untouched.

---

Found by scanning long-standing open issues rather than hitting it in my own work.
Drafted with AI assistance (Claude Opus 5, `claude-opus-5`); I have reviewed and
verified every change and the measurements above.
